### PR TITLE
fix(core): partition step cache key by tenant_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`,
+  so a cache shared across tenants no longer serves one tenant's cached output
+  asset to another for an otherwise-identical step (#68).
+
 ## [0.3.3] - 2026-05-26
 
 Release-pipeline hardening + refresh of two PyPI wheels with stale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one
   tenant's cached output asset to another for an otherwise-identical step.
-  Single-tenant keys are unchanged, and `RunnableConfig` no longer advertises a
-  `tenant_id` key that was never honored (#68).
+  Single-tenant keys are unchanged. A `tenant_id` in `RunnableConfig` is now
+  rejected at runtime (it was never honored), so a dynamic caller passing it via
+  `config()` / `invoke(config=...)` fails loudly instead of silently bypassing
+  cache isolation (#68).
 
 ## [0.3.3] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`,
-  so a cache shared across tenants no longer serves one tenant's cached output
-  asset to another for an otherwise-identical step (#68).
+- `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
+  when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
+  `StepCache.get`/`put`), so a cache shared across tenants no longer serves one
+  tenant's cached output asset to another for an otherwise-identical step.
+  Single-tenant keys are unchanged, and `RunnableConfig` no longer advertises a
+  `tenant_id` key that was never honored (#68).
 
 ## [0.3.3] - 2026-05-26
 

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -16,7 +16,7 @@ Fluent API for building and executing multi-step generative media workflows with
 - `Pipeline.batch_run(prompts, max_concurrency=5, sink=None, pipeline_timeout=None, on_step_complete=None)` — Execute pipeline independently for each prompt (sync)
 - `Pipeline.abatch_run(prompts, max_concurrency=5, sink=None, pipeline_timeout=None, on_step_complete=None)` — Execute pipeline for each prompt with async concurrency control
 - `PipelineResult.save()` — Save output with optional manifest embedding
-- `StepCache` — File-based cache keyed by deterministic hash of step inputs
+- `StepCache` — File-based cache keyed by deterministic hash of step inputs, partitioned by `tenant_id` so a shared cache stays isolated across tenants
 - `StepCompleteEvent` — Dataclass fired via `on_step_complete` after each step finishes
 
 ## Canonical Files

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -16,7 +16,7 @@ Fluent API for building and executing multi-step generative media workflows with
 - `Pipeline.batch_run(prompts, max_concurrency=5, sink=None, pipeline_timeout=None, on_step_complete=None)` — Execute pipeline independently for each prompt (sync)
 - `Pipeline.abatch_run(prompts, max_concurrency=5, sink=None, pipeline_timeout=None, on_step_complete=None)` — Execute pipeline for each prompt with async concurrency control
 - `PipelineResult.save()` — Save output with optional manifest embedding
-- `StepCache` — File-based cache keyed by deterministic hash of step inputs, partitioned by `tenant_id` so a shared cache stays isolated across tenants
+- `StepCache` — File-based cache keyed by deterministic hash of step inputs; partitioned by `tenant_id` only when a tenant is set (via `Pipeline(tenant_id=...)`, or passed directly to `StepCache.get`/`put`), so a shared cache stays isolated across tenants. Single-tenant keys are unchanged.
 - `StepCompleteEvent` — Dataclass fired via `on_step_complete` after each step finishes
 
 ## Canonical Files

--- a/libs/core/genblaze_core/_utils.py
+++ b/libs/core/genblaze_core/_utils.py
@@ -33,6 +33,18 @@ def compute_sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def normalize_tenant_id(tenant_id: str | None) -> str | None:
+    """Normalize a tenant identifier: strip surrounding whitespace, "" -> None.
+
+    Tenancy must read identically wherever it is used (cache key, Run metadata,
+    sinks), so empty / whitespace-only values collapse to ``None`` in one place
+    rather than being special-cased at each call site.
+    """
+    if tenant_id is None:
+        return None
+    return tenant_id.strip() or None
+
+
 def _run_async(coro: Coroutine) -> Any:
     """Run an async coroutine from sync code safely.
 

--- a/libs/core/genblaze_core/pipeline/cache.py
+++ b/libs/core/genblaze_core/pipeline/cache.py
@@ -25,10 +25,11 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
 
     ``tenant_id`` partitions the key so a shared cache never serves one
     tenant's output to another. It lives on ``Run``, not ``Step``, so callers
-    must pass it explicitly; it defaults to ``None`` for single-tenant use.
+    must pass it explicitly. It is folded into the key only when set; when it is
+    ``None`` (single-tenant), the key matches the pre-tenant behavior, so existing
+    on-disk cache entries stay valid.
     """
     key_data = {
-        "tenant_id": tenant_id,
         "provider": step.provider,
         "model": step.model,
         "model_version": step.model_version,
@@ -43,6 +44,10 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
         # Use content hash or URL for cache correctness — asset_id is random per execution
         "input_ids": sorted(a.sha256 or a.url for a in step.inputs) if step.inputs else None,
     }
+    # Only fold tenant_id in when set, so single-tenant keys are byte-identical
+    # to the pre-tenant behavior and existing cache entries remain valid.
+    if tenant_id is not None:
+        key_data["tenant_id"] = tenant_id
     return canonical_hash(key_data)
 
 

--- a/libs/core/genblaze_core/pipeline/cache.py
+++ b/libs/core/genblaze_core/pipeline/cache.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 from pathlib import Path
 
+from genblaze_core._utils import normalize_tenant_id
 from genblaze_core.canonical.json import canonical_hash
 from genblaze_core.models.step import Step
 
@@ -25,10 +26,11 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
 
     ``tenant_id`` partitions the key so a shared cache never serves one
     tenant's output to another. It lives on ``Run``, not ``Step``, so callers
-    must pass it explicitly. It is folded into the key only when set; when it is
-    ``None`` (single-tenant), the key matches the pre-tenant behavior, so existing
-    on-disk cache entries stay valid.
+    must pass it explicitly. It is normalized (whitespace stripped, empty -> None)
+    and folded into the key only when present; an unset tenant yields the
+    pre-tenant key, so existing single-tenant cache entries stay valid.
     """
+    tenant_id = normalize_tenant_id(tenant_id)
     key_data = {
         "provider": step.provider,
         "model": step.model,
@@ -44,9 +46,7 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
         # Use content hash or URL for cache correctness — asset_id is random per execution
         "input_ids": sorted(a.sha256 or a.url for a in step.inputs) if step.inputs else None,
     }
-    # Fold tenant_id in only when set (non-empty); None and "" hash identically, so
-    # single-tenant keys match the pre-tenant behavior and stay backward-compatible.
-    if tenant_id:
+    if tenant_id is not None:
         key_data["tenant_id"] = tenant_id
     return canonical_hash(key_data)
 

--- a/libs/core/genblaze_core/pipeline/cache.py
+++ b/libs/core/genblaze_core/pipeline/cache.py
@@ -44,9 +44,9 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
         # Use content hash or URL for cache correctness — asset_id is random per execution
         "input_ids": sorted(a.sha256 or a.url for a in step.inputs) if step.inputs else None,
     }
-    # Only fold tenant_id in when set, so single-tenant keys are byte-identical
-    # to the pre-tenant behavior and existing cache entries remain valid.
-    if tenant_id is not None:
+    # Fold tenant_id in only when set (non-empty); None and "" hash identically, so
+    # single-tenant keys match the pre-tenant behavior and stay backward-compatible.
+    if tenant_id:
         key_data["tenant_id"] = tenant_id
     return canonical_hash(key_data)
 

--- a/libs/core/genblaze_core/pipeline/cache.py
+++ b/libs/core/genblaze_core/pipeline/cache.py
@@ -15,15 +15,20 @@ from genblaze_core.models.step import Step
 logger = logging.getLogger("genblaze.cache")
 
 
-def step_cache_key(step: Step) -> str:
+def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
     """Compute deterministic cache key from step inputs.
 
     Key is derived from every Step field whose change would legitimately
     yield a different output: provider, model, model_version, model_hash,
     prompt, negative_prompt, prompt_visibility (affects redaction on reuse),
     params, seed, modality, step_type, and input asset content IDs.
+
+    ``tenant_id`` partitions the key so a shared cache never serves one
+    tenant's output to another. It lives on ``Run``, not ``Step``, so callers
+    must pass it explicitly; it defaults to ``None`` for single-tenant use.
     """
     key_data = {
+        "tenant_id": tenant_id,
         "provider": step.provider,
         "model": step.model,
         "model_version": step.model_version,
@@ -67,9 +72,9 @@ class StepCache:
     def _path(self, key: str) -> Path:
         return self._dir / f"{key}.json"
 
-    def get(self, step: Step) -> Step | None:
+    def get(self, step: Step, tenant_id: str | None = None) -> Step | None:
         """Return cached step result, or None if not cached (race-free)."""
-        key = step_cache_key(step)
+        key = step_cache_key(step, tenant_id)
         path = self._path(key)
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -81,9 +86,9 @@ class StepCache:
             logger.warning("Cache entry corrupt or unreadable (treating as miss): %s", exc)
             return None
 
-    def put(self, step: Step, result: Step) -> None:
+    def put(self, step: Step, result: Step, tenant_id: str | None = None) -> None:
         """Cache a completed step result (atomic write, thread-safe)."""
-        key = step_cache_key(step)
+        key = step_cache_key(step, tenant_id)
         path = self._path(key)
         data = result.model_dump_json().encode("utf-8")
         fd, tmp = tempfile.mkstemp(dir=self._dir, suffix=".tmp")

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -236,7 +236,8 @@ class Pipeline(Runnable[None, PipelineResult]):
         preflight: bool = True,
     ):
         self._name = name
-        self._tenant_id = tenant_id
+        # Normalize ""/whitespace -> None so cache keys and Run metadata agree.
+        self._tenant_id = (tenant_id.strip() or None) if tenant_id else None
         self._project_id = project_id
         self._parent_run_id: str | None = None
         self._steps: list[_PipelineStep] = []
@@ -1349,8 +1350,6 @@ class Pipeline(Runnable[None, PipelineResult]):
             msg = "Pipeline has no steps. Add steps with .step() before calling .run()."
             raise GenblazeError(msg)
 
-        self._validate_steps()
-
         # Resolve config: explicit override > inline kwargs > pipeline-level config
         config: RunnableConfig | None
         if _config_override is not None:
@@ -1362,7 +1361,11 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
+        # Reject an invalid config-level tenant before model preflight (which may
+        # do network work), so a bad invoke(config={"tenant_id": ...}) fails fast.
         self._reject_config_tenant(config)
+
+        self._validate_steps()
 
         run_id = new_id()
         spinner: Spinner | None = None
@@ -1535,8 +1538,6 @@ class Pipeline(Runnable[None, PipelineResult]):
                 f"max_concurrency must be None (unlimited) or >= 1, got {max_concurrency}"
             )
 
-        self._validate_steps()
-
         # Resolve config: explicit override > inline kwargs > pipeline-level config
         config: RunnableConfig | None
         if _config_override is not None:
@@ -1548,7 +1549,11 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
+        # Reject an invalid config-level tenant before model preflight (which may
+        # do network work), so a bad ainvoke(config={"tenant_id": ...}) fails fast.
         self._reject_config_tenant(config)
+
+        self._validate_steps()
 
         run_id = new_id()
         # input_from requires sequential execution (needs prior step results)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -271,7 +271,24 @@ class Pipeline(Runnable[None, PipelineResult]):
             self._tracer = NoOpTracer()
         self._event_emitter: QueueEmitter | None = None
 
+    @staticmethod
+    def _reject_config_tenant(cfg: RunnableConfig | None) -> None:
+        """Reject a per-call ``tenant_id`` in ``RunnableConfig``.
+
+        ``RunnableConfig`` is a ``TypedDict`` and does not validate keys at
+        runtime, so a config-level ``tenant_id`` would slip through as a plain
+        dict key. It is never applied to the cache key or the Run, so accepting
+        it silently would leak one tenant's cached output to another. Fail loudly
+        and point at the supported path.
+        """
+        if cfg is not None and "tenant_id" in cfg:
+            raise ValueError(
+                "RunnableConfig does not support 'tenant_id'. Set the tenant on "
+                "the pipeline instead: Pipeline(..., tenant_id=...) (see #68)."
+            )
+
     def config(self, cfg: RunnableConfig) -> Pipeline:
+        self._reject_config_tenant(cfg)
         self._config = cfg
         return self
 
@@ -1345,6 +1362,7 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
+        self._reject_config_tenant(config)
 
         run_id = new_id()
         spinner: Spinner | None = None
@@ -1530,6 +1548,7 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
+        self._reject_config_tenant(config)
 
         run_id = new_id()
         # input_from requires sequential execution (needs prior step results)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -782,7 +782,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                 return self._apply_moderation_failure(result, mod_result, "post")
 
         if self._cache is not None and result.status == StepStatus.SUCCEEDED:
-            self._cache.put(cache_key_step, result)
+            self._cache.put(cache_key_step, result, tenant_id=self._tenant_id)
 
         return result
 
@@ -806,7 +806,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                 return self._apply_moderation_failure(step, mod_result, "pre")
 
         if self._cache is not None:
-            cached = self._cache.get(step)
+            cached = self._cache.get(step, tenant_id=self._tenant_id)
             if cached is not None:
                 return cached
 
@@ -864,7 +864,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                 return self._apply_moderation_failure(step, mod_result, "pre")
 
         if self._cache is not None:
-            cached = self._cache.get(step)
+            cached = self._cache.get(step, tenant_id=self._tenant_id)
             if cached is not None:
                 return cached
 

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal
 
-from genblaze_core._utils import _SECRET_PATTERNS, new_id, utc_now
+from genblaze_core._utils import _SECRET_PATTERNS, new_id, normalize_tenant_id, utc_now
 from genblaze_core.builders.run_builder import RunBuilder
 from genblaze_core.exceptions import (
     BatchPipelineError,
@@ -236,8 +236,7 @@ class Pipeline(Runnable[None, PipelineResult]):
         preflight: bool = True,
     ):
         self._name = name
-        # Normalize ""/whitespace -> None so cache keys and Run metadata agree.
-        self._tenant_id = (tenant_id.strip() or None) if tenant_id else None
+        self._tenant_id = normalize_tenant_id(tenant_id)
         self._project_id = project_id
         self._parent_run_id: str | None = None
         self._steps: list[_PipelineStep] = []

--- a/libs/core/genblaze_core/runnable/config.py
+++ b/libs/core/genblaze_core/runnable/config.py
@@ -17,7 +17,7 @@ class RunnableConfig(TypedDict, total=False):
     tags: list[str]
     metadata: dict[str, Any]
     run_id: str
-    tenant_id: str
+    # Tenancy is set via Pipeline(tenant_id=...), not per-call config (see #68).
     timeout: float
     max_retries: int
     on_progress: Callable[[ProgressEvent], None] | None

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -223,6 +223,31 @@ async def test_pipeline_cache_no_cross_tenant_hit_async(tmp_path: Path) -> None:
     assert a2.invoke_count == 0
 
 
+def test_config_rejects_tenant_id() -> None:
+    """Issue #68: a tenant_id in RunnableConfig is rejected, not silently ignored.
+
+    RunnableConfig is a TypedDict (no runtime key validation), so a dynamic caller
+    could pass tenant_id and never get isolation. Reject it loudly instead.
+    """
+    with pytest.raises(ValueError, match="tenant_id"):
+        Pipeline("c").config({"tenant_id": "tenant-a"})  # type: ignore[arg-type]
+
+
+def test_invoke_rejects_config_tenant_id() -> None:
+    """Issue #68: tenant_id via invoke(config=...) is rejected at run resolution."""
+    p = Pipeline("c").step(CountingProvider(), model="m", prompt="p")
+    with pytest.raises(ValueError, match="tenant_id"):
+        p.invoke(config={"tenant_id": "tenant-a"})  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_rejects_config_tenant_id() -> None:
+    """Issue #68: tenant_id via ainvoke(config=...) is rejected at arun resolution."""
+    p = Pipeline("c").step(CountingProvider(), model="m", prompt="p")
+    with pytest.raises(ValueError, match="tenant_id"):
+        await p.ainvoke(config={"tenant_id": "tenant-a"})  # type: ignore[arg-type]
+
+
 def test_pipeline_cache_clear(tmp_path: Path) -> None:
     """Cache.clear() should invalidate all entries."""
     cache = StepCache(tmp_path / "cache")

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -267,6 +267,17 @@ def test_empty_tenant_normalized_to_none() -> None:
     assert Pipeline("c", tenant_id="acme")._tenant_id == "acme"
 
 
+def test_normalize_tenant_id_helper() -> None:
+    """Issue #68: one shared normalizer feeds both the cache key and Run metadata."""
+    from genblaze_core._utils import normalize_tenant_id
+
+    assert normalize_tenant_id(None) is None
+    assert normalize_tenant_id("") is None
+    assert normalize_tenant_id("   ") is None
+    assert normalize_tenant_id("  acme ") == "acme"
+    assert normalize_tenant_id("acme") == "acme"
+
+
 def test_pipeline_cache_clear(tmp_path: Path) -> None:
     """Cache.clear() should invalidate all entries."""
     cache = StepCache(tmp_path / "cache")

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -166,6 +166,40 @@ def test_pipeline_cache_miss_different_new_fields(field: str, val_a: str, val_b:
     assert step_cache_key(a) != step_cache_key(b)
 
 
+def test_step_cache_key_tenant_isolation() -> None:
+    """Issue #68: tenant_id partitions the key; default stays backward-compatible.
+
+    tenant_id lives on Run, not Step, so a shared StepCache must be told the
+    tenant explicitly or it will serve one tenant's output to another.
+    """
+    from genblaze_core.models.step import Step
+    from genblaze_core.pipeline.cache import step_cache_key
+
+    s = Step(provider="p", model="m", prompt="same")
+    assert step_cache_key(s, tenant_id="tenant-a") != step_cache_key(s, tenant_id="tenant-b")
+    # Single-tenant callers that pass no tenant_id keep the prior key.
+    assert step_cache_key(s, tenant_id=None) == step_cache_key(s)
+
+
+def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:
+    """Issue #68: a shared StepCache must not serve one tenant's result to another."""
+    cache = StepCache(tmp_path / "cache")
+
+    a1 = CountingProvider()
+    Pipeline("c", tenant_id="tenant-a").cache(cache).step(a1, model="m", prompt="p").run()
+    assert a1.invoke_count == 1
+
+    # Identical step, different tenant, shared cache -> must MISS (no cross-tenant leak).
+    b1 = CountingProvider()
+    Pipeline("c", tenant_id="tenant-b").cache(cache).step(b1, model="m", prompt="p").run()
+    assert b1.invoke_count == 1
+
+    # Same tenant again -> cache hit, provider not called.
+    a2 = CountingProvider()
+    Pipeline("c", tenant_id="tenant-a").cache(cache).step(a2, model="m", prompt="p").run()
+    assert a2.invoke_count == 0
+
+
 def test_pipeline_cache_clear(tmp_path: Path) -> None:
     """Cache.clear() should invalidate all entries."""
     cache = StepCache(tmp_path / "cache")

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -182,6 +182,8 @@ def test_step_cache_key_tenant_isolation() -> None:
     # A set tenant_id changes the key, but leaving it unset preserves the legacy
     # key (tenant_id is folded in only when present), so existing caches stay valid.
     assert step_cache_key(s, tenant_id="tenant-a") != step_cache_key(s)
+    # Empty / whitespace tenant is treated as unset, matching Run-level handling.
+    assert step_cache_key(s, tenant_id="") == step_cache_key(s)
 
 
 def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:
@@ -246,6 +248,23 @@ async def test_ainvoke_rejects_config_tenant_id() -> None:
     p = Pipeline("c").step(CountingProvider(), model="m", prompt="p")
     with pytest.raises(ValueError, match="tenant_id"):
         await p.ainvoke(config={"tenant_id": "tenant-a"})  # type: ignore[arg-type]
+
+
+def test_config_tenant_rejected_before_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #68: reject a config-level tenant before (networked) model preflight."""
+    p = Pipeline("c").step(CountingProvider(), model="m", prompt="p")
+    preflight_calls: list[int] = []
+    monkeypatch.setattr(p, "_validate_steps", lambda: preflight_calls.append(1))
+    with pytest.raises(ValueError, match="tenant_id"):
+        p.invoke(config={"tenant_id": "tenant-a"})  # type: ignore[arg-type]
+    assert preflight_calls == []  # rejected before preflight ran
+
+
+def test_empty_tenant_normalized_to_none() -> None:
+    """Issue #68: empty / whitespace tenant_id normalizes to None so cache and run agree."""
+    assert Pipeline("c", tenant_id="")._tenant_id is None
+    assert Pipeline("c", tenant_id="   ")._tenant_id is None
+    assert Pipeline("c", tenant_id="acme")._tenant_id == "acme"
 
 
 def test_pipeline_cache_clear(tmp_path: Path) -> None:

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -182,8 +182,10 @@ def test_step_cache_key_tenant_isolation() -> None:
     # A set tenant_id changes the key, but leaving it unset preserves the legacy
     # key (tenant_id is folded in only when present), so existing caches stay valid.
     assert step_cache_key(s, tenant_id="tenant-a") != step_cache_key(s)
-    # Empty / whitespace tenant is treated as unset, matching Run-level handling.
+    # Empty / whitespace tenant is treated as unset, matching Run-level handling
+    # (normalize_tenant_id strips whitespace, so both "" and "   " collapse to None).
     assert step_cache_key(s, tenant_id="") == step_cache_key(s)
+    assert step_cache_key(s, tenant_id="   ") == step_cache_key(s)
 
 
 def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -179,6 +179,9 @@ def test_step_cache_key_tenant_isolation() -> None:
     assert step_cache_key(s, tenant_id="tenant-a") != step_cache_key(s, tenant_id="tenant-b")
     # Single-tenant callers that pass no tenant_id keep the prior key.
     assert step_cache_key(s, tenant_id=None) == step_cache_key(s)
+    # A set tenant_id changes the key, but leaving it unset preserves the legacy
+    # key (tenant_id is folded in only when present), so existing caches stay valid.
+    assert step_cache_key(s, tenant_id="tenant-a") != step_cache_key(s)
 
 
 def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:
@@ -197,6 +200,26 @@ def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:
     # Same tenant again -> cache hit, provider not called.
     a2 = CountingProvider()
     Pipeline("c", tenant_id="tenant-a").cache(cache).step(a2, model="m", prompt="p").run()
+    assert a2.invoke_count == 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cache_no_cross_tenant_hit_async(tmp_path: Path) -> None:
+    """Issue #68 (async path): a shared StepCache must isolate tenants under arun()."""
+    cache = StepCache(tmp_path / "cache")
+
+    a1 = CountingProvider()
+    await Pipeline("c", tenant_id="tenant-a").cache(cache).step(a1, model="m", prompt="p").arun()
+    assert a1.invoke_count == 1
+
+    # Identical step, different tenant, shared cache -> must MISS (no cross-tenant leak).
+    b1 = CountingProvider()
+    await Pipeline("c", tenant_id="tenant-b").cache(cache).step(b1, model="m", prompt="p").arun()
+    assert b1.invoke_count == 1
+
+    # Same tenant again -> cache hit, provider not called.
+    a2 = CountingProvider()
+    await Pipeline("c", tenant_id="tenant-a").cache(cache).step(a2, model="m", prompt="p").arun()
     assert a2.invoke_count == 0
 
 


### PR DESCRIPTION
## Summary

Fixes #68 (P1, security). A shared `StepCache` keyed entries off `step_cache_key(step)`, but `tenant_id` lives on `Run`, not `Step`. In a multi-tenant deployment sharing one cache, two tenants issuing an otherwise-identical step collided on the same key, so one tenant could receive another tenant's cached output asset (a durable B2 object URL plus SHA-256) and a false provenance record.

## Change

- `step_cache_key(step, tenant_id=None)` folds `tenant_id` into the hashed key, and `StepCache.get`/`put` accept and forward it.
- `Pipeline` passes `self._tenant_id` at the three cache call sites (one `put`, plus the sync and async `get`).
- `tenant_id` is folded into the key only when set, so single-tenant keys are byte-identical to the pre-#68 behavior and existing on-disk caches stay valid (addresses the Copilot review).
- Removed `tenant_id` from `RunnableConfig` and now reject it at runtime in `config()`, in `run`/`arun` config resolution, and via `invoke`/`ainvoke`. It was never applied to the cache or the Run, so a dynamic caller passing it would have silently shared the cache; it now fails loudly and points at `Pipeline(tenant_id=...)` (addresses the Codex review).

## Tests

- `test_step_cache_key_tenant_isolation`: different `tenant_id` gives a different key; `tenant_id=None` equals the prior key; a set tenant differs from no tenant.
- `test_pipeline_cache_no_cross_tenant_hit` and `test_pipeline_cache_no_cross_tenant_hit_async`: with a shared cache, tenant B misses tenant A under both `run()` and `arun()`.
- `test_config_rejects_tenant_id`, `test_invoke_rejects_config_tenant_id`, `test_ainvoke_rejects_config_tenant_id`: the config-level tenant path raises instead of leaking.

## Verification (genblaze conda env)

- Full suite green: `make test` across all 16 packages, 0 failures.
- `ruff check` clean, `ruff format --check` clean, `mypy libs/core` reports no issues.

## Docs

- `docs/features/pipeline.md` and `CHANGELOG.md` state that partitioning applies only when a tenant is set, that single-tenant keys are unchanged, and that the `RunnableConfig` tenant key is rejected.

Closes #68
