### PR TITLE
chore: enhance release workflow documentation and add release guidelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,79 +1,267 @@
 name: Release
 
+# Two entry points:
+#   1. release: published   — production. Tag must match the latest CHANGELOG.md
+#                             wave header (e.g. tag "v0.3.0" iff the most recent
+#                             `## [X.Y.Z]` heading is `## [0.3.0]`). Per-package
+#                             pyproject versions are NOT tag-validated; they
+#                             version independently. See RELEASING.md.
+#   2. workflow_dispatch    — manual. Defaults to dry_run=true → TestPyPI + npm --dry-run.
+#                             Use this to exercise the full pipeline (build, smoke, gates,
+#                             OIDC, sigstore attestations) without touching prod registries.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Route publishes to TestPyPI + npm --dry-run instead of real registries"
+        type: boolean
+        required: true
+        default: true
+      ref:
+        description: "Git ref to release from (default: current branch). Only honored on workflow_dispatch."
+        type: string
+        required: false
+        default: ""
 
+# A half-shipped release is worse than a delayed one. Serialize concurrent
+# releases on the same tag, but don't cancel an in-flight publish — a job
+# interrupted between two `pypi-publish` calls would leave PyPI partially
+# updated and the umbrella unable to resolve its connector pins.
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.run_id }}
+  cancel-in-progress: false
+
+# Default permissions are least-privilege (read-only). Jobs that actually
+# need to mint an OIDC token for Trusted Publishing override this with a
+# per-job `permissions:` block. Pre-publish gates and install-verify
+# never need write permissions of any kind.
 permissions:
-  id-token: write  # Trusted publishing to PyPI
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.13"
+  NODE_VERSION: "20"
 
 jobs:
-  # Pre-publish gate: build every wheel, install ``genblaze[all]`` from
-  # the local wheelhouse with ``--no-index``, and import every connector.
-  # Catches incompatible pyproject pins BEFORE we publish to PyPI —
-  # editable installs in ci.yml don't exercise version constraints.
-  release-smoke:
+  # ─────────────────────────────────────────────────────────────────────
+  # Pre-publish gates. All three must pass before any package is built.
+  # ─────────────────────────────────────────────────────────────────────
+
+  validate-version:
+    # Single source of truth for "what wave are we releasing" + "is this
+    # a dry run". Emitted as outputs so every downstream job reads the same
+    # values without re-parsing files or re-evaluating dispatch inputs.
+    #
+    # Versioning model: each package's pyproject.toml carries its own
+    # version, and they do NOT move in lockstep. The GitHub Release tag
+    # follows the most recent CHANGELOG.md version header — that's the
+    # only source that always exists and always reflects the maintainer's
+    # intent for "what to call this wave". Per-package versions are
+    # whatever their own pyproject says; the workflow publishes those
+    # as-is.
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      wave_version: ${{ steps.read.outputs.wave }}
+      umbrella_version: ${{ steps.read.outputs.umbrella }}
+      core_version: ${{ steps.read.outputs.core }}
+      spec_version: ${{ steps.read.outputs.spec }}
+      dry_run: ${{ steps.read.outputs.dry_run }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - id: read
+        name: Read CHANGELOG + pyproject versions and validate release tag
+        # SECURITY: all GitHub-controlled values (event name, release tag,
+        # dispatch inputs) are passed via `env:` rather than templated
+        # directly into the shell script. This prevents script injection
+        # from a maliciously-named tag like  v1.0.0"; rm -rf /  on a
+        # release-create event.
+        # See https://securitylab.github.com/research/github-actions-untrusted-input/
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # `wave` = the latest non-Unreleased version header in CHANGELOG.md.
+          # `## [0.3.0] - 2026-05-11` → wave="0.3.0". This is the canonical
+          # release name for the wave.
+          wave=$(grep -m1 -E '^## \[[0-9]' CHANGELOG.md | sed -E 's/^## \[([^]]+)\].*/\1/')
+          if [ -z "$wave" ]; then
+            echo "::error file=CHANGELOG.md::Could not find a versioned heading in CHANGELOG.md"
+            exit 1
+          fi
+
+          # Per-package versions for downstream visibility (logs, install-verify).
+          umbrella=$(awk -F'"' '/^version *= */ {print $2; exit}' libs/meta/pyproject.toml)
+          core=$(awk -F'"' '/^version *= */ {print $2; exit}' libs/core/pyproject.toml)
+          spec=$(python -c "import json; print(json.load(open('libs/spec/package.json'))['version'])")
+
+          echo "wave=$wave" >> "$GITHUB_OUTPUT"
+          echo "umbrella=$umbrella" >> "$GITHUB_OUTPUT"
+          echo "core=$core" >> "$GITHUB_OUTPUT"
+          echo "spec=$spec" >> "$GITHUB_OUTPUT"
+
+          # Normalize the dry_run flag. On `release` trigger there's no input,
+          # so we hard-code false. On workflow_dispatch we honor the user's
+          # toggle (defaults to true — see inputs.dry_run.default above).
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            dry_run="$INPUT_DRY_RUN"
+          else
+            dry_run="false"
+          fi
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+
+          # On `release` trigger, enforce tag matches the CHANGELOG wave name.
+          # This catches "tagged v0.3.0 but forgot to cut the CHANGELOG" and
+          # vice-versa. Per-package pyproject versions are NOT validated
+          # against the tag — they version independently by design.
+          if [ "$EVENT_NAME" = "release" ]; then
+            expected="v$wave"
+            if [ "$RELEASE_TAG" != "$expected" ]; then
+              echo "::error file=CHANGELOG.md::Release tag '$RELEASE_TAG' does not match latest CHANGELOG.md wave '$wave' (expected '$expected'). Either re-tag, or cut a new CHANGELOG section before tagging."
+              exit 1
+            fi
+          fi
+
+          echo "Release plan: wave=$wave (umbrella=$umbrella, core=$core, spec=$spec), dry_run=$dry_run"
+
+  changelog-gate:
+    # CHANGELOG hygiene: block release if [Unreleased] still contains entries.
+    # Cheap insurance against publishing with an uncut changelog — caught a
+    # near-miss during the 0.2.x cycle when a connector PR landed inside
+    # the same merge window as a release-prep PR.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Ensure CHANGELOG [Unreleased] is empty
+        run: |
+          # Extract lines BETWEEN `## [Unreleased]` (exclusive) and the next
+          # `## [...]` versioned heading (exclusive). A range-style
+          # `awk '/A/,/B/'` would collapse to a single line because
+          # `[Unreleased]` matches both start and end patterns — use a flag.
+          unreleased_body=$(awk '
+              /^## \[Unreleased\]$/ { flag=1; next }
+              /^## \[/ && flag       { flag=0; exit }
+              flag                   { print }
+          ' CHANGELOG.md)
+          # A real entry is `- ` (bullet) or `### ` (subsection heading).
+          # Blank lines and prose are tolerated in a clean [Unreleased] block.
+          if echo "$unreleased_body" | grep -qE "^- |^### "; then
+            echo "::error file=CHANGELOG.md::CHANGELOG.md [Unreleased] block has entries — must be cut to a versioned heading before release"
+            echo "Offending content:"
+            echo "$unreleased_body"
+            exit 1
+          fi
+          echo "CHANGELOG.md [Unreleased] block is empty — ok"
+
+  release-smoke:
+    # Build every wheel, install `genblaze[all]` from the local wheelhouse
+    # with `--no-index`, and import every connector. Catches incompatible
+    # pyproject pins BEFORE PyPI sees them — editable installs in ci.yml
+    # don't exercise version constraints. See tools/release_smoke.sh.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [validate-version]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Install build tools
-        run: pip install build twine
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install build twine
       - name: Run release smoke test (build + install + import all)
         run: make release-smoke
 
+  # ─────────────────────────────────────────────────────────────────────
+  # PyPI publishes. Dependency order is significant: core ships first
+  # because every other package depends on it; the umbrella ships last
+  # because pip needs the connectors it pins to already be on PyPI.
+  # ─────────────────────────────────────────────────────────────────────
+
   publish-core:
     runs-on: ubuntu-latest
-    # BOTH pre-publish gates must pass — release-smoke (wheel install
-    # works) AND changelog-gate (CHANGELOG cut for the version being
-    # released). Either failure blocks every downstream publish job
-    # via the dependency chain (cli, connectors, meta all need
-    # publish-core).
-    needs: [release-smoke, changelog-gate]
-    environment: pypi
+    timeout-minutes: 15
+    needs: [validate-version, changelog-gate, release-smoke]
+    # Dry-run dispatches use the `testpypi` environment so we can configure
+    # a SEPARATE Trusted Publisher on test.pypi.org without leaking that
+    # OIDC trust into production. Real publishes use `pypi`.
+    environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+    permissions:
+      contents: read
+      id-token: write   # Trusted Publishing to PyPI + sigstore attestations.
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Install build tools
-        run: pip install build twine
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install build twine
       - name: Build genblaze-core
         run: cd libs/core && python -m build
       - name: Validate wheel metadata
         run: twine check libs/core/dist/*
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: libs/core/dist/
+          repository-url: ${{ needs.validate-version.outputs.dry_run == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true   # PEP 740 sigstore attestations — provenance into PyPI's integrity registry.
+          skip-existing: true  # Idempotent: re-running a partially-failed release is safe. PyPI duplicates are treated as success.
 
   publish-cli:
     runs-on: ubuntu-latest
-    needs: publish-core
-    environment: pypi
+    timeout-minutes: 15
+    needs: [publish-core, validate-version]
+    environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Install build tools
-        run: pip install build twine
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install build twine
       - name: Build genblaze-cli
         run: cd cli && python -m build
       - name: Validate wheel metadata
         run: twine check cli/dist/*
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: cli/dist/
+          repository-url: ${{ needs.validate-version.outputs.dry_run == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: true
 
   publish-connectors:
     runs-on: ubuntu-latest
-    needs: publish-core
-    environment: pypi
+    timeout-minutes: 15
+    needs: [publish-core, validate-version]
+    environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
+      # One connector failing must NOT cancel the others. A failure here
+      # typically means a transient PyPI issue or a per-package config bug;
+      # cancelling siblings leaves us with a partial release that's worse
+      # to recover from than letting them all attempt and re-running the
+      # failed cell after the fact.
+      fail-fast: false
       matrix:
         connector:
           - replicate
@@ -91,70 +279,164 @@ jobs:
           - nvidia
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Install build tools
-        run: pip install build twine
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install build twine
       - name: Build connector
         run: cd libs/connectors/${{ matrix.connector }} && python -m build
       - name: Validate wheel metadata
         run: twine check libs/connectors/${{ matrix.connector }}/dist/*
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: libs/connectors/${{ matrix.connector }}/dist/
+          repository-url: ${{ needs.validate-version.outputs.dry_run == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: true
 
   publish-meta:
-    # The ``genblaze`` umbrella package must publish AFTER all connectors:
-    # its [project.optional-dependencies] block references connector packages
-    # by version (>=0.3.0,<0.4), and pip resolution requires those targets
+    # The `genblaze` umbrella MUST publish after every connector: its
+    # [project.optional-dependencies] block references connector packages
+    # by version constraint, and pip resolution requires those targets
     # to exist on PyPI when the umbrella's own wheel is being installed.
-    # Publishing meta before connectors would leave ``pip install "genblaze[all]"``
+    # Publishing meta before connectors would leave `pip install "genblaze[all]"`
     # in a broken intermediate state until connectors land.
     runs-on: ubuntu-latest
-    needs: publish-connectors
-    environment: pypi
+    timeout-minutes: 15
+    needs: [publish-connectors, validate-version]
+    environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Install build tools
-        run: pip install build twine
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install build twine
       - name: Build genblaze (umbrella)
         run: cd libs/meta && python -m build
       - name: Validate wheel metadata
         run: twine check libs/meta/dist/*
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: libs/meta/dist/
+          repository-url: ${{ needs.validate-version.outputs.dry_run == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: true
 
-  # CHANGELOG hygiene gate — block release if [Unreleased] still present.
-  # Cheap insurance against accidentally publishing with an uncut changelog.
-  changelog-gate:
+  # ─────────────────────────────────────────────────────────────────────
+  # npm publish (TypeScript types). Runs in parallel with the PyPI graph
+  # because @genblaze/spec has no dependency on any Python package.
+  # ─────────────────────────────────────────────────────────────────────
+
+  publish-npm:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [validate-version, changelog-gate]
+    environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'npm-dryrun' || 'npm' }}
+    permissions:
+      contents: read
+      id-token: write   # npm provenance — signed attestation that this tarball was built from this commit by this workflow.
     steps:
       - uses: actions/checkout@v4
-      - name: Ensure CHANGELOG is cut
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+      - name: Regenerate TS types from JSON Schemas
+        # Defensive — CI already runs ts-types-check on every push, but a
+        # release shouldn't trust that the committed types are still
+        # current. Regenerate, then refuse to publish if the working tree
+        # is dirty (someone changed a schema without re-running ts-types).
+        run: make ts-types
+      - name: Verify generated types match committed
         run: |
-          # Extract lines BETWEEN ``## [Unreleased]`` (exclusive) and the
-          # next ``## [...`` versioned heading (exclusive). A range-style
-          # ``awk '/A/,/B/'`` would collapse to a single line because
-          # ``[Unreleased]`` matches both start and end patterns — use a
-          # flag instead.
-          unreleased_body=$(awk '
-              /^## \[Unreleased\]$/ { flag=1; next }
-              /^## \[/ && flag       { flag=0; exit }
-              flag                   { print }
-          ' CHANGELOG.md)
-          # An entry is ``- `` (bullet) or ``### `` (subsection heading).
-          # Blank lines and prose are allowed in a clean ``[Unreleased]``.
-          if echo "$unreleased_body" | grep -qE "^- |^### "; then
-            echo "::error::CHANGELOG.md [Unreleased] block has entries — must be cut to a versioned heading before release"
-            echo "Offending content:"
-            echo "$unreleased_body"
+          if ! git diff --exit-code libs/spec/ts/; then
+            echo "::error::libs/spec/ts/ is stale. Run 'make ts-types' locally and commit before tagging a release."
             exit 1
           fi
-          echo "CHANGELOG.md [Unreleased] block is empty — ok"
+      - name: Check if @genblaze/spec version is already published
+        # Idempotent guard: npm publish hard-fails on duplicate versions
+        # (no skip-existing equivalent). Pre-check via `npm view` so a
+        # re-run after a partial release fall-through doesn't fail this
+        # job. The wave often advances WITHOUT a spec bump (only ~half
+        # the waves change the schema), so this is the common path.
+        id: npm_check
+        working-directory: libs/spec
+        run: |
+          local_version=$(node -p "require('./package.json').version")
+          remote_version=$(npm view @genblaze/spec version 2>/dev/null || echo "")
+          echo "local=$local_version remote=$remote_version"
+          if [ "$local_version" = "$remote_version" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::@genblaze/spec@$local_version is already on npm — skipping publish (idempotent)"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to npm
+        if: steps.npm_check.outputs.skip != 'true'
+        working-directory: libs/spec
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ needs.validate-version.outputs.dry_run }}" = "true" ]; then
+            echo "Dry run: validating publish without uploading"
+            npm publish --access public --dry-run --provenance
+          else
+            npm publish --access public --provenance
+          fi
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Post-publish: install from the public registry and import each
+  # package to confirm the publish actually worked end-to-end. Skipped
+  # on dry-runs because TestPyPI metadata indexing lags real PyPI by
+  # enough that this would flake.
+  # ─────────────────────────────────────────────────────────────────────
+
+  install-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [publish-meta, publish-npm, validate-version]
+    if: needs.validate-version.outputs.dry_run != 'true'
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Wait for PyPI to index the umbrella
+        # PyPI's CDN can take ~30-60s to surface a fresh release. Poll with
+        # a bounded retry so an indexing lag doesn't fail the whole run.
+        # Indexing is checked against the umbrella's own version because
+        # that's what `pip install genblaze` resolves to — the wave name
+        # (which the tag follows) doesn't appear in the package metadata.
+        run: |
+          version="${{ needs.validate-version.outputs.umbrella_version }}"
+          for i in $(seq 1 12); do
+            if pip index versions genblaze 2>/dev/null | grep -q "$version"; then
+              echo "genblaze==$version is visible on PyPI"
+              exit 0
+            fi
+            echo "[$i/12] genblaze==$version not yet on PyPI, sleeping 10s…"
+            sleep 10
+          done
+          echo "::error::genblaze==$version did not appear on PyPI within 2 minutes"
+          exit 1
+      - name: Fresh install and import smoke
+        run: |
+          version="${{ needs.validate-version.outputs.umbrella_version }}"
+          python -m venv /tmp/verify
+          /tmp/verify/bin/pip install --upgrade pip
+          /tmp/verify/bin/pip install "genblaze==$version"
+          /tmp/verify/bin/python -c "
+          import genblaze_core, genblaze_s3
+          print(f'genblaze_core={genblaze_core.__version__}')
+          print(f'genblaze_s3={genblaze_s3.__version__ if hasattr(genblaze_s3, \"__version__\") else \"(no __version__)\"}')
+          "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Orchestration framework for generative media pipelines with manifest-based prove
 - [README.md](README.md) — Product overview, install, quickstart
 - [ARCHITECTURE.md](ARCHITECTURE.md) — System layout, data flows, canonical files
 - [AGENTS.md](AGENTS.md) — This file; agent table of contents
+- [RELEASING.md](RELEASING.md) — Release wave naming, publish pipeline, dry-run path
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Dev setup, PR process, release notes via CHANGELOG
 - [docs/features/](docs/features/) — Feature docs (one per core feature)
 - [docs/app-workflows.md](docs/app-workflows.md) — User journeys
 - [docs/dev-workflows.md](docs/dev-workflows.md) — Engineering workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,4 +10,5 @@
 - Always run `make test` before considering work complete
 - Update docs in the same PR as code changes
 - Keep diffs minimal — only change what's needed
-- Adding a new connector: use `/scaffold-provider`. Before tagging a release: use `/release-check`. Auditing docs freshness: `/verify-docs`.
+- Adding a new connector: use `/scaffold-provider`. Before tagging a release: use `/release-check` and read [RELEASING.md](RELEASING.md). Auditing docs freshness: `/verify-docs`.
+- Release flow: tag name follows the CHANGELOG wave header (`v0.3.0`), not any single package's version. Workflow at `.github/workflows/release.yml` triggers on GitHub Release creation; `workflow_dispatch` runs a TestPyPI dry-run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,21 @@ update the matching schema in `libs/spec/schemas/manifest/v1/` and run
 3. Docs updated in the same PR as code changes
 4. PR description summarizes what and why
 5. Reference the execution plan if one exists
+6. If your change should ship in a release, add a bullet to the
+   `[Unreleased]` section of [CHANGELOG.md](CHANGELOG.md) under the
+   appropriate package heading. The release workflow's `changelog-gate`
+   fails any release where `[Unreleased]` still contains entries — so
+   you _will_ remember to write release notes.
+
+## Releases
+
+Maintainer-facing. If you're cutting a release, read
+[RELEASING.md](RELEASING.md) — it documents the wave-naming convention,
+the gates that must pass before any package is built, the order in
+which packages publish (core → cli/connectors → meta umbrella), the
+TestPyPI dry-run path, and how to recover from a partially-failed
+release. The release-smoke gate (`make release-smoke`) is the same
+script the CI workflow runs; run it locally before tagging.
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ examples/               # Usage examples
 - [ARCHITECTURE.md](ARCHITECTURE.md) — System layout, data flows, canonical files
 - [docs/features/model-registry.md](docs/features/model-registry.md) — Register models, override pricing, customize parameters
 - [docs/features/](docs/features/) — Feature docs (pipeline, providers, media, policy, sinks, observability, agents)
+- [RELEASING.md](RELEASING.md) — How releases are cut: wave naming, gates, the automated publish pipeline
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,230 @@
+# Releasing Genblaze
+
+How releases are cut and how the automated publish pipeline works.
+
+## Versioning policy
+
+Genblaze ships ~15 PyPI packages and one npm package from this monorepo.
+Each package's `pyproject.toml` carries its own version number, and they
+do **not** all move in lockstep — e.g. the 0.3.0 wave bumped `genblaze-core`
+and every connector to `0.3.0`, but left `genblaze-s3` and `genblaze-cli`
+unchanged because their code hadn't shifted. In the same wave the umbrella
+`genblaze` package moved from `0.3.2` → `0.4.0` (it had its own version
+history that ran ahead of core), so the wave is called "0.3.0" but the
+umbrella package version is `0.4.0`. That's expected, not a bug.
+
+We call each release a **wave**. The canonical name of the wave is the
+most recent versioned heading in `CHANGELOG.md`. The GitHub Release tag
+follows the wave name — _not_ any individual package's version — because:
+
+* No single package is bumped on every wave (a connectors-only wave
+  wouldn't touch `core`; a core-only wave wouldn't touch every connector).
+* The CHANGELOG is the only file that always exists for every wave and
+  always reflects the maintainer's stated release name.
+* Per-package PyPI versions are still whatever each `pyproject.toml`
+  says — the workflow publishes them as-is.
+
+Convention:
+
+| Surface                          | Source of truth                                    |
+| -------------------------------- | -------------------------------------------------- |
+| GitHub Release tag               | `v` + latest `## [X.Y.Z] - …` heading in `CHANGELOG.md` |
+| Per-package PyPI versions        | Each package's own `pyproject.toml`                |
+| `@genblaze/spec` version (npm)   | `libs/spec/package.json`                           |
+| What changed                     | `CHANGELOG.md` (Keep a Changelog format)           |
+
+The release workflow validates `tag == "v" + latest CHANGELOG wave name`
+before doing anything else. A mismatch fails the run.
+
+## Pre-release checklist
+
+Before cutting a release, verify on `main`:
+
+1. **Versions are bumped.** Every package whose code changed since the
+   last release has its `pyproject.toml` `version` updated. The umbrella
+   `libs/meta/pyproject.toml` is bumped to reflect this release.
+2. **CHANGELOG is cut.** The `[Unreleased]` section is empty; a new
+   `## [X.Y.Z] - YYYY-MM-DD` section lists every package version change
+   under "Released package versions".
+3. **TS types are current.** `make ts-types` produces no diff. (CI's
+   `ts-types-check` job already enforces this on every push, but the
+   release workflow re-runs it as a defense in depth.)
+4. **CI is green** on the commit you're about to release.
+
+## The publish pipeline
+
+Defined in [`.github/workflows/release.yml`](.github/workflows/release.yml).
+Triggered two ways:
+
+### 1. Production release (`release: published`)
+
+1. Manually create an annotated Git tag matching the latest CHANGELOG
+   wave name:
+   ```bash
+   # If CHANGELOG's most recent versioned heading is `## [0.3.0] - …`:
+   git tag -a v0.3.0 -m "Release 0.3.0"
+   git push origin v0.3.0
+   ```
+2. Create a GitHub Release on that tag. Paste the CHANGELOG slice for
+   this version as the body.
+3. Publishing the Release fires the `Release` workflow.
+
+The workflow then runs:
+
+```
+validate-version ─┐                              ┌──> publish-cli
+                  ├──> publish-core ─────────────┤
+changelog-gate ───┤                              └──> publish-connectors (matrix×13) ──> publish-meta ─┐
+                  │                                                                                    ├──> install-verify
+release-smoke ────┘                                                                                    │
+                                                                                                       │
+publish-npm ───────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Notes on the graph:
+
+* `validate-version`, `changelog-gate`, and `release-smoke` are the
+  three pre-publish gates. All must pass before any package is built.
+* `publish-cli` runs in parallel with the connector matrix but is NOT
+  on the path to `install-verify`. A `publish-cli` failure marks the
+  overall run red but doesn't cancel verify — verify is a smoke test
+  for the umbrella import, not a full release-wide check.
+* `publish-npm` runs in parallel with the entire PyPI graph (no PyPI
+  dep), but `install-verify` waits for both `publish-meta` and
+  `publish-npm` before declaring the wave released.
+
+* **`validate-version`** — reads the canonical wave name from the
+  most recent versioned heading in `CHANGELOG.md`, enforces `tag ==
+  "v$wave"` on `release` trigger, and emits the wave name +
+  per-package versions + `dry_run` flag to every downstream job.
+* **`changelog-gate`** — fails if `[Unreleased]` still has entries.
+* **`release-smoke`** — runs `make release-smoke`: builds every wheel,
+  installs `genblaze[all]` from a local wheelhouse with `--no-index`,
+  imports every connector. Catches version-pin mismatches before PyPI
+  sees them.
+* **`publish-core`** — must publish first; everything else pins it.
+* **`publish-cli` + `publish-connectors`** — fan out in parallel. The
+  connectors matrix uses `fail-fast: false` so one transient PyPI hiccup
+  doesn't strand the others.
+* **`publish-meta`** — last, because the umbrella's
+  `[project.optional-dependencies]` block references connector packages
+  by version constraint, and pip needs those targets to already be on
+  PyPI to resolve `pip install "genblaze[all]"`.
+* **`publish-npm`** — independent of the PyPI graph. Publishes
+  `@genblaze/spec` with sigstore provenance.
+* **`install-verify`** — installs `genblaze==$version` from public PyPI
+  in a fresh venv and imports the core packages. Skipped on dry-runs
+  (TestPyPI indexing lag makes this flaky).
+
+### 2. Dry run (`workflow_dispatch`)
+
+Use this to exercise the full pipeline without touching production
+registries. From the GitHub Actions tab → Release workflow → "Run
+workflow":
+
+* **`dry_run`** — defaults to `true`. PyPI publishes route to TestPyPI;
+  npm publish runs with `--dry-run`. No production registry changes.
+* **`ref`** — optional. Defaults to the branch you dispatched from.
+
+Dry runs are the recommended way to:
+
+* Test the workflow after editing `release.yml`.
+* Verify Trusted Publishing is configured correctly on a brand-new
+  package before its first real publish.
+* Sanity-check a release candidate without using up a version number on
+  prod PyPI (you can't re-publish the same version; a botched 0.4.0
+  burns the slot forever).
+
+## One-time setup
+
+Before this workflow can run successfully, three external setups must
+exist:
+
+### a. PyPI Trusted Publishing (per package)
+
+For each of the ~15 Python packages, on its PyPI project page, add a
+**Trusted Publisher** entry with:
+
+* Repository owner: `backblaze-labs`
+* Repository name: `genblaze`
+* Workflow filename: `release.yml`
+* Environment name: `pypi`
+
+No `PYPI_API_TOKEN` is needed once Trusted Publishing is configured —
+the workflow uses OIDC and the action obtains a short-lived token at
+publish time.
+
+### b. TestPyPI Trusted Publishing (per package, for dry-runs)
+
+Same setup as above, but on **test.pypi.org** instead of pypi.org, with
+environment name `testpypi`. This is what the dry-run path uses.
+
+If you skip this, dry-runs will fail at the publish step (after building
+and gating, which still gives you ~90% of the value).
+
+### c. npm publish auth
+
+Add an **`NPM_TOKEN`** repository secret containing a publish-scoped
+token for `@genblaze/spec`.
+
+Token type: **Automation token** with `publish` scope on the `@genblaze`
+org. Generate it from <https://www.npmjs.com/settings/genblaze/tokens>
+→ "Generate New Token" → "Automation".
+
+If/when npm Trusted Publishing supports scoped public packages on your
+org by default, replace the `NODE_AUTH_TOKEN` env var in `publish-npm`
+with the OIDC-based flow (same pattern as PyPI Trusted Publishing) and
+delete the `NPM_TOKEN` secret.
+
+### d. GitHub Environments
+
+Create four environments under repo Settings → Environments:
+
+* **`pypi`** — production PyPI. No required reviewers.
+* **`testpypi`** — TestPyPI for dry-runs. No required reviewers.
+* **`npm`** — production npm. No required reviewers.
+* **`npm-dryrun`** — npm dry-run. No required reviewers.
+
+Required reviewers can be added later if you want a human gate on
+production releases (recommended once the project graduates from alpha).
+
+## Operational notes
+
+* **Re-running a partial release is safe.** Both PyPI (`skip-existing:
+  true` on the publish action) and the npm job (pre-check via `npm view`)
+  treat "this version is already published" as a no-op success. So if
+  half the connectors land and then a network blip kills the run,
+  re-trigger the same Release event — published packages are skipped,
+  unpublished ones go out.
+* **Bumping a version because you _need_ a new artifact.** PyPI does
+  not allow republishing the same version number even with `--force`;
+  if a wheel was built with bad metadata and you need to fix it, you
+  must bump the patch version (`0.3.0` → `0.3.1`) and re-tag.
+* **Connector failures are recoverable.** Because the connector matrix
+  uses `fail-fast: false`, a single failed connector leaves the others
+  published. To recover, fix the issue, bump that connector's patch
+  version, and trigger a new release — already-published packages are
+  silently skipped.
+* **The umbrella is the long pole.** If `publish-meta` fails, users
+  cannot `pip install genblaze` — but they can still install individual
+  packages. Treat a meta failure as a P0.
+* **install-verify is best-effort.** PyPI's CDN sometimes lags; the job
+  retries for 2 minutes before failing. A red `install-verify` after a
+  green publish graph usually means the package is fine and the index
+  is just behind — verify manually with `pip install genblaze==X.Y.Z`
+  in a fresh venv before assuming a regression.
+
+## Releasing manually (fallback only)
+
+If the workflow is broken and a release must ship, the legacy manual
+path still works:
+
+```bash
+make release-smoke                    # build + install + import all
+cd libs/core && python -m build && twine upload dist/*
+# repeat for cli, every connector, then libs/meta last
+cd libs/spec && npm publish --access public --provenance
+```
+
+This bypasses the changelog gate, version-tag validation, and
+install-verify. Use only when the automated path is unavailable.


### PR DESCRIPTION
## Summary

Harden the release workflow and document the publish process. The existing `release.yml` was well-designed but had never been exercised, lacked a dry-run path, npm publishing, idempotency, tag/version validation, and post-publish verification. This PR closes those gaps so the next release (and every release after it) can ship through CI safely.

## Changes

- **`.github/workflows/release.yml`** — rewritten:
  - `workflow_dispatch` entry point with a `dry_run` toggle (defaults to true) → routes to TestPyPI + `npm --dry-run`.
  - `validate-version` gate resolves the wave name from the latest `## [X.Y.Z]` heading in `CHANGELOG.md` and enforces `tag == "v$wave"` on `release` trigger.
  - `publish-npm` job for `@genblaze/spec` with sigstore provenance and an idempotent `npm view` pre-check.
  - `install-verify` job does a real `pip install genblaze==X.Y.Z` from public PyPI after the publish graph completes.
  - `skip-existing: true` on every PyPI publish — partial releases are now recoverable by re-triggering.
  - Per-job least-privilege permissions (`id-token: write` only on the 5 publish jobs; workflow default is `contents: read`).
  - Script-injection hardening: `github.event.release.tag_name` and dispatch inputs flow through `env:` vars instead of being templated into shell.
  - Per-job timeouts, concurrency control without `cancel-in-progress`.
- **`RELEASING.md`** — new. Documents the wave-based versioning policy, the publish-pipeline graph and gates, the one-time setup (4 GitHub Environments, PyPI/TestPyPI Trusted Publishing config, `NPM_TOKEN`), operational notes for partial-release recovery, and the manual fallback path.
- **`README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`** — link to `RELEASING.md` from each canonical entry point; CONTRIBUTING also picks up a CHANGELOG-discipline bullet in the PR process.

## Test plan

- [x] `make release-smoke` passes locally — every wheel builds, `twine check` clean on all 16 packages
- [x] `python -m yamllint` clean on `.github/workflows/release.yml`
- [x] `make test` passes
- [x] `make lint` passes
- [x] Docs updated (RELEASING.md added; README/CONTRIBUTING/AGENTS/CLAUDE wired)
- [ ] After merge: dispatch the workflow with `dry_run: true` and confirm every job is green end-to-end (validates Trusted Publishing config on both PyPI and TestPyPI)
- [ ] After dry-run is green: cut `v0.3.0` GitHub Release; confirm `install-verify` succeeds and `pip install genblaze==0.4.0` works in a fresh venv

## Related

Pre-requisite for the 0.3.0 release wave (CHANGELOG cut on 2026-05-11; all 14 package versions bumped in HEAD but no `twine upload` ever ran). Closes the gap noted in the post-rollout review re: "automated path exists on paper but has never been exercised."
