### PR TITLE
docs(builders): add class and method docstrings to StepBuilder and RunBuilder

### DIFF
--- a/libs/core/genblaze_core/builders/run_builder.py
+++ b/libs/core/genblaze_core/builders/run_builder.py
@@ -48,7 +48,10 @@ class RunBuilder:
         return self
 
     def add_step(self, step: Step) -> RunBuilder:
-        """Append a ``Step`` to this run. The step's ``run_id`` and ``step_index`` are set by ``.build()``."""
+        """Append a ``Step`` to this run.
+
+        The step's ``run_id`` and ``step_index`` are set by ``.build()``.
+        """
         self._steps.append(step)
         return self
 

--- a/libs/core/genblaze_core/builders/run_builder.py
+++ b/libs/core/genblaze_core/builders/run_builder.py
@@ -8,6 +8,14 @@ from genblaze_core.models.step import Step
 
 
 class RunBuilder:
+    """Fluent builder for Run models.
+
+    Use ``RunBuilder(name)`` to start a chain (name is optional), then call
+    methods (all returning ``self`` for chaining). Add steps via
+    ``add_step()`` (which accepts a ``Step`` built by ``StepBuilder``), then
+    call ``.build()`` to produce a ``Run`` instance.
+    """
+
     def __init__(self, name: str | None = None):
         self._data: dict = {}
         if name:
@@ -20,10 +28,12 @@ class RunBuilder:
         return self
 
     def tenant(self, tenant_id: str) -> RunBuilder:
+        """Set the tenant identifier for multi-tenancy."""
         self._data["tenant_id"] = tenant_id
         return self
 
     def project(self, project_id: str) -> RunBuilder:
+        """Set the project identifier."""
         self._data["project_id"] = project_id
         return self
 
@@ -33,18 +43,22 @@ class RunBuilder:
         return self
 
     def status(self, s: RunStatus) -> RunBuilder:
+        """Set the initial run status."""
         self._data["status"] = s
         return self
 
     def add_step(self, step: Step) -> RunBuilder:
+        """Append a ``Step`` to this run. The step's ``run_id`` and ``step_index`` are set by ``.build()``."""
         self._steps.append(step)
         return self
 
     def meta(self, **kwargs) -> RunBuilder:
+        """Add arbitrary metadata as key-value pairs."""
         self._data.setdefault("metadata", {}).update(kwargs)
         return self
 
     def build(self) -> Run:
+        """Build and return a ``Run`` instance with steps wired up."""
         run = Run(**self._data)
         # Copy steps to avoid mutating caller-owned objects (safe for double-build)
         steps = [s.model_copy() for s in self._steps]

--- a/libs/core/genblaze_core/builders/step_builder.py
+++ b/libs/core/genblaze_core/builders/step_builder.py
@@ -59,7 +59,10 @@ class StepBuilder:
         return self
 
     def input_asset(self, url: str, media_type: str, **kwargs) -> StepBuilder:
-        """Add an input asset URL and MIME type. Accepts keyword arguments forwarded to ``Asset``."""
+        """Add an input asset URL and MIME type.
+
+        Extra keyword arguments are forwarded to ``Asset``.
+        """
         self._data.setdefault("inputs", []).append(Asset(url=url, media_type=media_type, **kwargs))
         return self
 
@@ -74,7 +77,10 @@ class StepBuilder:
         return self
 
     def asset(self, url: str, media_type: str, **kwargs) -> StepBuilder:
-        """Add an output asset URL and MIME type. Accepts keyword arguments forwarded to ``Asset``."""
+        """Add an output asset URL and MIME type.
+
+        Extra keyword arguments are forwarded to ``Asset``.
+        """
         self._data.setdefault("assets", []).append(Asset(url=url, media_type=media_type, **kwargs))
         return self
 

--- a/libs/core/genblaze_core/builders/step_builder.py
+++ b/libs/core/genblaze_core/builders/step_builder.py
@@ -8,60 +8,81 @@ from genblaze_core.models.step import Step
 
 
 class StepBuilder:
+    """Fluent builder for Step models.
+
+    Use ``StepBuilder(provider, model)`` to start a chain, then call methods
+    (all returning ``self`` for chaining). Call ``.build()`` to produce a
+    ``Step`` instance.
+    """
+
     def __init__(self, provider: str, model: str):
         self._data: dict = {"provider": provider, "model": model}
 
     def prompt(self, text: str) -> StepBuilder:
+        """Set the generation prompt text."""
         self._data["prompt"] = text
         return self
 
     def negative_prompt(self, text: str) -> StepBuilder:
+        """Set a negative prompt to steer the model away from certain concepts."""
         self._data["negative_prompt"] = text
         return self
 
     def modality(self, m: Modality) -> StepBuilder:
+        """Set the output modality (e.g. ``Modality.IMAGE``)."""
         self._data["modality"] = m
         return self
 
     def visibility(self, v: PromptVisibility) -> StepBuilder:
+        """Set the prompt redaction level."""
         self._data["prompt_visibility"] = v
         return self
 
     def step_type(self, t: StepType) -> StepBuilder:
+        """Set the step type (e.g. ``StepType.GENERATE``)."""
         self._data["step_type"] = t
         return self
 
     def seed(self, s: int) -> StepBuilder:
+        """Set a random seed for reproducibility."""
         self._data["seed"] = s
         return self
 
     def model_version(self, v: str) -> StepBuilder:
+        """Set a specific model version hash."""
         self._data["model_version"] = v
         return self
 
     def model_hash(self, h: str) -> StepBuilder:
+        """Set a model weights hash for integrity verification."""
         self._data["model_hash"] = h
         return self
 
     def input_asset(self, url: str, media_type: str, **kwargs) -> StepBuilder:
+        """Add an input asset URL and MIME type. Accepts keyword arguments forwarded to ``Asset``."""
         self._data.setdefault("inputs", []).append(Asset(url=url, media_type=media_type, **kwargs))
         return self
 
     def params(self, **kwargs) -> StepBuilder:
+        """Add provider-specific parameters as key-value pairs."""
         self._data.setdefault("params", {}).update(kwargs)
         return self
 
     def status(self, s: StepStatus) -> StepBuilder:
+        """Set the initial step status."""
         self._data["status"] = s
         return self
 
     def asset(self, url: str, media_type: str, **kwargs) -> StepBuilder:
+        """Add an output asset URL and MIME type. Accepts keyword arguments forwarded to ``Asset``."""
         self._data.setdefault("assets", []).append(Asset(url=url, media_type=media_type, **kwargs))
         return self
 
     def meta(self, **kwargs) -> StepBuilder:
+        """Add arbitrary metadata as key-value pairs."""
         self._data.setdefault("metadata", {}).update(kwargs)
         return self
 
     def build(self) -> Step:
+        """Build and return a ``Step`` instance from the accumulated data."""
         return Step(**self._data)


### PR DESCRIPTION
## Summary

Add docstrings to the public `StepBuilder` and `RunBuilder` fluent APIs (the discoverable top-level entry points for the library).

## Changes

- **StepBuilder** (15 methods): class docstring + single-line docstring on every method
- **RunBuilder** (7 methods): class docstring + single-line docstring on each previously undocumented method (`tenant`, `project`, `status`, `add_step`, `meta`, `build`); `run_id` and `parent` docstrings preserved verbatim

## Fixes

Fixes [backblaze-labs/genblaze#11](https://github.com/backblaze-labs/genblaze/issues/11)