### PR TITLE
fix: declare httpx for replicate connector

### DIFF
--- a/libs/connectors/replicate/genblaze_replicate/provider.py
+++ b/libs/connectors/replicate/genblaze_replicate/provider.py
@@ -279,7 +279,7 @@ class ReplicateProvider(BaseProvider):
                     self._client = replicate.Client(timeout=timeout)
             except ImportError as exc:
                 raise ProviderError(
-                    "replicate package not installed. Run: pip install replicate"
+                    "replicate or httpx package not installed. Run: pip install replicate httpx"
                 ) from exc
         return self._client
 

--- a/libs/connectors/replicate/pyproject.toml
+++ b/libs/connectors/replicate/pyproject.toml
@@ -25,6 +25,7 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 dependencies = [
     "genblaze-core>=0.3.0,<0.4",
     "replicate>=0.25",
+    "httpx>=0.25,<1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #37.

genblaze-replicate imports httpx directly in ReplicateProvider._get_client() to construct the client timeout, but the connector package metadata only declared genblaze-core and eplicate.

This PR:
- declares httpx>=0.25,<1.0 in the replicate connector dependencies
- updates the missing dependency message so missing httpx is not reported as only a missing eplicate install