### PR TITLE
feat(connectors): add genblaze-hume Octave TTS provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           pip install -e "libs/connectors/elevenlabs[dev]"
           pip install -e "libs/connectors/stability-audio[dev]"
           pip install -e "libs/connectors/lmnt[dev]"
+          pip install -e "libs/connectors/hume[dev]"
           pip install -e "libs/connectors/gmicloud[dev]"
           pip install -e "libs/connectors/langsmith[dev]"
           pip install -e "libs/connectors/nvidia[dev]"
@@ -90,7 +91,7 @@ jobs:
       - name: Typecheck connectors
         run: |
           failed=""
-          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt gmicloud langsmith nvidia; do
+          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia; do
             echo "=== Typechecking $conn ==="
             if ! mypy libs/connectors/$conn/genblaze_*/ --ignore-missing-imports; then
               failed="$failed $conn"
@@ -193,6 +194,7 @@ jobs:
           pip install -e "libs/connectors/elevenlabs[dev]"
           pip install -e "libs/connectors/stability-audio[dev]"
           pip install -e "libs/connectors/lmnt[dev]"
+          pip install -e "libs/connectors/hume[dev]"
           pip install -e "libs/connectors/gmicloud[dev]"
           pip install -e "libs/connectors/langsmith[dev]"
           pip install -e "libs/connectors/nvidia[dev]"
@@ -203,7 +205,7 @@ jobs:
           cd libs/core && pytest tests/ -v --cov=genblaze_core --cov-report=xml --cov-report=term-missing
       - name: Run connector tests
         run: |
-          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt gmicloud langsmith nvidia; do
+          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia; do
             echo "=== Testing $conn ==="
             (cd libs/connectors/$conn && pytest -v)
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,7 @@ jobs:
           - elevenlabs
           - stability-audio
           - lmnt
+          - hume
           - gmicloud
           - langsmith
           - nvidia

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-<!-- last_verified: 2026-04-23 -->
+<!-- last_verified: 2026-06-15 -->
 # Agents
 
 ## Repo Purpose
 
-Orchestration framework for generative media pipelines with manifest-based provenance tracking. Produces 14 pip-installable packages: `genblaze-core`, 11 provider adapter packages (`genblaze-openai`, `genblaze-google`, `genblaze-runway`, `genblaze-luma`, `genblaze-decart`, `genblaze-replicate`, `genblaze-elevenlabs`, `genblaze-stability-audio`, `genblaze-lmnt`, `genblaze-gmicloud`, `genblaze-nvidia`), `genblaze-s3`, and `genblaze-cli`.
+Orchestration framework for generative media pipelines with manifest-based provenance tracking. Produces 15 pip-installable packages: `genblaze-core`, 12 provider adapter packages (`genblaze-openai`, `genblaze-google`, `genblaze-runway`, `genblaze-luma`, `genblaze-decart`, `genblaze-replicate`, `genblaze-elevenlabs`, `genblaze-stability-audio`, `genblaze-lmnt`, `genblaze-hume`, `genblaze-gmicloud`, `genblaze-nvidia`), `genblaze-s3`, and `genblaze-cli`.
 
 ## Architecture Boundaries
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-06-15 -->
 # Architecture
 
 ## Components
@@ -14,6 +14,7 @@
   - `genblaze-elevenlabs` — ElevenLabs (TTS + sound effects)
   - `genblaze-stability-audio` — Stability AI (Stable Audio music)
   - `genblaze-lmnt` — LMNT (fast TTS)
+  - `genblaze-hume` — Hume AI (Octave TTS)
   - `genblaze-gmicloud` — GMICloud (video, image, audio via request queue)
   - `genblaze-nvidia` — NVIDIA NIM / build.nvidia.com (video, image, audio, chat)
 - **genblaze-s3** (`libs/connectors/s3/`) — S3-compatible storage backend
@@ -65,6 +66,7 @@
 - **ElevenLabs API** — TTS + sound effects (`genblaze-elevenlabs`)
 - **Stability AI API** — Stable Audio music (`genblaze-stability-audio`)
 - **LMNT API** — Fast TTS (`genblaze-lmnt`)
+- **Hume AI API** — Octave TTS (`genblaze-hume`)
 - **GMICloud API** — Video, image, audio via request queue (`genblaze-gmicloud`)
 - All accessed via lazy SDK imports — no runtime dependency unless the connector is used
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `genblaze-hume`: new provider adapter for Hume AI **Octave TTS** (audio /
+  text-to-speech). Synchronous `SyncProvider` that decodes the API's base64
+  audio to a local `file://` asset; `step.model` (`octave-1` / `octave-2`)
+  maps to the Octave `version` field. Ships a pattern-keyed `octave-*` model
+  family with a permissive fallback, `DiscoverySupport.NONE`, and no hardcoded
+  pricing (register per-character rates via the recipe in
+  `docs/reference/pricing-recipes.md`). Available as `pip install genblaze-hume`
+  or the `genblaze[hume]` / `genblaze[audio]` extras.
+
 ### Fixed
 
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install:
 	pip install -e libs/connectors/elevenlabs
 	pip install -e libs/connectors/stability-audio
 	pip install -e libs/connectors/lmnt
+	pip install -e libs/connectors/hume
 	pip install -e libs/connectors/gmicloud
 	pip install -e libs/connectors/langsmith
 	pip install -e libs/connectors/nvidia
@@ -30,6 +31,7 @@ install-dev:
 	pip install -e "libs/connectors/elevenlabs[dev]"
 	pip install -e "libs/connectors/stability-audio[dev]"
 	pip install -e "libs/connectors/lmnt[dev]"
+	pip install -e "libs/connectors/hume[dev]"
 	pip install -e "libs/connectors/gmicloud[dev]"
 	pip install -e "libs/connectors/langsmith[dev]"
 	pip install -e "libs/connectors/nvidia[dev]"
@@ -48,6 +50,7 @@ test:
 	cd libs/connectors/elevenlabs && pytest -v
 	cd libs/connectors/stability-audio && pytest -v
 	cd libs/connectors/lmnt && pytest -v
+	cd libs/connectors/hume && pytest -v
 	cd libs/connectors/gmicloud && pytest -v
 	cd libs/connectors/langsmith && pytest -v
 	cd libs/connectors/nvidia && pytest -v

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-06-15 -->
 <h1 align="center" style="border-bottom: none">
     Genblaze
 </h1>
@@ -66,6 +66,7 @@ pip install genblaze-replicate       # Replicate (Flux, SDXL, etc.)
 pip install genblaze-elevenlabs      # ElevenLabs TTS + sound effects
 pip install genblaze-stability-audio # Stability AI Stable Audio (music)
 pip install genblaze-lmnt            # LMNT fast TTS
+pip install genblaze-hume            # Hume AI Octave TTS
 ```
 
 Install names use hyphens, Python imports use underscores: `pip install genblaze-<name>` → `import genblaze_<name>`.
@@ -157,6 +158,7 @@ Genblaze ships adapters for major generative AI platforms. The matrix below is t
 | **ElevenLabs** | — | — | TTS + Sound Effects | — |
 | **Stability AI** | — | — | Stable Audio (music) | — |
 | **LMNT** | — | — | TTS | — |
+| **Hume** | — | — | Octave TTS | — |
 
 ## Configure API keys
 
@@ -176,6 +178,7 @@ Every provider reads its credentials from an environment variable. You don't nee
 | ElevenLabs (TTS + SFX) | `ELEVENLABS_API_KEY` | [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys) |
 | Stability AI (music) | `STABILITY_API_KEY` | [platform.stability.ai](https://platform.stability.ai/account/keys) |
 | LMNT (fast TTS) | `LMNT_API_KEY` | [app.lmnt.com](https://app.lmnt.com/account) |
+| Hume (Octave TTS) | `HUME_API_KEY` | [platform.hume.ai](https://platform.hume.ai/) |
 
 **Example — one provider + B2 storage:**
 

--- a/docs/exec-plans/active/hume-provider.md
+++ b/docs/exec-plans/active/hume-provider.md
@@ -1,0 +1,197 @@
+# Exec Plan: Add Hume AI (Octave TTS) Provider
+
+**Status:** active
+**Author:** kmahaney@backblaze.com
+**Created:** 2026-06-15
+**Scope:** New connector package `genblaze-hume` exposing `HumeTTSProvider` (audio / text-to-speech).
+
+---
+
+## 1. Summary
+
+Add [Hume AI](https://www.hume.ai/) as a generative-media provider. The relevant
+product for genblaze is **Octave TTS** — a synchronous text-to-speech API. This
+maps to a single **audio** connector built on `SyncProvider`, modeled closely on
+the existing `genblaze-lmnt` and `genblaze-elevenlabs` connectors.
+
+EVI (Empathic Voice Interface, speech-to-speech) and Expression Measurement are
+**out of scope** — neither fits the `Pipeline`/`Step`/manifest generation model.
+
+### Hume API facts (verified against official docs, 2026-06-15)
+
+| Aspect | Value |
+|---|---|
+| Base URL | `https://api.hume.ai`, endpoint `POST /v0/tts` |
+| Auth header | `X-Hume-Api-Key` (SDK reads `HUME_API_KEY`) |
+| Python SDK | `pip install hume`; sync client `from hume import HumeClient` (async `AsyncHumeClient` also exists) |
+| Synthesize call | `client.tts.synthesize_json(...)` → non-streaming full result |
+| Request shape | `utterances=[Utterance(text=, voice=, description=, speed=, trailing_silence=)]`, top-level `format`, `num_generations`, `version` ("1"/"2"), `temperature`, `split_utterances`, `instant_mode` |
+| Voice | `VoiceRef` by id or name (provider `HUME_AI` / `CUSTOM_VOICE`); optional — omitting it generates a novel voice |
+| Format | discriminated by `type`: `{"type":"mp3"}` / `{"type":"wav"}` / `{"type":"pcm"}` |
+| Response | `generations[]` each with `audio` (**base64**), `duration` (s), `encoding.{format, sample_rate}` (default 48000 Hz), `file_size`, `generation_id`, `snippets[]` with optional word/phoneme `timestamps` |
+| Models | No per-slug catalog. Octave model selected via `version` "1" or "2" (Octave 2 = preview, multi-language, requires a voice) |
+
+**Sources:**
+- [TTS overview](https://dev.hume.ai/docs/text-to-speech-tts/overview)
+- [synthesize-json reference](https://dev.hume.ai/reference/text-to-speech-tts/synthesize-json)
+- [Python quickstart](https://dev.hume.ai/docs/text-to-speech-tts/quickstart/python)
+- [hume-python-sdk](https://github.com/HumeAI/hume-python-sdk)
+
+### Key design consequences
+
+- **Base class:** `SyncProvider` — Hume's `synthesize_json` is synchronous (use sync `HumeClient`, no `_run_async` needed). Implement `generate(step) → Step`.
+- **Base64, not URLs:** like ElevenLabs/LMNT, decode `generation.audio` and write to `output_dir` (or a tempfile) and set a `file://` URL — guide §9.
+- **No model catalog → `DiscoverySupport.NONE`:** Hume has no `/models` listing; only `version` 1/2. Family-matched `octave-*` slugs return `OK_PROVISIONAL`. Document the rationale in the class docstring (guide §11.2). This mirrors `genblaze-lmnt`.
+- **`model` slug → `version`:** genblaze `step.model` carries the slug (e.g. `octave-2`); translate to the API's `version` field inside `generate()` (`octave-2` → `"2"`, `octave-1` → `"1"`).
+
+---
+
+## 2. Closest existing reference
+
+`libs/connectors/lmnt/` — audio TTS, `SyncProvider`, `DiscoverySupport.NONE`,
+`per_input_chars` pricing, base64/bytes → `output_dir`/tempfile → `file://`.
+Borrow audio-metadata + optional word-timing handling from
+`libs/connectors/elevenlabs/genblaze_elevenlabs/provider.py`.
+
+---
+
+## 3. Files to create
+
+```
+libs/connectors/hume/
+├── genblaze_hume/
+│   ├── __init__.py          # export HumeTTSProvider + __version__
+│   ├── _version.py          # __version__ = "0.1.0"
+│   ├── py.typed             # REQUIRED — typed marker shipped in wheel
+│   ├── _errors.py           # map_hume_error(exc) -> ProviderErrorCode
+│   └── provider.py          # HumeTTSProvider(SyncProvider)
+├── tests/
+│   ├── __init__.py
+│   ├── test_hume_provider.py        # ProviderComplianceTests subclass + error mapping
+│   └── test_catalog_decoupling.py   # mirror lmnt: no hardcoded pricing, family match
+├── README.md
+└── pyproject.toml
+```
+
+> Prefer running `/scaffold-provider hume audio sync` first to generate this
+> skeleton from current conventions, then apply the Hume-specific wiring below.
+
+---
+
+## 4. Implementation steps
+
+### 4.1 `pyproject.toml`
+- `name = "genblaze-hume"`, `version = "0.1.0"`, `requires-python = ">=3.11"`, MIME/keyword classifiers matching `genblaze-elevenlabs`.
+- Dependencies: `genblaze-core>=0.3.0,<0.4` (confirm current core minor against a sibling at edit time) and `hume>=0.x` (pin to the installed major).
+- Entry point — **required for discovery**:
+  ```toml
+  [project.entry-points."genblaze.providers"]
+  hume-tts = "genblaze_hume:HumeTTSProvider"
+  ```
+- `[tool.hatch.build.targets.wheel] packages = ["genblaze_hume"]`, `[tool.pytest.ini_options] testpaths = ["tests"]`.
+
+### 4.2 `provider.py` — `HumeTTSProvider(SyncProvider)`
+- `name = "hume-tts"`, `discovery_support = DiscoverySupport.NONE` (docstring explains: no upstream catalog endpoint; only Octave `version` 1/2).
+- **Model family** (guide §11.1): single `ModelFamily(name="hume-octave", pattern=re.compile(r"^octave-"), spec_template=ModelSpec(model_id="*", modality=Modality.AUDIO), example_slugs=("octave-1","octave-2"))`. `spec_template.pricing` **must be `None`**. `create_registry()` returns `ModelRegistry(provider_families=(...,), fallback=ModelSpec(model_id="*", modality=Modality.AUDIO))`.
+- `__init__(self, api_key=None, output_dir=None, *, models=None, retry_policy=None, probe_cache_ttl=None, probe_cache_max_entries=None)` → **always** `super().__init__(models=..., retry_policy=..., probe_cache_ttl=..., probe_cache_max_entries=...)`. Store `api_key`, `output_dir`, lazy `_client`.
+- `_get_client()`: lazy import `from hume import HumeClient`; raise `ProviderError("hume package not installed. Run: pip install hume")` on `ImportError`; construct with `api_key` (falls back to `HUME_API_KEY` env).
+- `get_capabilities()`: `supported_modalities=[Modality.AUDIO]`, `supported_inputs=["text"]`, `models=self._models.known()`, `output_formats=["audio/mpeg","audio/wav","audio/pcm"]`. `accepts_chain_input=False` (text-only).
+- `normalize_params()` (idempotent, guarded with `if "x" in p and "native" not in p`):
+  - `voice_id` → keep as `voice_id` internally; map to `VoiceRef`/utterance voice in `generate()`.
+  - `output_format` → internal format key, mapped to Hume `{"type": mp3|wav|pcm}` in `generate()`.
+  - Pass through `speed`, `temperature`, `trailing_silence`, `description`, `num_generations`.
+  - No `duration` mapping (Hume has no output-duration control; do **not** invent one).
+- `generate(step, config=None)`:
+  1. `payload = self.prepare_payload(step)`.
+  2. Resolve `version` from `step.model` (`octave-2`→`"2"`, else `"1"`).
+  3. Build `Utterance(text=step.prompt, voice=<VoiceRef if voice_id>, description=payload.get("description"), speed=..., trailing_silence=...)`.
+  4. Call `client.tts.synthesize_json(utterances=[...], format={"type": fmt}, num_generations=1, version=version, ...)`.
+  5. Take `generations[0]`: `base64.b64decode(gen.audio)` → write bytes to `output_dir/{step.step_id}.{ext}` (mkdir parents) or `tempfile.mkstemp`; `file://` + `urllib.parse.quote(resolved_path)`.
+  6. `validate_asset_url(file_url)` then build `Asset(url=file_url, media_type=<mime>)`; set `asset.size_bytes = len(bytes)`, `asset.duration = gen.duration`, `asset.metadata["audio_type"] = "speech"`.
+  7. `asset.audio = AudioMetadata(channels=1, codec=<from format>, sample_rate=gen.encoding.sample_rate)`.
+  8. **(Optional)** if `payload.get("with_timestamps")`: request `include_timestamp_types=["word"]` (Octave 2) and map `snippets[].timestamps` → `WordTiming` like ElevenLabs `_parse_*_alignment`. Mark as a follow-up if it complicates the first cut.
+  9. `step.assets.append(asset)`; `self._apply_registry_pricing(step)`; `return step`.
+  10. Error envelope: `except ProviderError: raise` / `except Exception as exc: raise ProviderError(f"Hume TTS failed: {exc}", error_code=map_hume_error(exc), retry_after=retry_after_from_response(exc)) from exc`.
+- **`list_voices(self, *, model=None, language=None)`** (guide §10): Hume exposes a voice library + custom voices (`client.tts.voices.list(...)`). Return `Voice` objects, filtering by `language` (BCP-47 prefix). If wiring the live call is non-trivial, ship a small curated static catalog first (gmicloud/Riva pattern) and note the live-API upgrade as follow-up. Non-blocking for compliance.
+
+### 4.3 `_errors.py` — `map_hume_error(exc) -> ProviderErrorCode`
+Delegate to the shared `classify_api_error`, with Hume-specific checks first if the
+SDK raises typed errors carrying `status_code` (e.g. `hume.core.api_error.ApiError`):
+```python
+from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_core.providers.base import classify_api_error
+
+def map_hume_error(exc):
+    status = getattr(exc, "status_code", None)
+    if status == 429: return ProviderErrorCode.RATE_LIMIT
+    if status in (401, 403): return ProviderErrorCode.AUTH_FAILURE
+    if status in (400, 422): return ProviderErrorCode.INVALID_INPUT
+    if status in (500, 502, 503): return ProviderErrorCode.SERVER_ERROR
+    return classify_api_error(exc)
+```
+
+### 4.4 `__init__.py` / `_version.py` / `py.typed`
+- `__init__.py`: `from genblaze_hume.provider import HumeTTSProvider`; re-export `__version__`; `__all__ = ["HumeTTSProvider"]`.
+- `py.typed`: empty marker file (must be packaged).
+
+### 4.5 Tests
+- `test_hume_provider.py`: subclass `ProviderComplianceTests` (`make_provider()` returns `HumeTTSProvider(api_key="test")` with `_client` set to a fake returning a base64 generation). Covers the 15 compliance checks (lifecycle, asset URL validation, media types, audio metadata, `normalize_params` idempotency, cost soft-check). Add Hume-specific tests: `map_hume_error` status-code mapping, `model`→`version` translation, base64→file write + `file://` URL.
+- `test_catalog_decoupling.py`: mirror lmnt — assert the registry ships **no** hardcoded pricing and that `octave-*` slugs match the family.
+
+---
+
+## 5. Integration / wiring (easy to miss → CI won't run otherwise)
+
+- **`Makefile`** — add `libs/connectors/hume` to all three: `install`, `install-dev`, and `test` targets (guide §18 checklist).
+- **`libs/meta/pyproject.toml`** — add umbrella extras: `hume = ["genblaze-hume>=0.3.0,<0.4"]`, and include it in the `audio` and `all` bundles.
+- **`docs/reference/pricing-recipes.md`** — add a `## Hume` section. Octave TTS bills per character → `per_input_chars(rate, per=1000)`. Pull the **exact** USD rate and tier breakdown from Hume's pricing page at implementation time (do not guess); include the upstream pricing URL.
+
+---
+
+## 6. Documentation (same-PR requirement — AGENTS.md)
+
+- **`README.md`**:
+  - Install section: add `pip install genblaze-hume` line.
+  - Providers matrix: add a **Hume** row (Audio = Octave TTS; Video/Image/Chat = —). Respect the "Update when adding a provider" comment above the table.
+  - "Configure API keys" table: add `Hume | HUME_API_KEY | platform.hume.ai`.
+- **`ARCHITECTURE.md`**: add `genblaze-hume` to the provider-adapters list, the External Services list (Hume API — Octave TTS), and any modality notes.
+- **`AGENTS.md`**: bump package/provider counts ("14 packages"/11 providers → 15 packages/12 providers) and add `genblaze-hume` to the connector enumeration.
+- **`libs/connectors/hume/README.md`**: usage snippet (env var, `HumeTTSProvider(output_dir=...)`, `Pipeline(...).step(..., model="octave-2", modality=Modality.AUDIO)`).
+- **No spec/schema change:** no new manifest or event fields are introduced, so `libs/spec` and `make ts-types` are **not** touched. Note this explicitly in the PR so reviewers don't expect regenerated TS types.
+
+---
+
+## 7. Invariants to respect (AGENTS.md + guide)
+
+- Provider implements the required lifecycle — `SyncProvider.generate()` (no `submit/poll/fetch_output` since it's synchronous).
+- `super().__init__(...)` always called (sets up retry/preflight/registry/poll cache).
+- `validate_asset_url()` on the output `file://` URL; **no API tokens** stored in `step.provider_payload`.
+- `normalize_params` idempotent.
+- `spec_template.pricing is None`; pricing user-registered only.
+- Pydantic v2 only; Python 3.11+; UUID ids (handled by core).
+- Canonical-hash determinism untouched (no model/serialization changes).
+- `make test`, `make lint`, `make typecheck` all green from repo root before PR.
+
+---
+
+## 8. Verification gate
+
+```bash
+pip install -e "libs/connectors/hume[dev]"   # dev install
+/test-package hume                             # fast single-package run
+make lint && make typecheck
+make test                                      # full-suite gate before PR
+```
+
+Manual smoke (optional, needs `HUME_API_KEY`): one-step `Pipeline` with
+`model="octave-2"`, `modality=Modality.AUDIO`, assert asset written, manifest
+verifies.
+
+---
+
+## 9. Open questions / decisions deferred to implementation
+
+1. **Voice catalog** — live `client.tts.voices.list()` vs. curated static catalog for the first cut. Default: static catalog now, live upgrade as follow-up.
+2. **Word/phoneme timestamps** — include in v1 or defer? Default: defer (Octave-2-only, adds response-shape branching).
+3. **Exact pricing rate** — confirm from Hume's current pricing page before writing the recipe; leave `cost_usd=None` until registered (SDK ships no prices).
+4. **`hume` SDK version pin** — confirm the installed major and whether the sync `HumeClient` (not just `AsyncHumeClient`) is exported in that version.

--- a/docs/features/provider-system.md
+++ b/docs/features/provider-system.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-06-15 -->
 # Feature: Provider System
 
 ## Purpose
@@ -110,7 +110,7 @@ Connectors as of 0.3.0:
 
 - `NATIVE`: OpenAI (TTS / DALL-E / Sora), ElevenLabs TTS, Replicate, NVIDIA chat
 - `PARTIAL`: NVIDIA generative endpoints (audio / video / image), GMICloud, Google (Veo / Imagen)
-- `NONE`: Decart, Runway, Luma, Stability-Audio, ElevenLabs SFX, LMNT
+- `NONE`: Decart, Runway, Luma, Stability-Audio, ElevenLabs SFX, LMNT, Hume
 
 ## Error Deduplication
 Each connector family shares a single error mapper module:

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-04 -->
+<!-- last_verified: 2026-06-15 -->
 # Pricing recipes
 
 > **Not maintained.** Prices in this document are snapshots taken at the
@@ -78,6 +78,41 @@ fallback, so a `register_pricing("*", ...)` applies universally.
 
 ```python
 provider.models.register_pricing("*", per_input_chars(LMNT_PRICE_PER_CHAR, per=1))
+```
+
+---
+
+## Hume
+
+**Source:** user-registered (the SDK ships no prices for Hume).
+**Snapshot date:** TODO — fill in when you read the rate.
+**Verify at:** [hume.ai/pricing](https://www.hume.ai/pricing) /
+[platform.hume.ai](https://platform.hume.ai/).
+
+Hume Octave TTS bills per character of input text. The same rate applies to
+`octave-1` and `octave-2` (the model is selected via the request `version`
+field, not separate slugs). Replace `RATE` below with the current
+per-character USD rate from Hume's pricing page.
+
+```python
+from genblaze_core.providers import per_input_chars
+from genblaze_hume import HumeTTSProvider
+
+provider = HumeTTSProvider(api_key="...")
+
+# Octave is priced per 1,000 characters of input text.
+HUME_PRICE_PER_1K_CHARS = RATE  # TODO: confirm at hume.ai/pricing
+for slug in ("octave-1", "octave-2"):
+    provider.models.register_pricing(
+        slug, per_input_chars(HUME_PRICE_PER_1K_CHARS, per=1000)
+    )
+```
+
+To cover any Octave slug with one rule, register against `"*"` (the fallback
+spec's id) — the registry routes unmatched slugs through the fallback:
+
+```python
+provider.models.register_pricing("*", per_input_chars(HUME_PRICE_PER_1K_CHARS, per=1000))
 ```
 
 ---

--- a/libs/connectors/hume/README.md
+++ b/libs/connectors/hume/README.md
@@ -1,0 +1,61 @@
+<!-- last_verified: 2026-06-15 -->
+# genblaze-hume
+
+[Hume AI](https://www.hume.ai/) **Octave TTS** provider adapter for
+[genblaze](https://github.com/backblaze-labs/genblaze).
+
+Octave is an LLM-based text-to-speech model. This connector exposes it as a
+synchronous audio provider — generate speech, get a provenance manifest, and
+persist the result to Backblaze B2 / S3 like any other genblaze step.
+
+## Install
+
+```bash
+pip install genblaze-hume          # or: pip install "genblaze[hume]"
+export HUME_API_KEY="..."          # from https://platform.hume.ai/
+```
+
+## Usage
+
+```python
+from genblaze_core import Modality, Pipeline
+from genblaze_hume import HumeTTSProvider
+
+run, manifest = (
+    Pipeline("narration")
+    .step(
+        HumeTTSProvider(output_dir="output/"),
+        model="octave-2",
+        prompt="Welcome to the future of media provenance.",
+        modality=Modality.AUDIO,
+        voice_id="Ava Song",          # a Hume Voice Library voice name
+        output_format="mp3",          # mp3 | wav | pcm
+    )
+    .run()
+)
+
+print(manifest.canonical_hash)
+```
+
+`step.model` selects the Octave version: `octave-2` → API `version="2"`
+(multi-language, requires a voice), `octave-1` → `version="1"`.
+
+## Pricing
+
+The SDK ships no hardcoded prices. Octave bills per character of input text;
+register a recipe at runtime — see
+[`docs/reference/pricing-recipes.md`](https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md)
+("Hume" section):
+
+```python
+from genblaze_core.providers import per_input_chars
+
+provider = HumeTTSProvider(api_key="...")
+provider.models.register_pricing("octave-2", per_input_chars(RATE, per=1000))
+```
+
+## Docs
+
+- [Octave TTS overview](https://dev.hume.ai/docs/text-to-speech-tts/overview)
+- [synthesize-json reference](https://dev.hume.ai/reference/text-to-speech-tts/synthesize-json)
+- genblaze [new-provider guide](https://github.com/backblaze-labs/genblaze/blob/main/docs/guides/new-provider.md)

--- a/libs/connectors/hume/genblaze_hume/__init__.py
+++ b/libs/connectors/hume/genblaze_hume/__init__.py
@@ -1,0 +1,7 @@
+"""Hume AI (Octave TTS) provider adapter for genblaze."""
+
+from genblaze_hume.provider import HumeTTSProvider
+
+from ._version import __version__  # noqa: F401 — re-exported
+
+__all__ = ["HumeTTSProvider"]

--- a/libs/connectors/hume/genblaze_hume/_errors.py
+++ b/libs/connectors/hume/genblaze_hume/_errors.py
@@ -1,0 +1,25 @@
+"""Shared Hume error mapping — used by provider.py.
+
+The Hume Python SDK is Fern-generated and raises ``ApiError`` subclasses
+carrying a ``status_code`` attribute. We classify off the status code when
+present, then fall back to the shared string-based classifier.
+"""
+
+from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_core.providers.base import classify_api_error
+
+
+def map_hume_error(exc: Exception) -> ProviderErrorCode:
+    """Map a Hume API exception to a ProviderErrorCode."""
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status == 429:
+            return ProviderErrorCode.RATE_LIMIT
+        if status in (401, 403):
+            return ProviderErrorCode.AUTH_FAILURE
+        if status in (400, 422):
+            return ProviderErrorCode.INVALID_INPUT
+        if status in (500, 502, 503, 504):
+            return ProviderErrorCode.SERVER_ERROR
+    # Fall back to shared string-based classifier.
+    return classify_api_error(exc)

--- a/libs/connectors/hume/genblaze_hume/_version.py
+++ b/libs/connectors/hume/genblaze_hume/_version.py
@@ -1,0 +1,14 @@
+"""``genblaze-hume`` package version — single source of truth via importlib.metadata.
+
+Reading from ``importlib.metadata`` keeps the constant equal to whatever
+wheel is installed; no manual edits per release.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__: str = version("genblaze-hume")
+except PackageNotFoundError:  # pragma: no cover — editable dev installs
+    __version__ = "0.0.0+unknown"

--- a/libs/connectors/hume/genblaze_hume/provider.py
+++ b/libs/connectors/hume/genblaze_hume/provider.py
@@ -1,0 +1,309 @@
+"""HumeTTSProvider — adapter for the Hume AI Octave Text-to-Speech API.
+
+Synchronous API: ``client.tts.synthesize_json()`` returns the full result
+with **base64-encoded** audio (no URLs), so this provider decodes the bytes
+and writes them to ``output_dir`` (or a tempfile), exposing a ``file://``
+asset URL — the same shape as the ElevenLabs / LMNT connectors.
+
+**Catalog architecture (genblaze-core 0.3.0):** Hume exposes no per-model
+catalog endpoint — the Octave model is selected via the request's
+``version`` field ("1" or "2"), not a slug list. This connector therefore
+declares ``DiscoverySupport.NONE`` and ships a single pattern-keyed
+``ModelFamily`` for ``octave-*`` slugs (family-matched slugs preflight as
+``OK_PROVISIONAL``) plus a permissive fallback so any slug passes through.
+The connector maps ``step.model`` → the API ``version`` field.
+
+**Pricing**: Octave TTS bills per character of input text. The SDK ships
+zero hardcoded prices — register a recipe at runtime; see
+``docs/reference/pricing-recipes.md`` ("Hume" section).
+
+Docs: https://dev.hume.ai/docs/text-to-speech-tts/overview
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.asset import Asset, AudioMetadata
+from genblaze_core.models.enums import Modality, ProviderErrorCode
+from genblaze_core.models.step import Step
+from genblaze_core.models.voice import Voice
+from genblaze_core.providers import (
+    DiscoverySupport,
+    ModelFamily,
+    ModelRegistry,
+    ModelSpec,
+    ProviderCapabilities,
+    RetryPolicy,
+    SyncProvider,
+)
+from genblaze_core.providers.retry import retry_after_from_response
+from genblaze_core.runnable.config import RunnableConfig
+
+from ._errors import map_hume_error
+
+logger = logging.getLogger("genblaze.hume.tts")
+
+# Octave output format → MIME type → file extension. Hume's ``format``
+# request field is discriminated by ``type``: mp3 / wav / pcm.
+_FORMAT_TO_MIME = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+_FORMAT_TO_EXT = {
+    "audio/mpeg": ".mp3",
+    "audio/wav": ".wav",
+    "audio/pcm": ".pcm",
+}
+
+# ``step.model`` slug → Octave model ``version`` request field. Slugs that
+# don't map (custom / future) omit ``version`` and let the API default.
+_VERSION_FROM_MODEL = {
+    "octave-1": "1",
+    "octave-2": "2",
+}
+
+# Canonical → native param contracts, shared by the family spec_template and
+# the permissive fallback so aliasing is uniform across matched/unmatched
+# slugs. ``prepare_payload`` applies these (voice_id→voice, output_format→
+# format) and coerces numeric params to float.
+_HUME_PARAM_ALIASES = {"voice_id": "voice", "output_format": "format"}
+_HUME_PARAM_COERCERS = {"speed": float, "temperature": float, "trailing_silence": float}
+
+# The Hume Octave family covers ``octave-1`` / ``octave-2`` (and any future
+# ``octave-*`` line). The wire shape is uniform across versions — only the
+# ``version`` request field changes — so a single family suffices.
+# spec_template.pricing MUST be None (pricing is user-registered).
+_HUME_OCTAVE_FAMILY = ModelFamily(
+    name="hume-octave",
+    pattern=re.compile(r"^octave-"),
+    spec_template=ModelSpec(
+        model_id="*",
+        modality=Modality.AUDIO,
+        param_aliases=_HUME_PARAM_ALIASES,
+        param_coercers=_HUME_PARAM_COERCERS,
+    ),
+    description="Hume Octave TTS family — octave-1 / octave-2.",
+    example_slugs=("octave-1", "octave-2"),
+)
+
+_HUME_FALLBACK = ModelSpec(
+    model_id="*",
+    modality=Modality.AUDIO,
+    param_aliases=_HUME_PARAM_ALIASES,
+    param_coercers=_HUME_PARAM_COERCERS,
+)
+
+
+class HumeTTSProvider(SyncProvider):
+    """Provider adapter for Hume AI Octave Text-to-Speech.
+
+    Models match the ``hume-octave`` family — any ``^octave-`` slug, mapped
+    to the API ``version`` field. The synthesize call is synchronous and
+    returns base64 audio, which is decoded to a local ``file://`` asset.
+
+    Args:
+        api_key: Hume API key. Falls back to ``HUME_API_KEY`` env var.
+        output_dir: Directory for output audio files (default system temp).
+        models: Optional custom ``ModelRegistry`` — overrides the class default.
+        retry_policy: Optional retry policy override.
+        probe_cache_ttl: Per-instance probe-cache TTL (no-op for NONE
+            discovery but accepted for API uniformity with other providers).
+        probe_cache_max_entries: Per-instance probe-cache size cap.
+    """
+
+    name = "hume-tts"
+    discovery_support = DiscoverySupport.NONE
+    """Hume exposes no ``GET /models`` catalog — the Octave model is chosen
+    via the request ``version`` field, not a slug list. Family-matched
+    ``octave-*`` slugs preflight as ``OK_PROVISIONAL``; everything else
+    resolves through the permissive fallback as ``UNKNOWN_PERMISSIVE``."""
+
+    @classmethod
+    def create_registry(cls) -> ModelRegistry:
+        return ModelRegistry(
+            provider_families=(_HUME_OCTAVE_FAMILY,),
+            fallback=_HUME_FALLBACK,
+        )
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        """Hume Octave TTS: audio speech generation from text."""
+        return ProviderCapabilities(
+            supported_modalities=[Modality.AUDIO],
+            supported_inputs=["text"],
+            models=self._models.known(),
+            output_formats=["audio/mpeg", "audio/wav", "audio/pcm"],
+        )
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        output_dir: str | Path | None = None,
+        *,
+        models: ModelRegistry | None = None,
+        retry_policy: RetryPolicy | None = None,
+        probe_cache_ttl: float | None = None,
+        probe_cache_max_entries: int | None = None,
+    ):
+        super().__init__(
+            models=models,
+            retry_policy=retry_policy,
+            probe_cache_ttl=probe_cache_ttl,
+            probe_cache_max_entries=probe_cache_max_entries,
+        )
+        self._api_key = api_key
+        self._output_dir = Path(output_dir) if output_dir else None
+        self._client: Any = None
+
+    def _get_client(self):
+        if self._client is None:
+            # The Hume SDK does not auto-read HUME_API_KEY — resolve it here and
+            # fail fast with a clear, correctly-classified error rather than
+            # constructing a keyless client that 401s deep inside generate().
+            key = self._api_key or os.getenv("HUME_API_KEY")
+            if not key:
+                raise ProviderError(
+                    "No Hume API key found. Pass api_key=... or set HUME_API_KEY.",
+                    error_code=ProviderErrorCode.AUTH_FAILURE,
+                )
+            try:
+                from hume import HumeClient
+            except ImportError as exc:
+                raise ProviderError("hume package not installed. Run: pip install hume") from exc
+            self._client = HumeClient(api_key=key)
+        return self._client
+
+    def generate(self, step: Step, config: RunnableConfig | None = None) -> Step:
+        """Generate speech audio via the Hume Octave TTS API."""
+        client = self._get_client()
+        try:
+            # Run the spec pipeline — rewrites voice_id→voice,
+            # output_format→format, and coerces speed/temperature to float.
+            payload = self.prepare_payload(step)
+
+            out_format = payload.get("format", "mp3")
+            if out_format not in _FORMAT_TO_MIME:
+                raise ProviderError(
+                    f"Unsupported output_format {out_format!r}. "
+                    f"Must be one of: {', '.join(sorted(_FORMAT_TO_MIME))}.",
+                    error_code=ProviderErrorCode.INVALID_INPUT,
+                )
+            media_type = _FORMAT_TO_MIME[out_format]
+            ext = _FORMAT_TO_EXT[media_type]
+
+            # Lazy-import the request models so an absent SDK only fails inside
+            # the ImportError path of _get_client (and so tests can mock them).
+            # Note: `voice_id` is interpreted as a Hume Voice Library *name*
+            # (PostedUtteranceVoiceWithName), not an opaque id — see README.
+            from hume.tts import PostedUtterance, PostedUtteranceVoiceWithName
+
+            utt_kwargs: dict[str, Any] = {"text": payload.get("prompt", step.prompt or "")}
+            voice = payload.get("voice")
+            if voice:
+                utt_kwargs["voice"] = PostedUtteranceVoiceWithName(name=voice, provider="HUME_AI")
+            if "description" in payload:
+                utt_kwargs["description"] = payload["description"]
+            if "speed" in payload:
+                utt_kwargs["speed"] = payload["speed"]
+            if "trailing_silence" in payload:
+                utt_kwargs["trailing_silence"] = payload["trailing_silence"]
+
+            synth_kwargs: dict[str, Any] = {
+                "utterances": [PostedUtterance(**utt_kwargs)],
+                "format": {"type": out_format},
+                "num_generations": 1,
+            }
+            version = _VERSION_FROM_MODEL.get(step.model or "")
+            if version is not None:
+                synth_kwargs["version"] = version
+            if "temperature" in payload:
+                synth_kwargs["temperature"] = payload["temperature"]
+
+            response = client.tts.synthesize_json(**synth_kwargs)
+            generation = response.generations[0]
+            audio_bytes = base64.b64decode(generation.audio)
+
+            if self._output_dir:
+                self._output_dir.mkdir(parents=True, exist_ok=True)
+                out_path = self._output_dir / f"{step.step_id}{ext}"
+            else:
+                fd, tmp = tempfile.mkstemp(suffix=ext)
+                os.close(fd)
+                out_path = Path(tmp)
+
+            out_path.write_bytes(audio_bytes)
+            # Local file output — no validate_asset_url() (it only permits
+            # HTTPS; file:// is the documented local-provider convention).
+            file_url = f"file://{quote(str(out_path.resolve()))}"
+            asset = Asset(url=file_url, media_type=media_type)
+            asset.metadata["audio_type"] = "speech"
+            asset.size_bytes = len(audio_bytes)
+
+            duration = getattr(generation, "duration", None)
+            if duration is not None:
+                asset.duration = float(duration)
+
+            audio_meta: dict[str, Any] = {"channels": 1, "codec": out_format}
+            encoding = getattr(generation, "encoding", None)
+            if encoding is not None:
+                sample_rate = getattr(encoding, "sample_rate", None)
+                if sample_rate:
+                    audio_meta["sample_rate"] = int(sample_rate)
+            asset.audio = AudioMetadata(**audio_meta)
+
+            step.assets.append(asset)
+
+            self._apply_registry_pricing(step)
+            return step
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"Hume TTS failed: {exc}",
+                error_code=map_hume_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc
+
+    def list_voices(
+        self,
+        *,
+        model: str | None = None,
+        language: str | None = None,
+    ) -> list[Voice]:
+        """Return voices from Hume's Voice Library (best-effort, live fetch).
+
+        Degrades to an empty list if the SDK call fails or the catalog can't
+        be read — callers treat an empty list as "no picker available".
+
+        Hume's voice catalog (``ReturnVoice``) exposes ``id`` / ``name`` /
+        ``provider`` and a ``compatible_octave_models`` list; it carries no
+        per-voice language tag, so the ``language`` filter cannot be honored
+        here and is accepted only for interface parity with the base hook.
+        """
+        try:
+            client = self._get_client()
+            raw = client.tts.voices.list(provider="HUME_AI")
+            voices: list[Voice] = []
+            for v in raw:
+                vid = getattr(v, "id", None) or getattr(v, "name", None)
+                if not vid:
+                    continue
+                if model is not None:
+                    compatible = getattr(v, "compatible_octave_models", None)
+                    if compatible and model not in compatible:
+                        continue
+                vname = getattr(v, "name", None) or vid
+                voices.append(Voice(voice_id=str(vid), name=str(vname), provider=self.name))
+            return voices
+        except Exception as exc:  # noqa: BLE001 — advisory hook, never fatal
+            logger.debug("Hume list_voices failed: %s", exc)
+            return []

--- a/libs/connectors/hume/pyproject.toml
+++ b/libs/connectors/hume/pyproject.toml
@@ -24,10 +24,11 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.0,<0.4",
-    # Modern Fern-generated SDK surface (sync HumeClient, client.tts.synthesize_json,
-    # hume.tts.Posted* request models). Bounded below 1.0 so a future major can't
-    # silently reshape the client out from under these call sites.
-    "hume>=0.8,<1",
+    # The provider passes `version` (octave-1/-2 → Octave version) and
+    # `temperature` to synthesize_json; both kwargs only exist together from
+    # hume 0.13.13 (earlier 0.x raise TypeError on the octave-* path). Bounded
+    # below 1.0 so a future major can't silently reshape these call sites.
+    "hume>=0.13.13,<1",
 ]
 
 [project.urls]
@@ -49,3 +50,8 @@ packages = ["genblaze_hume"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/hume/pyproject.toml
+++ b/libs/connectors/hume/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "genblaze-hume"
+version = "0.3.0"
+description = "Hume AI (Octave TTS) provider adapter for genblaze"
+authors = [{name = "Kamren Mahaney", email = "kmahaney@backblaze.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia",
+    "Topic :: Software Development :: Libraries",
+]
+keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "hume", "octave", "tts", "audio"]
+
+dependencies = [
+    "genblaze-core>=0.3.0,<0.4",
+    # Modern Fern-generated SDK surface (sync HumeClient, client.tts.synthesize_json,
+    # hume.tts.Posted* request models). Bounded below 1.0 so a future major can't
+    # silently reshape the client out from under these call sites.
+    "hume>=0.8,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/backblaze-labs/genblaze"
+Documentation = "https://github.com/backblaze-labs/genblaze"
+Repository = "https://github.com/backblaze-labs/genblaze"
+Issues = "https://github.com/backblaze-labs/genblaze/issues"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.entry-points."genblaze.providers"]
+hume-tts = "genblaze_hume:HumeTTSProvider"
+
+[tool.hatch.build.targets.wheel]
+packages = ["genblaze_hume"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/libs/connectors/hume/tests/test_catalog_decoupling.py
+++ b/libs/connectors/hume/tests/test_catalog_decoupling.py
@@ -1,0 +1,83 @@
+"""Catalog-decoupling regression tests for ``genblaze-hume``.
+
+Hume declares ``DiscoverySupport.NONE`` — there's no upstream
+``GET /models`` endpoint (the Octave model is chosen via the request
+``version`` field). The connector ships a single ``octave-*`` family plus
+a permissive fallback; pricing is user-registered.
+
+This file pins the post-decoupling shape so a future edit can't silently
+regress it.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from genblaze_core.providers import DiscoverySupport, ValidationOutcome
+
+
+@pytest.fixture(autouse=True)
+def _patch_hume_sdk():
+    """Avoid importing the real hume SDK in tests."""
+    with patch.dict(sys.modules, {"hume": MagicMock(), "hume.tts": MagicMock()}):
+        yield
+
+
+class TestDiscoverySupportDeclaration:
+    def test_none(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        assert HumeTTSProvider.discovery_support is DiscoverySupport.NONE
+
+
+class TestRegistryShape:
+    def test_single_octave_family(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        names = {f.name for f in provider._models.families}
+        assert names == {"hume-octave"}
+
+    def test_octave_slugs_match_family(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        for slug in ("octave-1", "octave-2", "octave-3-preview"):
+            assert provider._models.match_family(slug) is not None, slug
+
+    def test_octave_validate_provisional(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        assert provider.validate_model("octave-2").outcome is ValidationOutcome.OK_PROVISIONAL
+
+    def test_non_octave_resolves_via_fallback(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        spec = provider._models.get("not-an-octave-slug")
+        assert spec is not None
+        assert (
+            provider.validate_model("not-an-octave-slug").outcome
+            is ValidationOutcome.UNKNOWN_PERMISSIVE
+        )
+
+
+class TestPricingPhaseOut:
+    def test_no_pricing_shipped(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        assert provider._models.get("octave-2").pricing is None
+        assert provider._models.get("anything").pricing is None
+
+
+class TestCrossProviderIsolation:
+    def test_does_not_match_other_provider_slugs(self) -> None:
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key="test")
+        for slug in ("veo-3.0-generate-001", "tts-1", "eleven_v2", "ray-2", "lmnt-1"):
+            assert provider._models.match_family(slug) is None, slug

--- a/libs/connectors/hume/tests/test_hume_provider.py
+++ b/libs/connectors/hume/tests/test_hume_provider.py
@@ -1,0 +1,324 @@
+"""Tests for HumeTTSProvider (mocked — no real API calls)."""
+
+from __future__ import annotations
+
+import base64
+import sys
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.enums import ProviderErrorCode, StepStatus
+from genblaze_core.models.step import Step
+from genblaze_core.testing import ProviderComplianceTests
+
+
+def _fake_response(raw: bytes = b"fake-audio-data", *, sample_rate: int = 48000):
+    """Build an OctaveResponse-shaped object with one base64 generation."""
+    generation = SimpleNamespace(
+        audio=base64.b64encode(raw).decode(),
+        duration=1.5,
+        encoding=SimpleNamespace(format="mp3", sample_rate=sample_rate),
+        file_size=len(raw),
+        generation_id="gen-123",
+    )
+    return SimpleNamespace(generations=[generation], request_id="req-1")
+
+
+@pytest.fixture
+def mock_hume(tmp_path):
+    """Patch the hume SDK modules and inject a mock client."""
+    fake_tts = MagicMock()  # provides PostedUtterance / PostedUtteranceVoiceWithName
+    with patch.dict(sys.modules, {"hume": MagicMock(), "hume.tts": fake_tts}):
+        from genblaze_hume import HumeTTSProvider
+
+        mock_client = MagicMock()
+        mock_client.tts.synthesize_json = MagicMock(return_value=_fake_response())
+        provider = HumeTTSProvider(api_key="test-key", output_dir=str(tmp_path))
+        provider._client = mock_client
+        yield provider, mock_client, fake_tts
+
+
+# --- happy path -----------------------------------------------------------
+
+
+def test_generate_returns_audio_asset(mock_hume):
+    provider, _, _ = mock_hume
+    step = Step(provider="hume-tts", model="octave-2", prompt="Hello world")
+    result = provider.generate(step)
+    assert len(result.assets) == 1
+    asset = result.assets[0]
+    assert asset.media_type == "audio/mpeg"
+    assert asset.url.startswith("file://")
+    assert asset.duration == 1.5
+    assert asset.audio is not None
+    assert asset.audio.channels == 1
+    assert asset.audio.codec == "mp3"
+    assert asset.audio.sample_rate == 48000
+    assert asset.metadata["audio_type"] == "speech"
+
+
+def test_invoke_full_lifecycle(mock_hume):
+    provider, _, _ = mock_hume
+    step = Step(provider="hume-tts", model="octave-2", prompt="Hello")
+    result = provider.invoke(step)
+    assert result.status == StepStatus.SUCCEEDED
+    assert len(result.assets) == 1
+
+
+def test_base64_decoded_to_file(mock_hume, tmp_path):
+    provider, _, _ = mock_hume
+    step = Step(provider="hume-tts", model="octave-2", prompt="Hi")
+    result = provider.generate(step)
+    path = result.assets[0].url.removeprefix("file://")
+    from urllib.parse import unquote
+
+    assert open(unquote(path), "rb").read() == b"fake-audio-data"
+
+
+# --- model → version mapping ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,expected_version",
+    [("octave-1", "1"), ("octave-2", "2")],
+)
+def test_model_maps_to_version(mock_hume, model, expected_version):
+    provider, client, _ = mock_hume
+    step = Step(provider="hume-tts", model=model, prompt="x")
+    provider.generate(step)
+    kwargs = client.tts.synthesize_json.call_args.kwargs
+    assert kwargs["version"] == expected_version
+
+
+def test_unmapped_octave_slug_omits_version(mock_hume):
+    provider, client, _ = mock_hume
+    step = Step(provider="hume-tts", model="octave-custom-preview", prompt="x")
+    provider.generate(step)
+    kwargs = client.tts.synthesize_json.call_args.kwargs
+    assert "version" not in kwargs
+
+
+# --- param mapping --------------------------------------------------------
+
+
+def test_voice_id_aliased_and_passed(mock_hume):
+    provider, _, fake_tts = mock_hume
+    step = Step(
+        provider="hume-tts",
+        model="octave-2",
+        prompt="test",
+        params={"voice_id": "Ava Song"},
+    )
+    provider.generate(step)
+    # voice_id → voice (alias), forwarded to the Hume voice-ref constructor.
+    fake_tts.PostedUtteranceVoiceWithName.assert_called_once()
+    assert fake_tts.PostedUtteranceVoiceWithName.call_args.kwargs["name"] == "Ava Song"
+
+
+def test_output_format_maps_to_wav(mock_hume):
+    provider, client, _ = mock_hume
+    step = Step(
+        provider="hume-tts",
+        model="octave-2",
+        prompt="test",
+        params={"output_format": "wav"},
+    )
+    result = provider.generate(step)
+    assert client.tts.synthesize_json.call_args.kwargs["format"] == {"type": "wav"}
+    assert result.assets[0].media_type == "audio/wav"
+    assert result.assets[0].url.endswith(".wav")
+
+
+def test_normalize_params_idempotent(mock_hume):
+    provider, _, _ = mock_hume
+    params = {"voice_id": "Ava", "output_format": "mp3", "speed": 1.1}
+    once = provider.normalize_params(params)
+    twice = provider.normalize_params(once)
+    assert once == twice
+
+
+def test_unsupported_output_format_raises(mock_hume):
+    provider, _, _ = mock_hume
+    step = Step(
+        provider="hume-tts",
+        model="octave-2",
+        prompt="test",
+        params={"output_format": "ogg"},
+    )
+    with pytest.raises(ProviderError, match="Unsupported output_format") as ei:
+        provider.generate(step)
+    assert ei.value.error_code == ProviderErrorCode.INVALID_INPUT
+
+
+# --- credentials ----------------------------------------------------------
+
+
+def test_missing_api_key_raises_auth_failure(monkeypatch):
+    """No api_key and no HUME_API_KEY → fail fast with AUTH_FAILURE, not a
+    deferred opaque error from a keyless client."""
+    monkeypatch.delenv("HUME_API_KEY", raising=False)
+    with patch.dict(sys.modules, {"hume": MagicMock(), "hume.tts": MagicMock()}):
+        from genblaze_hume import HumeTTSProvider
+
+        provider = HumeTTSProvider(api_key=None)  # no injected client
+        step = Step(provider="hume-tts", model="octave-2", prompt="hi")
+        with pytest.raises(ProviderError, match="No Hume API key") as ei:
+            provider.generate(step)
+        assert ei.value.error_code == ProviderErrorCode.AUTH_FAILURE
+
+
+# --- list_voices ----------------------------------------------------------
+
+
+def test_list_voices_maps_catalog(mock_hume):
+    provider, client, _ = mock_hume
+    client.tts.voices.list.return_value = [
+        SimpleNamespace(id="v1", name="Ava", compatible_octave_models=["octave-2"]),
+        SimpleNamespace(id="v2", name="Ben", compatible_octave_models=["octave-1"]),
+    ]
+    voices = provider.list_voices()
+    assert [v.voice_id for v in voices] == ["v1", "v2"]
+    assert all(v.provider == "hume-tts" for v in voices)
+
+
+def test_list_voices_filters_by_compatible_model(mock_hume):
+    provider, client, _ = mock_hume
+    client.tts.voices.list.return_value = [
+        SimpleNamespace(id="v1", name="Ava", compatible_octave_models=["octave-2"]),
+        SimpleNamespace(id="v2", name="Ben", compatible_octave_models=["octave-1"]),
+    ]
+    voices = provider.list_voices(model="octave-2")
+    assert [v.voice_id for v in voices] == ["v1"]
+
+
+def test_list_voices_degrades_to_empty_on_error(mock_hume):
+    provider, client, _ = mock_hume
+    client.tts.voices.list.side_effect = RuntimeError("transport down")
+    assert provider.list_voices() == []
+
+
+# --- cost -----------------------------------------------------------------
+
+
+def test_cost_none_by_default(mock_hume):
+    """The SDK ships zero hardcoded prices — cost is None until registered."""
+    provider, _, _ = mock_hume
+    step = Step(provider="hume-tts", model="octave-2", prompt="Hello world")
+    result = provider.generate(step)
+    assert result.cost_usd is None
+
+
+def test_cost_tracked_with_user_registered_pricing(mock_hume):
+    from genblaze_core.providers import per_input_chars
+
+    provider, _, _ = mock_hume
+    provider.models.register_pricing("octave-2", per_input_chars(0.0002, per=1))
+    step = Step(provider="hume-tts", model="octave-2", prompt="Hello world")
+    result = provider.generate(step)
+    assert result.cost_usd == pytest.approx(len("Hello world") * 0.0002)
+
+
+# --- error mapping --------------------------------------------------------
+
+
+def test_api_error_raises_provider_error(mock_hume):
+    provider, client, _ = mock_hume
+    err = RuntimeError("boom")
+    err.status_code = 429  # type: ignore[attr-defined]
+    client.tts.synthesize_json.side_effect = err
+    step = Step(provider="hume-tts", model="octave-2", prompt="x")
+    with pytest.raises(ProviderError, match="Hume TTS failed") as ei:
+        provider.generate(step)
+    assert ei.value.error_code == ProviderErrorCode.RATE_LIMIT
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (429, ProviderErrorCode.RATE_LIMIT),
+        (401, ProviderErrorCode.AUTH_FAILURE),
+        (403, ProviderErrorCode.AUTH_FAILURE),
+        (400, ProviderErrorCode.INVALID_INPUT),
+        (422, ProviderErrorCode.INVALID_INPUT),
+        (503, ProviderErrorCode.SERVER_ERROR),
+    ],
+)
+def test_map_hume_error_status_codes(status, expected):
+    from genblaze_hume._errors import map_hume_error
+
+    exc = RuntimeError("err")
+    exc.status_code = status  # type: ignore[attr-defined]
+    assert map_hume_error(exc) == expected
+
+
+def test_map_hume_error_no_status_falls_back():
+    from genblaze_hume._errors import map_hume_error
+
+    # No status_code attribute → string-based classifier fallback.
+    assert map_hume_error(RuntimeError("totally opaque")) == ProviderErrorCode.UNKNOWN
+
+
+# --- catalog-decoupling proof-point --------------------------------------
+
+
+def test_declares_discovery_support_none():
+    from genblaze_core.providers import DiscoverySupport
+    from genblaze_hume import HumeTTSProvider
+
+    assert HumeTTSProvider.discovery_support is DiscoverySupport.NONE
+
+
+def test_octave_slug_matches_family(mock_hume):
+    """``octave-*`` slugs match the family → OK_PROVISIONAL at preflight."""
+    from genblaze_core.providers import ValidationOutcome
+
+    provider, _, _ = mock_hume
+    result = provider.validate_model("octave-2")
+    assert result.outcome is ValidationOutcome.OK_PROVISIONAL
+
+
+def test_non_octave_slug_unknown_permissive(mock_hume):
+    """Non-octave slugs fall through the permissive fallback."""
+    from genblaze_core.providers import ValidationOutcome
+
+    provider, _, _ = mock_hume
+    result = provider.validate_model("some-other-model")
+    assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
+
+
+def test_family_and_fallback_carry_no_pricing(mock_hume):
+    provider, _, _ = mock_hume
+    assert provider._models.get("octave-2").pricing is None
+    assert provider._models.get("anything-else").pricing is None
+
+
+# --- compliance harness ---------------------------------------------------
+
+
+class TestHumeCompliance(ProviderComplianceTests):
+    """Verify HumeTTSProvider satisfies the genblaze provider contract."""
+
+    # As of genblaze-core 0.3.0 the SDK ships zero hardcoded prices.
+    # Hume users register pricing via ``provider.models.register_pricing()``;
+    # see ``docs/reference/pricing-recipes.md``.
+    expects_cost = False
+
+    @pytest.fixture(autouse=True)
+    def _patch_sdk(self):
+        with patch.dict(sys.modules, {"hume": MagicMock(), "hume.tts": MagicMock()}):
+            yield
+
+    def make_provider(self):
+        from genblaze_hume import HumeTTSProvider
+
+        mock_client = MagicMock()
+        mock_client.tts.synthesize_json = MagicMock(return_value=_fake_response())
+        provider = HumeTTSProvider(api_key="test-key", output_dir=tempfile.mkdtemp())
+        provider._client = mock_client
+        return provider
+
+    def make_step(self):
+        return Step(provider="hume-tts", model="octave-2", prompt="test prompt")

--- a/libs/core/tests/unit/test_version_coherence.py
+++ b/libs/core/tests/unit/test_version_coherence.py
@@ -67,7 +67,7 @@ class TestVersionCoherence:
 class TestConnectorVersionCoherence:
     """Each genblaze-* connector's ``__version__`` must read from
     ``importlib.metadata`` rather than a hardcoded string. Plan 5
-    Phase 1B closed the version-drift class of bug across all 13
+    Phase 1B closed the version-drift class of bug across all 14
     connector packages."""
 
     @staticmethod
@@ -112,6 +112,9 @@ class TestConnectorVersionCoherence:
 
     def test_genblaze_lmnt(self):
         self._check("genblaze_lmnt", "genblaze-lmnt")
+
+    def test_genblaze_hume(self):
+        self._check("genblaze_hume", "genblaze-hume")
 
     def test_genblaze_stability_audio(self):
         self._check("genblaze_stability_audio", "genblaze-stability-audio")

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -46,6 +46,7 @@ decart = ["genblaze-decart>=0.3.0,<0.4"]
 elevenlabs = ["genblaze-elevenlabs>=0.3.0,<0.4"]
 stability-audio = ["genblaze-stability-audio>=0.3.0,<0.4"]
 lmnt = ["genblaze-lmnt>=0.3.0,<0.4"]
+hume = ["genblaze-hume>=0.3.0,<0.4"]
 langsmith = ["genblaze-langsmith>=0.2.1,<0.4"]
 nvidia = ["genblaze-nvidia>=0.3.0,<0.4"]
 
@@ -67,6 +68,7 @@ image = [
 audio = [
     "genblaze-elevenlabs>=0.3.0,<0.4",
     "genblaze-lmnt>=0.3.0,<0.4",
+    "genblaze-hume>=0.3.0,<0.4",
     "genblaze-stability-audio>=0.3.0,<0.4",
     "genblaze-gmicloud>=0.3.0,<0.4",
     "genblaze-nvidia>=0.3.0,<0.4",
@@ -82,6 +84,7 @@ all = [
     "genblaze-elevenlabs>=0.3.0,<0.4",
     "genblaze-stability-audio>=0.3.0,<0.4",
     "genblaze-lmnt>=0.3.0,<0.4",
+    "genblaze-hume>=0.3.0,<0.4",
     "genblaze-langsmith>=0.2.1,<0.4",
     "genblaze-nvidia>=0.3.0,<0.4",
 ]

--- a/tools/check_pin_parity.py
+++ b/tools/check_pin_parity.py
@@ -99,6 +99,7 @@ PACKAGES: list[str] = [
     "libs/connectors/elevenlabs",
     "libs/connectors/stability-audio",
     "libs/connectors/lmnt",
+    "libs/connectors/hume",
     "libs/connectors/gmicloud",
     "libs/connectors/langsmith",
     "libs/connectors/nvidia",
@@ -226,10 +227,7 @@ def main() -> int:
             print(f"  DRIFT {label}: source pins diverge from PyPI wheel")
 
     print()
-    print(
-        f"Summary: {len(matched)} parity, {len(unreleased)} fresh, "
-        f"{len(drift_reports)} drift"
-    )
+    print(f"Summary: {len(matched)} parity, {len(unreleased)} fresh, {len(drift_reports)} drift")
 
     if drift_reports:
         print()

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -50,6 +50,7 @@ PACKAGES=(
     "libs/connectors/elevenlabs"
     "libs/connectors/stability-audio"
     "libs/connectors/lmnt"
+    "libs/connectors/hume"
     "libs/connectors/gmicloud"
     "libs/connectors/langsmith"
     "libs/connectors/nvidia"
@@ -108,6 +109,7 @@ connectors = [
     "genblaze_elevenlabs",
     "genblaze_stability_audio",
     "genblaze_lmnt",
+    "genblaze_hume",
     "genblaze_gmicloud",
     "genblaze_langsmith",
     "genblaze_nvidia",


### PR DESCRIPTION
## What & why

Adds **`genblaze-hume`**, a new provider connector wrapping Hume AI's
**Octave** text-to-speech API as a synchronous audio provider
(`SyncProvider`). Octave is an LLM-based TTS model; this lets genblaze
pipelines generate speech with a provenance manifest like any other step.

Design highlights:
- The Hume API returns **base64 audio** (not URLs), so the provider decodes
  it to a local `file://` asset — the same pattern as the ElevenLabs/LMNT
  connectors.
- `step.model` (`octave-1` / `octave-2`) maps to the Octave `version`
  request field; unknown slugs omit `version`.
- Ships a pattern-keyed `^octave-` `ModelFamily` + permissive fallback with
  `DiscoverySupport.NONE` (Hume has no model-catalog endpoint).
- Pricing is **user-registered** (no hardcoded rates); a per-character
  recipe is documented in `docs/reference/pricing-recipes.md`.
- Fails fast on a missing API key (`AUTH_FAILURE`) and on an unsupported
  `output_format` (`INVALID_INPUT`).

## Scope

**New package:** `libs/connectors/hume/` — provider, `_errors`, `py.typed`,
tests (incl. `TestHumeCompliance(ProviderComplianceTests)` and a
catalog-decoupling regression suite), README.

**Integration:** `genblaze.providers` entry point; Makefile
`install`/`install-dev`/`test`; `genblaze[hume]` / `[audio]` / `[all]`
umbrella extras; per-connector `test_version_coherence` case.

**Docs (same-PR):** README install/matrix/keys rows, ARCHITECTURE connector
+ external-services lists, AGENTS package/provider counts,
`provider-system.md` NONE-tier list, and the pricing recipe.

## Execution plan

`docs/exec-plans/active/hume-provider.md` (included in this PR).

## Gates passed

- `make lint` — ruff check + format clean (376 files)
- `make typecheck` — mypy clean (90 files)
- `make test` — full suite green; `genblaze-hume` 49 passed / 2 skipped
  (expected skips: no chain inputs, `expects_cost=False`), and core's
  cross-provider conformance suite discovers and passes `HumeTTSProvider`.

## Related issue

None — no existing issue tracks a Hume/Octave connector (searched open +
closed). New connector contribution per `docs/guides/new-provider.md`.

## Release notes

`[Unreleased]` → `### Added` bullet added to `CHANGELOG.md` under
`genblaze-hume`.

## Follow-ups (not blocking)

- Fill the concrete per-character rate in the pricing recipe (left as a
  `RATE` placeholder — no published rate fabricated).
- Confirm the `hume` SDK call sites against an installed SDK before
  promoting beyond Alpha (dependency pinned `hume>=0.8,<1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
