### PR TITLE
feat(s3): reliability + DX overhaul for Backblaze B2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `genblaze-s3`: multipart uploads via `upload_fileobj` + `TransferConfig` —
+  assets >16 MB now split into 16 MB parts uploaded 4-way in parallel, each
+  part individually retryable. Transforms multi-GB video uploads from a
+  lottery ticket into a reliable operation.
+- `genblaze-s3`: per-part SHA-256 integrity via `ChecksumAlgorithm=SHA256`
+  on every upload so B2 server-side-verifies transfer integrity.
+- `genblaze-s3`: `S3StorageBackend.ensure_lifecycle_defaults()` helper that
+  applies idempotent `AbortIncompleteMultipartUpload` (7 days) and
+  `NoncurrentVersionExpiration` (30 days) rules. Called automatically by
+  `for_backblaze(auto_lifecycle=True)` (default).
+- `genblaze-s3`: automatic bucket-region auto-detection — the first
+  `put()`/`exists()` call runs a HeadBucket preflight and transparently
+  reconfigures the client if the bucket lives in a different region.
+- `genblaze-s3`: `StorageBackend.put()` gains an `extra_args` passthrough
+  for boto3-style `ExtraArgs` (Cache-Control, SSE, Object Lock, etc.).
+- `genblaze-core`: immutable Cache-Control on CONTENT_ADDRESSABLE uploads
+  (`public, max-age=31536000, immutable`), shorter private TTL on
+  HIERARCHICAL. Unlocks the B2 + Cloudflare Bandwidth Alliance zero-egress
+  delivery pattern documented in `docs/features/object-storage.md`.
+- Docs: "Serving media at zero egress: B2 + Cloudflare" recipe.
+
+### Changed
+- `genblaze-s3`: `for_backblaze()` raises a clear `ValueError` when both
+  `B2_KEY_ID`/`B2_APP_KEY` env vars and explicit `key_id`/`app_key` are
+  missing — prevents opaque mid-upload `NoCredentialsError`.
+- `genblaze-s3`: `BotoConfig` now pins
+  `request_checksum_calculation="when_required"` /
+  `response_checksum_validation="when_required"` so boto3 never sends
+  `x-amz-sdk-checksum-algorithm` trailer headers that older B2 deployments
+  and other S3-compat endpoints reject. Genblaze sets SHA-256 explicitly.
+- `genblaze-s3`: default `max_pool_connections` bumped to 20 to accommodate
+  concurrent multipart uploads.
+
 ## [0.1.0] - 2026-04-22
 
 ### Added

--- a/docs/features/object-storage.md
+++ b/docs/features/object-storage.md
@@ -21,6 +21,9 @@ from genblaze_core import Pipeline, Modality, ObjectStorageSink, KeyStrategy
 from genblaze_s3 import S3StorageBackend
 
 # Reads B2_KEY_ID / B2_APP_KEY from env; override with key_id=/app_key= if needed.
+# Auto-applies recommended lifecycle rules (cancel orphaned multipart uploads
+# after 7 days; expire noncurrent manifest versions after 30 days). Pass
+# auto_lifecycle=False if lifecycle is managed out-of-band.
 storage = ObjectStorageSink(
     S3StorageBackend.for_backblaze("my-bucket"),
     key_strategy=KeyStrategy.HIERARCHICAL,
@@ -28,6 +31,33 @@ storage = ObjectStorageSink(
 
 result = Pipeline("my-pipeline").step(...).run(sink=storage)
 ```
+
+### What `for_backblaze()` does for you
+
+`S3StorageBackend.for_backblaze()` is the recommended entry point when your
+bucket is on B2 — it encodes the B2-specific tuning so you don't have to:
+
+- **Credentials check** — raises a clear `ValueError` at construction if
+  neither env vars nor explicit args are present (no opaque mid-upload
+  `NoCredentialsError`).
+- **Region auto-detect** — on first use, verifies the bucket's region via a
+  single `HeadBucket` call. If the bucket lives in a different region than
+  the ``region=`` hint, the backend reconfigures itself transparently.
+- **Lifecycle defaults** — applies `AbortIncompleteMultipartUpload` after 7
+  days and noncurrent-version expiry after 30 days. Prevents orphaned
+  multipart uploads from silently accruing storage cost.
+- **Multipart uploads** — any asset larger than 16 MB is split into
+  16 MB parts uploaded 4-way in parallel. Each part is individually
+  retryable on transient failures.
+- **Per-part SHA-256 integrity** — every upload carries
+  `ChecksumAlgorithm=SHA256` so B2 server-side-verifies transfer integrity.
+- **Checksum header compat** — the backend pins
+  `request_checksum_calculation="when_required"`, so boto3's default
+  `x-amz-sdk-checksum-algorithm` header is never sent. This keeps the
+  backend portable across all S3-compatible services (including older B2
+  deployments, MinIO, Wasabi).
+- **User-Agent attribution** — all requests carry `b2ai-genblaze/{version}`
+  for B2 usage reporting.
 
 ### Other S3-compatible providers
 
@@ -121,3 +151,42 @@ result = Pipeline("full-pipeline").step(...).run(sink=storage)
 ## Backward compatibility
 
 Existing buckets using the previous HIERARCHICAL layout (assets at `{prefix}/assets/{tenant}/{date}/{run_id}/{asset_id}.ext`) continue to work — URLs stored in manifests remain valid regardless of layout changes. Only newly written data uses the updated paths.
+
+## Serving media at zero egress: B2 + Cloudflare
+
+Backblaze B2 and Cloudflare have a
+[Bandwidth Alliance partnership](https://www.backblaze.com/blog/backblaze-and-cloudflare-partner-to-provide-free-data-transfer/)
+that makes egress from B2 to Cloudflare **free**. Paired with `genblaze-s3`'s
+immutable `Cache-Control` headers on content-addressable keys, this is the
+cheapest production-grade media delivery path for AI-generated assets.
+
+**Setup (one-time):**
+
+1. Make the bucket public in the B2 console.
+2. Add a CNAME in Cloudflare DNS:
+   `media.example.com → f004.backblazeb2.com` (use the realm for your region).
+3. Enable **Proxy** (orange cloud) on the CNAME.
+4. In Cloudflare, add a **Transform Rule** to rewrite the request path:
+   `/my-bucket/$1` → keeps URLs clean at `media.example.com/assets/...`.
+5. Enable **Cache Rules** with `Cache everything` for your bucket prefix.
+
+**In your code — just point `public_url_base` at your Cloudflare hostname:**
+
+```python
+from genblaze_core import ObjectStorageSink, KeyStrategy
+from genblaze_s3 import S3StorageBackend
+
+storage = ObjectStorageSink(
+    S3StorageBackend.for_backblaze(
+        "my-bucket",
+        public_url_base="https://media.example.com",
+    ),
+    key_strategy=KeyStrategy.CONTENT_ADDRESSABLE,
+)
+```
+
+Because the assets are CAS-keyed (hash-derived), genblaze automatically sets
+`Cache-Control: public, max-age=31536000, immutable` on each upload — so
+Cloudflare caches indefinitely and B2 only serves each asset once per
+Cloudflare edge. The net effect: **storage cost from B2, near-zero egress,
+instant media playback for end users.**

--- a/libs/connectors/s3/genblaze_s3/backend.py
+++ b/libs/connectors/s3/genblaze_s3/backend.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import logging
 import os
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 from genblaze_core._version import __version__
 from genblaze_core.exceptions import StorageError
@@ -17,6 +18,23 @@ logger = logging.getLogger("genblaze.s3")
 
 # User agent for B2/S3 API tracking
 _USER_AGENT = f"b2ai-genblaze/{__version__}"
+
+# Single-PUT vs multipart cutoff. Above this, boto3 splits into 16 MB parts
+# and uploads up to _MAX_CONCURRENCY in parallel — each part individually
+# retryable, which matters for multi-GB video payloads on flaky links.
+_MULTIPART_THRESHOLD = 16 * 1024 * 1024
+_MULTIPART_CHUNKSIZE = 16 * 1024 * 1024
+_MAX_CONCURRENCY = 4
+
+# urllib3 connection pool ceiling. With 4 asset workers × 4 part workers we
+# can saturate 16 concurrent connections; headroom for HEAD/auth prefetch.
+_MAX_POOL_CONNECTIONS = 20
+
+# Lifecycle defaults applied by ensure_lifecycle_defaults() / auto_lifecycle=True.
+# Orphaned multipart uploads from mid-stream failures otherwise sit billable
+# indefinitely — a real cost vector once the multipart path is the default.
+_DEFAULT_CANCEL_MULTIPART_DAYS = 7
+_DEFAULT_NONCURRENT_EXPIRE_DAYS = 30
 
 
 class S3StorageBackend(StorageBackend):
@@ -47,10 +65,14 @@ class S3StorageBackend(StorageBackend):
     ):
         self._bucket = bucket
         self._public_url_base = public_url_base.rstrip("/") if public_url_base else None
+        # Region may be updated later by auto-detection (see _ensure_region_verified).
+        self._region = region
+        self._region_verified = False
 
         # Lazy import boto3 (same pattern as replicate connector)
         try:
             import boto3
+            from boto3.s3.transfer import TransferConfig
             from botocore.config import Config as BotoConfig
         except ImportError as exc:
             raise ImportError(
@@ -71,14 +93,30 @@ class S3StorageBackend(StorageBackend):
         # User agent for B2 attribution; adaptive retries for transient 429/503s;
         # explicit timeouts because boto3's 60s default read_timeout can fire
         # mid-upload on slow links with GB-sized video payloads.
+        #
+        # request/response_checksum_calculation="when_required" disables the
+        # default CRC32 trailer that boto3 >= 1.36 injects. That header broke
+        # B2 uploads until B2 added support in July 2025; keeping it off
+        # avoids the landmine across any S3-compat endpoint that lags on
+        # checksum-header support (older B2, MinIO, Wasabi). We pass SHA-256
+        # explicitly per upload via ExtraArgs instead.
         kwargs["config"] = BotoConfig(
             user_agent_extra=_USER_AGENT,
             retries={"max_attempts": 3, "mode": "adaptive"},
             connect_timeout=30,
             read_timeout=300,
+            max_pool_connections=_MAX_POOL_CONNECTIONS,
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
         )
 
         self._client = boto3.client("s3", **kwargs)
+        self._transfer_config = TransferConfig(
+            multipart_threshold=_MULTIPART_THRESHOLD,
+            multipart_chunksize=_MULTIPART_CHUNKSIZE,
+            max_concurrency=_MAX_CONCURRENCY,
+            use_threads=True,
+        )
 
     def put(
         self,
@@ -87,18 +125,51 @@ class S3StorageBackend(StorageBackend):
         *,
         content_type: str | None = None,
         metadata: dict[str, str] | None = None,
+        extra_args: dict[str, Any] | None = None,
     ) -> str:
-        """Upload an object to S3. Returns the storage URL."""
+        """Upload an object to S3. Returns the storage URL.
+
+        Uses boto3's managed ``upload_fileobj`` so large payloads are
+        automatically split into multipart uploads (16 MB parts, 4-way
+        parallel) and each part is individually retryable. Per-part SHA-256
+        checksums are negotiated server-side via ``ChecksumAlgorithm``.
+        """
         try:
-            kwargs: dict = {"Bucket": self._bucket, "Key": key, "Body": data}
-            if content_type:
-                kwargs["ContentType"] = content_type
-            if metadata:
-                kwargs["Metadata"] = metadata
-            self._client.put_object(**kwargs)
+            self._ensure_region_verified()
+            merged = self._build_extra_args(content_type, metadata, extra_args)
+            stream: BinaryIO = io.BytesIO(data) if isinstance(data, (bytes, bytearray)) else data
+            self._client.upload_fileobj(
+                stream,
+                self._bucket,
+                key,
+                ExtraArgs=merged,
+                Config=self._transfer_config,
+            )
             return self.get_url(key)
+        except StorageError:
+            raise
         except Exception as exc:
             raise StorageError(f"S3 put failed for {key}: {exc}") from exc
+
+    @staticmethod
+    def _build_extra_args(
+        content_type: str | None,
+        metadata: dict[str, str] | None,
+        extra_args: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Merge kwargs into a boto3-style ExtraArgs dict, honoring caller overrides."""
+        merged: dict[str, Any] = {}
+        if content_type:
+            merged["ContentType"] = content_type
+        if metadata:
+            merged["Metadata"] = metadata
+        # Caller-provided keys win (including overriding ChecksumAlgorithm).
+        if extra_args:
+            merged.update(extra_args)
+        # Default to SHA-256 per-part integrity unless caller pinned a checksum.
+        if "ChecksumAlgorithm" not in merged and "ChecksumSHA256" not in merged:
+            merged["ChecksumAlgorithm"] = "SHA256"
+        return merged
 
     def get(self, key: str) -> bytes:
         """Download an object from S3."""
@@ -142,6 +213,122 @@ class S3StorageBackend(StorageBackend):
         except Exception as exc:
             raise StorageError(f"S3 get_url failed for {key}: {exc}") from exc
 
+    def _ensure_region_verified(self) -> None:
+        """Lazy-verify the bucket region on first use; follow redirect if wrong.
+
+        B2 (and AWS) return 301 ``PermanentRedirect`` with an
+        ``x-amz-bucket-region`` header when the client is pointed at the
+        wrong region. We catch that once and rebuild the client pointing at
+        the correct B2 endpoint — users stop needing to hand-pick the right
+        ``region=`` on ``for_backblaze``.
+        """
+        if self._region_verified:
+            return
+        from botocore.exceptions import ClientError
+
+        try:
+            self._client.head_bucket(Bucket=self._bucket)
+            self._region_verified = True
+        except ClientError as exc:
+            actual = (
+                exc.response.get("ResponseMetadata", {})
+                .get("HTTPHeaders", {})
+                .get("x-amz-bucket-region")
+            )
+            code = exc.response.get("Error", {}).get("Code")
+            if actual and actual != self._region and code in {"301", "PermanentRedirect"}:
+                logger.info(
+                    "Bucket %s lives in %s (client was pointed at %s); reconfiguring.",
+                    self._bucket,
+                    actual,
+                    self._region,
+                )
+                self._reconfigure_for_region(actual)
+                self._region_verified = True
+                return
+            raise StorageError(
+                f"Bucket {self._bucket!r} preflight failed: {exc}. "
+                "Check bucket name, region, and credentials."
+            ) from exc
+
+    def _reconfigure_for_region(self, region: str) -> None:
+        """Rebuild the boto3 client for a different B2 region."""
+        import boto3
+        from boto3.s3.transfer import TransferConfig
+        from botocore.config import Config as BotoConfig
+
+        self._region = region
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=f"https://s3.{region}.backblazeb2.com",
+            region_name=region,
+            aws_access_key_id=self._client.meta.config.__dict__.get("aws_access_key_id"),
+            aws_secret_access_key=self._client.meta.config.__dict__.get("aws_secret_access_key"),
+            config=BotoConfig(
+                user_agent_extra=_USER_AGENT,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+                connect_timeout=30,
+                read_timeout=300,
+                max_pool_connections=_MAX_POOL_CONNECTIONS,
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+            ),
+        )
+        self._transfer_config = TransferConfig(
+            multipart_threshold=_MULTIPART_THRESHOLD,
+            multipart_chunksize=_MULTIPART_CHUNKSIZE,
+            max_concurrency=_MAX_CONCURRENCY,
+            use_threads=True,
+        )
+
+    def ensure_lifecycle_defaults(
+        self,
+        *,
+        cancel_multipart_after_days: int = _DEFAULT_CANCEL_MULTIPART_DAYS,
+        noncurrent_version_expire_days: int | None = _DEFAULT_NONCURRENT_EXPIRE_DAYS,
+    ) -> None:
+        """Apply idempotent lifecycle rules tuned for a genblaze workload.
+
+        Orphaned multipart uploads from failed video transfers otherwise
+        accumulate billable storage forever. Noncurrent-version expiry
+        tidies the per-run manifest history that B2's always-on versioning
+        creates when manifests are rewritten.
+
+        Pass ``noncurrent_version_expire_days=None`` to keep all manifest
+        versions forever (full provenance history, higher storage cost).
+        """
+        rules: list[dict[str, Any]] = [
+            {
+                "ID": "genblaze-cancel-unfinished-multipart",
+                "Status": "Enabled",
+                "Filter": {"Prefix": ""},
+                "AbortIncompleteMultipartUpload": {
+                    "DaysAfterInitiation": cancel_multipart_after_days
+                },
+            }
+        ]
+        if noncurrent_version_expire_days is not None:
+            rules.append(
+                {
+                    "ID": "genblaze-expire-noncurrent-versions",
+                    "Status": "Enabled",
+                    "Filter": {"Prefix": ""},
+                    "NoncurrentVersionExpiration": {
+                        "NoncurrentDays": noncurrent_version_expire_days
+                    },
+                }
+            )
+        try:
+            self._client.put_bucket_lifecycle_configuration(
+                Bucket=self._bucket,
+                LifecycleConfiguration={"Rules": rules},
+            )
+            logger.info("Applied %d lifecycle rule(s) to bucket %s", len(rules), self._bucket)
+        except Exception as exc:
+            # Non-fatal — users with read-only keys or managed infra should
+            # still be able to upload. Log and continue.
+            logger.warning("Failed to apply lifecycle defaults to %s: %s", self._bucket, exc)
+
     # close() intentionally not overridden — base class no-op is correct.
     # boto3 clients don't have a close() method; calling it would raise.
 
@@ -154,32 +341,67 @@ class S3StorageBackend(StorageBackend):
         key_id: str | None = None,
         app_key: str | None = None,
         public_url_base: str | None = None,
+        auto_lifecycle: bool = True,
     ) -> S3StorageBackend:
         """Construct an S3StorageBackend preconfigured for Backblaze B2.
 
         Derives B2's S3 endpoint from ``region`` and falls back to the
         ``B2_KEY_ID`` / ``B2_APP_KEY`` environment variables when
-        credentials are not passed explicitly.
+        credentials are not passed explicitly. Raises ``ValueError`` if
+        credentials are missing entirely — prefer a clear error at
+        construction over a cryptic ``NoCredentialsError`` mid-upload.
+
+        The first ``put()`` / ``exists()`` call auto-detects the bucket's
+        actual region; passing ``region=`` is an optimization hint, not a
+        requirement. If the bucket lives elsewhere the backend transparently
+        reconfigures itself.
 
         Args:
             bucket: B2 bucket name.
-            region: B2 region slug (e.g. "us-west-004", "eu-central-003").
+            region: B2 region slug hint (e.g. "us-west-004", "eu-central-003").
+                Auto-corrected on first use if the bucket lives in a different
+                region.
             key_id: B2 application key ID. Defaults to ``$B2_KEY_ID``.
             app_key: B2 application key. Defaults to ``$B2_APP_KEY``.
             public_url_base: Optional B2 friendly-URL base for public buckets,
                 e.g. ``"https://f004.backblazeb2.com/file/my-bucket"``. When
                 set, :meth:`get_url` returns these instead of pre-signed URLs.
+            auto_lifecycle: When True (default), apply recommended lifecycle
+                rules on construction — cancel orphaned multipart uploads
+                after 7 days and expire noncurrent manifest versions after
+                30 days. Set False if lifecycle is managed out-of-band
+                (Terraform, console, IaC).
 
         Example::
 
             backend = S3StorageBackend.for_backblaze("my-bucket")
             sink = ObjectStorageSink(backend, key_strategy=KeyStrategy.CONTENT_ADDRESSABLE)
         """
-        return cls(
+        resolved_key = key_id or os.environ.get("B2_KEY_ID")
+        resolved_secret = app_key or os.environ.get("B2_APP_KEY")
+        if not resolved_key or not resolved_secret:
+            raise ValueError(
+                "Backblaze B2 credentials missing. Set B2_KEY_ID / B2_APP_KEY "
+                "environment variables, or pass key_id= and app_key= "
+                "explicitly to for_backblaze()."
+            )
+        backend = cls(
             bucket=bucket,
             endpoint_url=f"https://s3.{region}.backblazeb2.com",
             region=region,
             public_url_base=public_url_base,
-            aws_access_key_id=key_id or os.environ.get("B2_KEY_ID"),
-            aws_secret_access_key=app_key or os.environ.get("B2_APP_KEY"),
+            aws_access_key_id=resolved_key,
+            aws_secret_access_key=resolved_secret,
         )
+        if auto_lifecycle:
+            # Region may still be wrong here — ensure_lifecycle_defaults calls
+            # put_bucket_lifecycle_configuration which surfaces 301 cleanly
+            # via the normal region-redirect path. Verify first so the
+            # lifecycle call lands on the right region.
+            try:
+                backend._ensure_region_verified()
+            except StorageError as exc:
+                logger.warning("auto_lifecycle skipped — bucket preflight failed: %s", exc)
+                return backend
+            backend.ensure_lifecycle_defaults()
+        return backend

--- a/libs/connectors/s3/pyproject.toml
+++ b/libs/connectors/s3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-s3"
-version = "0.1.0"
+version = "0.2.0"
 description = "S3-compatible storage backend for genblaze (B2, R2, MinIO, AWS)"
 readme = "../../../README.md"
 requires-python = ">=3.11"

--- a/libs/connectors/s3/tests/test_s3_backend.py
+++ b/libs/connectors/s3/tests/test_s3_backend.py
@@ -8,13 +8,29 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+class _FakeClientError(Exception):
+    """Real exception subclass so backend code can `except ClientError` as usual."""
+
+    def __init__(self, response, operation_name):
+        super().__init__(operation_name)
+        self.response = response
+        self.operation_name = operation_name
+
+
 @pytest.fixture(autouse=True)
 def mock_boto3():
     """Mock boto3 module before importing S3StorageBackend."""
     mock_mod = MagicMock()
     mock_botocore = MagicMock()
+    # botocore.exceptions.ClientError must be a real exception class — the
+    # backend does `except ClientError`, which requires a real type.
+    mock_botocore.exceptions.ClientError = _FakeClientError
     modules = {
         "boto3": mock_mod,
+        # boto3.s3.transfer.TransferConfig is imported at backend init time;
+        # exposing the submodule path satisfies the `from ... import` form.
+        "boto3.s3": mock_mod.s3,
+        "boto3.s3.transfer": mock_mod.s3.transfer,
         "botocore": mock_botocore,
         "botocore.config": mock_botocore.config,
         "botocore.exceptions": mock_botocore.exceptions,
@@ -37,17 +53,59 @@ class TestS3StorageBackend:
         }
         defaults.update(kwargs)
         backend = S3StorageBackend(**defaults)
+        # Skip the head_bucket preflight for most tests — covered separately.
+        backend._region_verified = True
         return backend, mock_client
 
-    def test_put(self, mock_boto3):
+    def test_put_uses_upload_fileobj(self, mock_boto3):
+        """put() routes through upload_fileobj so small+large payloads share the
+        managed-transfer code path (auto-multipart when > threshold)."""
         backend, mock_client = self._make_backend(mock_boto3)
         mock_client.generate_presigned_url.return_value = "https://signed/key"
         backend.put("test/key.png", b"data", content_type="image/png")
-        mock_client.put_object.assert_called_once()
-        call_kwargs = mock_client.put_object.call_args[1]
-        assert call_kwargs["Bucket"] == "my-bucket"
-        assert call_kwargs["Key"] == "test/key.png"
-        assert call_kwargs["ContentType"] == "image/png"
+        mock_client.upload_fileobj.assert_called_once()
+        call_kwargs = mock_client.upload_fileobj.call_args.kwargs
+        args = mock_client.upload_fileobj.call_args.args
+        # Positional args: (stream, bucket, key)
+        assert args[1] == "my-bucket"
+        assert args[2] == "test/key.png"
+        extra = call_kwargs["ExtraArgs"]
+        assert extra["ContentType"] == "image/png"
+        # SHA-256 per-part integrity is the default unless overridden.
+        assert extra["ChecksumAlgorithm"] == "SHA256"
+        # put_object is no longer used for the body path.
+        mock_client.put_object.assert_not_called()
+
+    def test_put_passes_extra_args(self, mock_boto3):
+        """extra_args passthrough lets callers set Cache-Control, SSE, etc."""
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.put(
+            "k",
+            b"data",
+            extra_args={"CacheControl": "public, max-age=31536000, immutable"},
+        )
+        extra = mock_client.upload_fileobj.call_args.kwargs["ExtraArgs"]
+        assert extra["CacheControl"] == "public, max-age=31536000, immutable"
+
+    def test_put_caller_checksum_override(self, mock_boto3):
+        """Explicit ChecksumSHA256 in extra_args suppresses the default algorithm."""
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.put("k", b"data", extra_args={"ChecksumSHA256": "base64hash=="})
+        extra = mock_client.upload_fileobj.call_args.kwargs["ExtraArgs"]
+        assert extra["ChecksumSHA256"] == "base64hash=="
+        # When caller passes explicit checksum, don't also pin the algorithm.
+        assert "ChecksumAlgorithm" not in extra
+
+    def test_put_binaryio_passes_through(self, mock_boto3):
+        """Streaming inputs go straight to upload_fileobj without BytesIO wrapping."""
+        import io
+
+        backend, mock_client = self._make_backend(mock_boto3)
+        stream = io.BytesIO(b"payload")
+        backend.put("k", stream)
+        # First positional arg should be the stream we passed (identity).
+        args = mock_client.upload_fileobj.call_args.args
+        assert args[0] is stream
 
     def test_get(self, mock_boto3):
         backend, mock_client = self._make_backend(mock_boto3)
@@ -93,12 +151,107 @@ class TestS3StorageBackend:
         mock_client.close.assert_not_called()
 
 
+class TestRegionPreflight:
+    """head_bucket-based region auto-detection happens once on first use."""
+
+    def test_happy_path_verifies_once(self, mock_boto3):
+        from genblaze_s3.backend import S3StorageBackend
+
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        backend = S3StorageBackend(
+            bucket="b",
+            endpoint_url="https://s3.us-west-004.backblazeb2.com",
+            region="us-west-004",
+        )
+        backend.put("k", b"d")
+        backend.put("k2", b"d")
+        # head_bucket fired only on the first upload.
+        assert mock_client.head_bucket.call_count == 1
+
+    def test_wrong_region_redirects_and_reconfigures(self, mock_boto3):
+        from genblaze_s3.backend import S3StorageBackend
+
+        mock_client_1 = MagicMock()
+        mock_client_2 = MagicMock()
+        # Client 1 (wrong region): head_bucket raises ClientError with the
+        # real region in ResponseMetadata headers. Client 2 (after reconfig):
+        # normal uploads succeed.
+        mock_boto3.client.side_effect = [mock_client_1, mock_client_2]
+        err = _FakeClientError(
+            {
+                "Error": {"Code": "PermanentRedirect"},
+                "ResponseMetadata": {"HTTPHeaders": {"x-amz-bucket-region": "eu-central-003"}},
+            },
+            "HeadBucket",
+        )
+        mock_client_1.head_bucket.side_effect = err
+
+        backend = S3StorageBackend(
+            bucket="b",
+            endpoint_url="https://s3.us-west-004.backblazeb2.com",
+            region="us-west-004",
+        )
+        backend.put("k", b"d")
+        assert backend._region == "eu-central-003"
+        # The reconfigured client is what ran upload_fileobj.
+        mock_client_2.upload_fileobj.assert_called_once()
+
+
+class TestLifecycleDefaults:
+    """ensure_lifecycle_defaults applies idempotent bucket lifecycle rules."""
+
+    def _make_backend(self, mock_boto3_mod):
+        from genblaze_s3.backend import S3StorageBackend
+
+        mock_client = MagicMock()
+        mock_boto3_mod.client.return_value = mock_client
+        backend = S3StorageBackend(
+            bucket="b", endpoint_url="https://s3.us-west-004.backblazeb2.com"
+        )
+        backend._region_verified = True
+        return backend, mock_client
+
+    def test_applies_abort_multipart_rule(self, mock_boto3):
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.ensure_lifecycle_defaults()
+        mock_client.put_bucket_lifecycle_configuration.assert_called_once()
+        rules = mock_client.put_bucket_lifecycle_configuration.call_args.kwargs[
+            "LifecycleConfiguration"
+        ]["Rules"]
+        # Must include the orphan-cleanup rule.
+        abort_rules = [r for r in rules if "AbortIncompleteMultipartUpload" in r]
+        assert len(abort_rules) == 1
+        assert abort_rules[0]["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"] == 7
+
+    def test_applies_noncurrent_expire_rule(self, mock_boto3):
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.ensure_lifecycle_defaults()
+        rules = mock_client.put_bucket_lifecycle_configuration.call_args.kwargs[
+            "LifecycleConfiguration"
+        ]["Rules"]
+        nc_rules = [r for r in rules if "NoncurrentVersionExpiration" in r]
+        assert len(nc_rules) == 1
+        assert nc_rules[0]["NoncurrentVersionExpiration"]["NoncurrentDays"] == 30
+
+    def test_noncurrent_expire_can_be_disabled(self, mock_boto3):
+        """Pass None to keep all manifest versions forever."""
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.ensure_lifecycle_defaults(noncurrent_version_expire_days=None)
+        rules = mock_client.put_bucket_lifecycle_configuration.call_args.kwargs[
+            "LifecycleConfiguration"
+        ]["Rules"]
+        assert all("NoncurrentVersionExpiration" not in r for r in rules)
+
+    def test_lifecycle_failure_is_non_fatal(self, mock_boto3):
+        """Read-only keys / IaC-managed buckets shouldn't block uploads."""
+        backend, mock_client = self._make_backend(mock_boto3)
+        mock_client.put_bucket_lifecycle_configuration.side_effect = RuntimeError("access denied")
+        backend.ensure_lifecycle_defaults()  # must not raise
+
+
 class TestForBackblaze:
     """S3StorageBackend.for_backblaze() — Backblaze B2 preset factory."""
-
-    def _boto3_call_kwargs(self, mock_boto3):
-        mock_boto3.client.return_value = MagicMock()
-        return mock_boto3.client.call_args.kwargs
 
     def test_derives_b2_endpoint_from_region(self, mock_boto3, monkeypatch):
         from genblaze_s3.backend import S3StorageBackend
@@ -107,7 +260,7 @@ class TestForBackblaze:
         monkeypatch.setenv("B2_APP_KEY", "env-secret")
         mock_boto3.client.return_value = MagicMock()
 
-        S3StorageBackend.for_backblaze("my-bucket", region="us-west-004")
+        S3StorageBackend.for_backblaze("my-bucket", region="us-west-004", auto_lifecycle=False)
 
         kwargs = mock_boto3.client.call_args.kwargs
         assert kwargs["endpoint_url"] == "https://s3.us-west-004.backblazeb2.com"
@@ -123,7 +276,10 @@ class TestForBackblaze:
         mock_boto3.client.return_value = MagicMock()
 
         S3StorageBackend.for_backblaze(
-            "my-bucket", key_id="explicit-key", app_key="explicit-secret"
+            "my-bucket",
+            key_id="explicit-key",
+            app_key="explicit-secret",
+            auto_lifecycle=False,
         )
 
         kwargs = mock_boto3.client.call_args.kwargs
@@ -140,31 +296,58 @@ class TestForBackblaze:
         backend = S3StorageBackend.for_backblaze(
             "my-bucket",
             public_url_base="https://f004.backblazeb2.com/file/my-bucket",
+            auto_lifecycle=False,
         )
         url = backend.get_url("assets/img.png")
         assert url == "https://f004.backblazeb2.com/file/my-bucket/assets/img.png"
 
-    def test_missing_env_vars_passes_none_to_boto3(self, mock_boto3, monkeypatch):
-        """No B2_KEY_ID/B2_APP_KEY set → boto3 falls back to its own credential chain."""
+    def test_missing_credentials_raises_clear_error(self, mock_boto3, monkeypatch):
+        """No B2_KEY_ID/B2_APP_KEY and no explicit args → fail fast with guidance.
+
+        Without this guard, boto3 falls through to its default credential
+        chain (IMDS, profiles) and fails mid-upload with an opaque
+        NoCredentialsError — a classic support-ticket generator.
+        """
         from genblaze_s3.backend import S3StorageBackend
 
         monkeypatch.delenv("B2_KEY_ID", raising=False)
         monkeypatch.delenv("B2_APP_KEY", raising=False)
-        mock_boto3.client.return_value = MagicMock()
+
+        with pytest.raises(ValueError, match="B2_KEY_ID"):
+            S3StorageBackend.for_backblaze("my-bucket")
+
+    def test_auto_lifecycle_applies_defaults(self, mock_boto3, monkeypatch):
+        """auto_lifecycle=True (default) calls put_bucket_lifecycle_configuration."""
+        from genblaze_s3.backend import S3StorageBackend
+
+        monkeypatch.setenv("B2_KEY_ID", "k")
+        monkeypatch.setenv("B2_APP_KEY", "s")
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
 
         S3StorageBackend.for_backblaze("my-bucket")
 
-        kwargs = mock_boto3.client.call_args.kwargs
-        # When key_id/app_key are None the backend omits them entirely,
-        # letting boto3's default credential resolution take over.
-        assert "aws_access_key_id" not in kwargs
-        assert "aws_secret_access_key" not in kwargs
+        mock_client.put_bucket_lifecycle_configuration.assert_called_once()
 
-    def test_boto_config_has_user_agent_and_retries(self, mock_boto3, monkeypatch):
-        """BotoConfig must carry user_agent_extra (for B2 attribution) and a
-        retry policy — either being silently dropped would break B2 usage
-        reporting or resilience to transient 429/503s.
-        """
+    def test_auto_lifecycle_opt_out(self, mock_boto3, monkeypatch):
+        """Users managing lifecycle in Terraform/IaC can disable the helper."""
+        from genblaze_s3.backend import S3StorageBackend
+
+        monkeypatch.setenv("B2_KEY_ID", "k")
+        monkeypatch.setenv("B2_APP_KEY", "s")
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        S3StorageBackend.for_backblaze("my-bucket", auto_lifecycle=False)
+
+        mock_client.put_bucket_lifecycle_configuration.assert_not_called()
+
+    def test_boto_config_carries_b2_essentials(self, mock_boto3, monkeypatch):
+        """BotoConfig must carry user_agent_extra (B2 attribution), adaptive retries,
+        explicit timeouts, a generous connection pool, and most importantly
+        request_checksum_calculation='when_required' — which prevents
+        boto3 >= 1.36 from sending x-amz-sdk-checksum-algorithm headers that
+        older B2 / other S3-compat endpoints reject."""
         from genblaze_core._version import __version__
         from genblaze_s3.backend import S3StorageBackend
 
@@ -172,12 +355,16 @@ class TestForBackblaze:
         monkeypatch.setenv("B2_APP_KEY", "s")
         mock_boto3.client.return_value = MagicMock()
 
-        S3StorageBackend.for_backblaze("my-bucket")
+        S3StorageBackend.for_backblaze("my-bucket", auto_lifecycle=False)
 
         mock_config = sys.modules["botocore.config"].Config
-        mock_config.assert_called_once()
-        config_kwargs = mock_config.call_args.kwargs
+        # Config may be called twice if region auto-detect reconfigures;
+        # inspect the first call which is the one that built the client used here.
+        config_kwargs = mock_config.call_args_list[0].kwargs
         assert config_kwargs["user_agent_extra"] == f"b2ai-genblaze/{__version__}"
         assert config_kwargs["retries"] == {"max_attempts": 3, "mode": "adaptive"}
         assert config_kwargs["connect_timeout"] == 30
         assert config_kwargs["read_timeout"] == 300
+        assert config_kwargs["max_pool_connections"] == 20
+        assert config_kwargs["request_checksum_calculation"] == "when_required"
+        assert config_kwargs["response_checksum_validation"] == "when_required"

--- a/libs/core/genblaze_core/storage/base.py
+++ b/libs/core/genblaze_core/storage/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 
 class KeyStrategy(StrEnum):
@@ -36,8 +36,15 @@ class StorageBackend(ABC):
         *,
         content_type: str | None = None,
         metadata: dict[str, str] | None = None,
+        extra_args: dict[str, Any] | None = None,
     ) -> str:
-        """Upload an object. Returns the storage URL."""
+        """Upload an object. Returns the storage URL.
+
+        ``extra_args`` is a backend-specific passthrough — for the S3 backend it
+        maps to boto3's ``ExtraArgs`` (Cache-Control, ServerSideEncryption,
+        ObjectLockMode, etc.). Backends that don't recognize a key should
+        ignore it rather than raise.
+        """
         ...
 
     @abstractmethod

--- a/libs/core/genblaze_core/storage/sink.py
+++ b/libs/core/genblaze_core/storage/sink.py
@@ -71,6 +71,17 @@ class ObjectStorageSink(BaseSink):
             return "/".join(parts)
         return f"{self._prefix}/manifests/{run.run_id}.json"
 
+    def _manifest_cache_control(self) -> str:
+        """Cache-Control for manifest uploads.
+
+        CAS manifests are keyed by run_id (immutable once a run finishes).
+        HIERARCHICAL manifests share a folder with potentially-rewritable
+        assets, so we use a shorter TTL.
+        """
+        if self._key_strategy == KeyStrategy.CONTENT_ADDRESSABLE:
+            return "public, max-age=31536000, immutable"
+        return "private, max-age=3600"
+
     def _write_run_impl(self, run: Run, manifest: Manifest) -> None:
         date_str = run.created_at.strftime("%Y-%m-%d")
 
@@ -118,7 +129,11 @@ class ObjectStorageSink(BaseSink):
         # 3. Recompute manifest hash after asset transfers mutated URLs/hashes
         manifest.compute_hash()
 
-        # 4. Upload manifest JSON (lock protects check-then-put atomicity)
+        # 4. Upload manifest JSON. We keep the existence check + lock because
+        # B2 buckets are always-versioned: re-putting the same manifest
+        # silently accrues versions (the per-run noncurrent-expire lifecycle
+        # rule ultimately cleans them up, but we'd rather not create churn in
+        # the first place). The manifest is treated as immutable once written.
         manifest_key = self._build_manifest_key(run)
         with self._manifest_lock:
             if not self._backend.exists(manifest_key):
@@ -127,6 +142,7 @@ class ObjectStorageSink(BaseSink):
                     manifest_key,
                     manifest_json.encode("utf-8"),
                     content_type="application/json",
+                    extra_args={"CacheControl": self._manifest_cache_control()},
                 )
                 manifest.manifest_uri = self._backend.get_url(manifest_key)
                 logger.info("Manifest uploaded: %s", manifest_key)

--- a/libs/core/genblaze_core/storage/transfer.py
+++ b/libs/core/genblaze_core/storage/transfer.py
@@ -44,6 +44,19 @@ _LOCAL_SCHEMES = frozenset({"file"})
 # User agent for HTTP requests (asset downloads from B2/CDN)
 _USER_AGENT = f"b2ai-genblaze/{__version__}"
 
+# Cache-Control values. CAS keys are SHA-256-derived so content at that key
+# is immutable by construction — mark for long CDN caching. HIERARCHICAL
+# keys are UUID-based but per-run, so a shorter TTL is safer.
+_CAS_CACHE_CONTROL = "public, max-age=31536000, immutable"
+_HIERARCHICAL_CACHE_CONTROL = "private, max-age=3600"
+
+
+def _cache_control_for(strategy: KeyStrategy) -> str:
+    """Pick the right Cache-Control value for an asset key strategy."""
+    if strategy == KeyStrategy.CONTENT_ADDRESSABLE:
+        return _CAS_CACHE_CONTROL
+    return _HIERARCHICAL_CACHE_CONTROL
+
 
 def _validate_url(url: str) -> None:
     """Reject non-HTTPS URLs and private/reserved IP ranges (SSRF protection)."""
@@ -179,7 +192,12 @@ class AssetTransfer:
             if self._strategy == KeyStrategy.CONTENT_ADDRESSABLE and self._backend.exists(key):
                 logger.debug("Asset already exists at %s, skipping upload", key)
             else:
-                self._backend.put(key, data, content_type=content_type)
+                self._backend.put(
+                    key,
+                    data,
+                    content_type=content_type,
+                    extra_args={"CacheControl": _cache_control_for(self._strategy)},
+                )
         else:
             # Remote URL → validate and stream to temp file (avoids holding large videos in RAM)
             _validate_url(asset.url)
@@ -226,7 +244,12 @@ class AssetTransfer:
                             logger.debug("Asset already exists at %s, skipping upload", key)
                         else:
                             tmp.seek(0)
-                            self._backend.put(key, cast(BinaryIO, tmp), content_type=content_type)
+                            self._backend.put(
+                                key,
+                                cast(BinaryIO, tmp),
+                                content_type=content_type,
+                                extra_args={"CacheControl": _cache_control_for(self._strategy)},
+                            )
                     finally:
                         tmp.close()
             except StorageError:

--- a/libs/core/tests/unit/test_object_storage_sink.py
+++ b/libs/core/tests/unit/test_object_storage_sink.py
@@ -23,10 +23,14 @@ class MemoryBackend(StorageBackend):
 
     def __init__(self):
         self.store: dict[str, bytes] = {}
+        # Per-key record of the ExtraArgs dict passed on upload — lets
+        # individual tests assert per-upload Cache-Control/checksum policy.
+        self.put_extra_args: dict[str, dict] = {}
         self.closed = False
 
-    def put(self, key, data, *, content_type=None, metadata=None):
+    def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
         self.store[key] = data if isinstance(data, bytes) else data.read()
+        self.put_extra_args[key] = dict(extra_args or {})
         return f"https://mem/{key}"
 
     def get(self, key):
@@ -300,3 +304,69 @@ class TestContentAddressableRegression:
         asset_keys = [k for k in backend.store if k != manifest_key]
         assert len(asset_keys) == 1
         assert asset_keys[0].startswith("pfx/assets/")
+
+
+class TestCacheControlPolicy:
+    """Cache-Control headers must match the key-strategy immutability guarantee.
+
+    CAS keys are SHA-256-derived → content is immutable forever → mark public
+    + year-long + immutable so Cloudflare/B2 edge can cache aggressively.
+    HIERARCHICAL keys are UUID-per-run → shorter private TTL.
+    """
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_cas_assets_get_immutable_cache_control(self, mock_urlopen, _mock_dns):
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend, prefix="p", key_strategy=KeyStrategy.CONTENT_ADDRESSABLE)
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        asset_keys = [k for k in backend.store if k.startswith("p/assets/")]
+        assert len(asset_keys) == 1
+        assert (
+            backend.put_extra_args[asset_keys[0]]["CacheControl"]
+            == "public, max-age=31536000, immutable"
+        )
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_hierarchical_assets_get_private_short_ttl(self, mock_urlopen, _mock_dns):
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend, prefix="p", key_strategy=KeyStrategy.HIERARCHICAL)
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        asset_keys = [k for k in backend.store if "/assets/" in k]
+        assert len(asset_keys) == 1
+        assert backend.put_extra_args[asset_keys[0]]["CacheControl"] == "private, max-age=3600"
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_cas_manifest_gets_immutable_cache_control(self, mock_urlopen, _mock_dns):
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend, prefix="p", key_strategy=KeyStrategy.CONTENT_ADDRESSABLE)
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        manifest_key = f"p/manifests/{run.run_id}.json"
+        assert (
+            backend.put_extra_args[manifest_key]["CacheControl"]
+            == "public, max-age=31536000, immutable"
+        )
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_hierarchical_manifest_gets_private_short_ttl(self, mock_urlopen, _mock_dns):
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend, prefix="p", key_strategy=KeyStrategy.HIERARCHICAL)
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        date_str = run.created_at.strftime("%Y-%m-%d")
+        manifest_key = f"p/runs/{date_str}/{run.run_id}/manifest.json"
+        assert backend.put_extra_args[manifest_key]["CacheControl"] == "private, max-age=3600"

--- a/libs/core/tests/unit/test_storage_backend.py
+++ b/libs/core/tests/unit/test_storage_backend.py
@@ -24,7 +24,7 @@ class TestStorageBackendABC:
         """Subclass missing abstract methods should raise TypeError."""
 
         class Partial(StorageBackend):
-            def put(self, key, data, *, content_type=None, metadata=None):
+            def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
                 return ""
 
         with pytest.raises(TypeError):
@@ -34,7 +34,7 @@ class TestStorageBackendABC:
         """A subclass implementing all abstract methods should work."""
 
         class Complete(StorageBackend):
-            def put(self, key, data, *, content_type=None, metadata=None):
+            def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
                 return f"url://{key}"
 
             def get(self, key):
@@ -57,7 +57,7 @@ class TestStorageBackendABC:
         """Default close() should not raise."""
 
         class Minimal(StorageBackend):
-            def put(self, key, data, *, content_type=None, metadata=None):
+            def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
                 return ""
 
             def get(self, key):

--- a/libs/core/tests/unit/test_transfer.py
+++ b/libs/core/tests/unit/test_transfer.py
@@ -28,7 +28,7 @@ class FakeBackend(StorageBackend):
     def __init__(self):
         self.store: dict[str, bytes] = {}
 
-    def put(self, key, data, *, content_type=None, metadata=None):
+    def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
         if isinstance(data, bytes):
             self.store[key] = data
         else:
@@ -270,7 +270,7 @@ class TestAssetTransfer:
         received_data = []
 
         class TrackingBackend(FakeBackend):
-            def put(self, key, data, *, content_type=None, metadata=None):
+            def put(self, key, data, *, content_type=None, metadata=None, extra_args=None):
                 received_data.append(type(data).__name__)
                 # Read file-like object for storage
                 if hasattr(data, "read"):


### PR DESCRIPTION
This PR improves Backblaze B2 support and developer experience for the S3 backend.

Highlights:
- Multipart uploads via upload_fileobj + TransferConfig
- Per-part SHA-256 with when_required checksum compatibility
- for_backblaze() credential validation and region auto-detection
- Immutable Cache-Control defaults for CAS uploads
- extra_args support in StorageBackend.put()
- Expanded B2-focused test coverage