### PR TITLE
feat(core): Object Lock retention for manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `genblaze-core`: `ObjectLockConfig` dataclass + `ObjectStorageSink(manifest_lock=...)`
+  parameter. Applies B2 Object Lock retention (GOVERNANCE or COMPLIANCE) to
+  manifest uploads — turns genblaze's canonical-hash provenance into an
+  immutable, audit-grade on-disk artifact. GOVERNANCE is the default;
+  COMPLIANCE logs a prominent warning at construction because its retention
+  cannot be shortened, even by the account root. See
+  `docs/features/object-storage.md` for the full recipe.
 - `genblaze-s3`: multipart uploads via `upload_fileobj` + `TransferConfig` —
   assets >16 MB now split into 16 MB parts uploaded 4-way in parallel, each
   part individually retryable. Transforms multi-GB video uploads from a

--- a/docs/features/object-storage.md
+++ b/docs/features/object-storage.md
@@ -147,10 +147,70 @@ result = Pipeline("full-pipeline").step(...).run(sink=storage)
 | `key_strategy` | `KeyStrategy` | `CONTENT_ADDRESSABLE` | Layout strategy |
 | `parquet_sink` | `ParquetSink` | `None` | Optional structured data sink |
 | `max_upload_workers` | `int` | `4` | Max parallel asset uploads per `write_run` call |
+| `manifest_lock` | `ObjectLockConfig \| None` | `None` | When set, applies Object Lock retention to manifests. See "Immutable provenance via Object Lock" below. |
 
 ## Backward compatibility
 
 Existing buckets using the previous HIERARCHICAL layout (assets at `{prefix}/assets/{tenant}/{date}/{run_id}/{asset_id}.ext`) continue to work — URLs stored in manifests remain valid regardless of layout changes. Only newly written data uses the updated paths.
+
+## Immutable provenance via Object Lock
+
+Genblaze's product promise is cryptographically verified provenance for
+every generated asset. **Object Lock** is the on-disk enforcement of that
+promise — once set, the manifest cannot be deleted or overwritten for the
+retention period, turning a hash-verified document into an audit-grade
+legal-hold artifact.
+
+Backblaze B2 supports Object Lock natively via the S3-compatible API.
+**Note:** the bucket must have Object Lock *enabled at creation time* — it
+cannot be toggled on later.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from genblaze_core import (
+    KeyStrategy,
+    ObjectLockConfig,
+    ObjectStorageSink,
+    Pipeline,
+)
+from genblaze_s3 import S3StorageBackend
+
+storage = ObjectStorageSink(
+    S3StorageBackend.for_backblaze("my-locked-bucket"),
+    key_strategy=KeyStrategy.CONTENT_ADDRESSABLE,
+    # GOVERNANCE: authorized admins holding s3:BypassGovernanceRetention
+    # can still delete. Safe default for audit trails.
+    manifest_lock=ObjectLockConfig(
+        retain_until=datetime.now(timezone.utc) + timedelta(days=365),
+        mode="GOVERNANCE",
+    ),
+)
+
+result = Pipeline("locked-run").step(...).run(sink=storage)
+# Manifest at s3://my-locked-bucket/manifests/{run_id}.json is now
+# immutably retained until the retain_until date.
+```
+
+### GOVERNANCE vs. COMPLIANCE
+
+- **GOVERNANCE** (default, recommended) — authorized users holding
+  `s3:BypassGovernanceRetention` can still delete. Standard audit-trail
+  retention.
+- **COMPLIANCE** — *no one* can delete the object until retention expires,
+  including the account root. A bad retention date cannot be shortened.
+  Use only for strict regulatory scenarios (e.g. legal hold). The sink
+  logs a loud warning at construction when this mode is chosen.
+
+### Why B2 Object Lock fits genblaze's provenance story
+
+- Native S3-API support — no separate native API required.
+- Priced transparently at standard storage rates.
+- Pairs with B2's always-on bucket versioning: every manifest write
+  creates a new, independently-lockable version.
+- Combined with genblaze's `canonical_hash`: the hash *proves* the
+  manifest hasn't been tampered with; Object Lock *prevents* it from
+  being tampered with in the first place.
 
 ## Serving media at zero egress: B2 + Cloudflare
 

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -73,6 +73,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ObjectStorageSink": ("genblaze_core.storage.sink", "ObjectStorageSink"),
     "AssetTransfer": ("genblaze_core.storage.transfer", "AssetTransfer"),
     "KeyStrategy": ("genblaze_core.storage.base", "KeyStrategy"),
+    "ObjectLockConfig": ("genblaze_core.storage.base", "ObjectLockConfig"),
     # testing
     "MockProvider": ("genblaze_core.testing", "MockProvider"),
     "MockVideoProvider": ("genblaze_core.testing", "MockVideoProvider"),

--- a/libs/core/genblaze_core/storage/__init__.py
+++ b/libs/core/genblaze_core/storage/__init__.py
@@ -1,7 +1,19 @@
 """Object storage abstractions for genblaze."""
 
-from genblaze_core.storage.base import KeyStrategy, StorageBackend
+from genblaze_core.storage.base import (
+    KeyStrategy,
+    ObjectLockConfig,
+    ObjectLockMode,
+    StorageBackend,
+)
 from genblaze_core.storage.sink import ObjectStorageSink
 from genblaze_core.storage.transfer import AssetTransfer
 
-__all__ = ["AssetTransfer", "KeyStrategy", "ObjectStorageSink", "StorageBackend"]
+__all__ = [
+    "AssetTransfer",
+    "KeyStrategy",
+    "ObjectLockConfig",
+    "ObjectLockMode",
+    "ObjectStorageSink",
+    "StorageBackend",
+]

--- a/libs/core/genblaze_core/storage/base.py
+++ b/libs/core/genblaze_core/storage/base.py
@@ -3,8 +3,45 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, Literal
+
+ObjectLockMode = Literal["GOVERNANCE", "COMPLIANCE"]
+
+
+@dataclass(frozen=True)
+class ObjectLockConfig:
+    """Object-lock retention applied to uploaded manifests.
+
+    Genblaze's product promise is cryptographically verified provenance.
+    Object Lock is the on-disk expression of that promise — once set, the
+    manifest cannot be deleted or overwritten for the retention period.
+
+    Modes:
+      * ``"GOVERNANCE"`` (default, recommended) — authorized users holding
+        the ``s3:BypassGovernanceRetention`` permission can still delete
+        locked objects. Use this for standard audit-trail retention.
+      * ``"COMPLIANCE"`` — *no one* can delete the object until retention
+        expires, including the account root. Choose only for strict
+        regulatory scenarios (e.g. legal hold); a bad retention date
+        cannot be shortened.
+
+    Backblaze B2 supports Object Lock natively. The bucket must have
+    Object Lock enabled at creation time — it cannot be toggled on an
+    existing bucket.
+    """
+
+    retain_until: datetime
+    mode: ObjectLockMode = "GOVERNANCE"
+
+    def to_extra_args(self) -> dict[str, Any]:
+        """Serialize into boto3 ``ExtraArgs`` keys for a put/upload call."""
+        return {
+            "ObjectLockMode": self.mode,
+            "ObjectLockRetainUntilDate": self.retain_until,
+        }
 
 
 class KeyStrategy(StrEnum):

--- a/libs/core/genblaze_core/storage/sink.py
+++ b/libs/core/genblaze_core/storage/sink.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from genblaze_core.models.manifest import Manifest
     from genblaze_core.models.run import Run
     from genblaze_core.sinks.parquet import ParquetSink
-    from genblaze_core.storage.base import StorageBackend
+    from genblaze_core.storage.base import ObjectLockConfig, StorageBackend
 
 logger = logging.getLogger("genblaze.storage.sink")
 
@@ -39,6 +39,7 @@ class ObjectStorageSink(BaseSink):
         key_strategy: KeyStrategy = KeyStrategy.CONTENT_ADDRESSABLE,
         parquet_sink: ParquetSink | None = None,
         max_upload_workers: int = _DEFAULT_UPLOAD_WORKERS,
+        manifest_lock: ObjectLockConfig | None = None,
     ):
         self._backend = backend
         self._prefix = prefix
@@ -48,6 +49,15 @@ class ObjectStorageSink(BaseSink):
         self._transfer = AssetTransfer(backend, prefix=asset_prefix, key_strategy=key_strategy)
         self._parquet_sink = parquet_sink
         self._max_upload_workers = max_upload_workers
+        self._manifest_object_lock = manifest_lock
+        if manifest_lock is not None and manifest_lock.mode == "COMPLIANCE":
+            logger.warning(
+                "ObjectStorageSink configured with COMPLIANCE-mode Object Lock "
+                "until %s. Manifests under this prefix cannot be deleted by "
+                "anyone — including the account root — until retention "
+                "expires. Bad retention dates cannot be shortened.",
+                manifest_lock.retain_until.isoformat(),
+            )
         # Lock protects only the manifest write (check-then-put must be atomic)
         self._manifest_lock = threading.Lock()
 
@@ -138,11 +148,14 @@ class ObjectStorageSink(BaseSink):
         with self._manifest_lock:
             if not self._backend.exists(manifest_key):
                 manifest_json = manifest.to_canonical_json()
+                manifest_extra: dict = {"CacheControl": self._manifest_cache_control()}
+                if self._manifest_object_lock is not None:
+                    manifest_extra.update(self._manifest_object_lock.to_extra_args())
                 self._backend.put(
                     manifest_key,
                     manifest_json.encode("utf-8"),
                     content_type="application/json",
-                    extra_args={"CacheControl": self._manifest_cache_control()},
+                    extra_args=manifest_extra,
                 )
                 manifest.manifest_uri = self._backend.get_url(manifest_key)
                 logger.info("Manifest uploaded: %s", manifest_key)

--- a/libs/core/tests/unit/test_object_storage_sink.py
+++ b/libs/core/tests/unit/test_object_storage_sink.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import socket
 import threading
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import RunStatus, StepStatus
 from genblaze_core.models.manifest import Manifest
 from genblaze_core.models.run import Run
 from genblaze_core.models.step import Step
-from genblaze_core.storage.base import KeyStrategy, StorageBackend
+from genblaze_core.storage.base import KeyStrategy, ObjectLockConfig, StorageBackend
 from genblaze_core.storage.sink import ObjectStorageSink
 
 # Fake DNS response — resolves to a public IP (bypasses SSRF check)
@@ -370,3 +372,103 @@ class TestCacheControlPolicy:
         date_str = run.created_at.strftime("%Y-%m-%d")
         manifest_key = f"p/runs/{date_str}/{run.run_id}/manifest.json"
         assert backend.put_extra_args[manifest_key]["CacheControl"] == "private, max-age=3600"
+
+
+class TestManifestObjectLock:
+    """Object Lock on manifests — the B2-native provenance retention story."""
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_governance_mode_passes_lock_to_backend(self, mock_urlopen, _mock_dns):
+        mock_urlopen.return_value = _mock_urlopen()
+        retain_until = datetime(2030, 1, 1, tzinfo=UTC)
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(
+            backend,
+            prefix="p",
+            key_strategy=KeyStrategy.CONTENT_ADDRESSABLE,
+            manifest_lock=ObjectLockConfig(retain_until=retain_until, mode="GOVERNANCE"),
+        )
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        manifest_key = f"p/manifests/{run.run_id}.json"
+        extra = backend.put_extra_args[manifest_key]
+        assert extra["ObjectLockMode"] == "GOVERNANCE"
+        assert extra["ObjectLockRetainUntilDate"] == retain_until
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_compliance_mode_logs_warning(self, mock_urlopen, _mock_dns, caplog):
+        """COMPLIANCE mode is a foot-gun — the sink should log loudly at init."""
+        import logging
+
+        mock_urlopen.return_value = _mock_urlopen()
+        retain_until = datetime(2030, 1, 1, tzinfo=UTC)
+        with caplog.at_level(logging.WARNING, logger="genblaze.storage.sink"):
+            ObjectStorageSink(
+                MemoryBackend(),
+                manifest_lock=ObjectLockConfig(retain_until=retain_until, mode="COMPLIANCE"),
+            )
+        assert any("COMPLIANCE" in rec.message for rec in caplog.records)
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_no_lock_by_default(self, mock_urlopen, _mock_dns):
+        """Without explicit manifest_lock, no ObjectLock keys are written."""
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend, prefix="p", key_strategy=KeyStrategy.CONTENT_ADDRESSABLE)
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        manifest_key = f"p/manifests/{run.run_id}.json"
+        extra = backend.put_extra_args[manifest_key]
+        assert "ObjectLockMode" not in extra
+        assert "ObjectLockRetainUntilDate" not in extra
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer.urllib.request.urlopen")
+    def test_lock_preserves_cache_control(self, mock_urlopen, _mock_dns):
+        """Object Lock and Cache-Control both end up on the same put call."""
+        mock_urlopen.return_value = _mock_urlopen()
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(
+            backend,
+            prefix="p",
+            key_strategy=KeyStrategy.CONTENT_ADDRESSABLE,
+            manifest_lock=ObjectLockConfig(
+                retain_until=datetime.now(UTC) + timedelta(days=365),
+            ),
+        )
+        run, manifest = _make_run_and_manifest()
+        sink.write_run(run, manifest)
+
+        manifest_key = f"p/manifests/{run.run_id}.json"
+        extra = backend.put_extra_args[manifest_key]
+        assert "ObjectLockMode" in extra
+        assert "CacheControl" in extra
+
+
+class TestObjectLockConfig:
+    """Direct tests of the ObjectLockConfig dataclass."""
+
+    def test_default_mode_is_governance(self):
+        cfg = ObjectLockConfig(retain_until=datetime(2030, 1, 1, tzinfo=UTC))
+        assert cfg.mode == "GOVERNANCE"
+
+    def test_to_extra_args_serializes_both_fields(self):
+        retain_until = datetime(2030, 1, 1, tzinfo=UTC)
+        cfg = ObjectLockConfig(retain_until=retain_until, mode="COMPLIANCE")
+        assert cfg.to_extra_args() == {
+            "ObjectLockMode": "COMPLIANCE",
+            "ObjectLockRetainUntilDate": retain_until,
+        }
+
+    def test_is_frozen(self):
+        """Frozen dataclass — configs shouldn't be mutated after construction."""
+        import dataclasses
+
+        cfg = ObjectLockConfig(retain_until=datetime(2030, 1, 1, tzinfo=UTC))
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.mode = "COMPLIANCE"  # type: ignore[misc]


### PR DESCRIPTION
This PR adds object lock support for provenance manifests.

Highlights:
- Frozen ObjectLockConfig dataclass
- GOVERNANCE by default, COMPLIANCE optional
- manifest retention wired through extra_args
- Compatible with existing Cache-Control behavior
- Additional tests and docs for immutable provenance