### PR TITLE
fix: resume post-submit step retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `genblaze-core`: post-submit step-level retries now resume the existing
   upstream prediction instead of submitting a new one, including transient
-  checkpoint failures after `submit()` returns (#70).
+  checkpoint failures after `submit()` returns by replaying idempotent
+  `on_submit(step_id, prediction_id)` callbacks before retry resume (#70).
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `genblaze-core`: post-submit step-level retries now resume the existing
+  upstream prediction instead of submitting a new one, including transient
+  checkpoint failures after `submit()` returns (#70).
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/docs/exec-plans/completed/issue-70-post-submit-retry-resume.md
+++ b/docs/exec-plans/completed/issue-70-post-submit-retry-resume.md
@@ -1,0 +1,26 @@
+<!-- last_verified: 2026-06-17 -->
+# Issue 70 Post-Submit Retry Resume
+
+Fixes issue #70: step-level retries after a successful upstream submit must resume
+the existing prediction instead of submitting another billed generation.
+
+## Scope
+
+| File | Change |
+|---|---|
+| `libs/core/genblaze_core/providers/base.py` | Route step-level retries through the resume lifecycle when a failed prior attempt reached poll/fetch with an `upstream_id`. Keep pre-submit and submit failures on the existing full re-submit path. |
+| `libs/core/tests/unit/test_provider_retry.py` | Add regression coverage for fetch retry, poll retry, submit retry, and async fetch retry call counts. |
+| `docs/features/retry-policy.md` | Document that post-submit step retries resume the existing upstream job. |
+
+## Acceptance Criteria
+
+- `fetch_output`-phase retries do not call `submit()` again.
+- Poll/fetch-phase failures resume the existing prediction.
+- Pre-submit/submit failures continue to re-submit.
+- Sync and async provider paths behave consistently.
+
+## Test Plan
+
+- `cd libs/core && pytest tests/unit/test_provider_retry.py -v`
+- `make lint`
+- `make test`

--- a/docs/features/moderation.md
+++ b/docs/features/moderation.md
@@ -1,7 +1,8 @@
 <!-- last_verified: 2026-06-17 -->
 # Moderation Hooks
 
-`ModerationHook` provides pre/post-step content screening for prompt text, text carried by input assets, and generated outputs.
+`ModerationHook` provides pre/post-step content screening for prompt text,
+manifest-visible input text, and generated outputs.
 
 ## Usage
 
@@ -29,7 +30,7 @@ result = (
 
 ## Execution order
 
-1. **Pre-step moderation** — `check_prompt()` before generation. Rejected prompts or textual inputs skip the provider entirely.
+1. **Pre-step moderation** — `check_prompt()` before generation. Rejected prompts or recognized textual inputs skip the provider entirely.
 2. **Cache lookup** — only reached if moderation passes.
 3. **Provider invoke** — with fallback model support.
 4. **Post-step moderation** — `check_output()` after generation. Rejected outputs are not cached.
@@ -40,12 +41,18 @@ result = (
 Pre-step moderation runs after pipeline inputs are resolved and before cache lookup or provider invocation. The payload passed to `check_prompt(prompt, params)` includes:
 
 - `Step.prompt` and `Step.negative_prompt` when they are not `None`
-- text carried by `Step.inputs`, including inputs from `external_inputs=`, `input_from=`, and `chain=True`
-- text found in `Asset.metadata["text"]`; strings are used as-is, bytes are decoded as UTF-8 with replacement, and structured values are JSON-stringified
+- text found in `Asset.metadata["text"]` on `Step.inputs`, including inputs from `external_inputs=`, `input_from=`, and `chain=True`; strings are used as-is, bytes are decoded as UTF-8 with replacement, and structured values are JSON-stringified
 
 When prompts and textual inputs are present, they are joined with blank lines and checked once. Promptless steps with textual inputs are moderated. Promptless steps with no textual inputs, such as compositors or transforms that only consume media URLs, still skip pre-step moderation.
 
-The pipeline does not fetch or read `Asset.url` during moderation. For `text/plain` inputs, carry the text in `Asset.metadata["text"]` until a first-class text asset field exists.
+### Security scope
+
+Pre-step moderation does **not** fetch or read `Asset.url`, even for
+`text/plain` assets, and it does not scan arbitrary metadata keys such as
+`caption`, `alt`, or provider-specific payload fields. Those channels remain the
+responsibility of the caller or provider adapter until Genblaze has a first-class
+text asset body field. For text input you want the pipeline to screen, mirror the
+exact text into `Asset.metadata["text"]`.
 
 ## Failure behavior
 

--- a/docs/features/retry-policy.md
+++ b/docs/features/retry-policy.md
@@ -58,7 +58,10 @@ There are two retry layers. Most users only need to think about the first.
    attempt already produced an upstream prediction ID from the current
    `submit()` call, the retry resumes that existing job instead of calling
    `submit()` again. This also covers a transient `on_submit` checkpoint
-   failure after the upstream job was created. Caller-supplied
+   failure after the upstream job was created: before an automatic resume polls
+   or fetches, the base provider calls `on_submit(step_id, prediction_id)` again
+   with the same prediction ID, so checkpoint callbacks must be idempotent for a
+   given `(step_id, prediction_id)`. Caller-supplied
    `step.metadata["upstream_id"]` is observability data and is not trusted as
    retry authority. Only failures before a current upstream ID exists use a
    fresh submit. The retryable-codes set is now also taken from the policy, so
@@ -74,15 +77,27 @@ Poll/fetch failures have the opposite safety rule: the upstream generation
 already exists, so step-level retries re-run the base poll/fetch resume loop
 against the same in-process prediction ID. This avoids duplicate renders and
 duplicate charges when the transient error happened after generation started.
-Internal step retries do not call provider overrides of the public `resume()`
-method; override `poll()` / `fetch_output()` for behavior shared by public
-resume and automatic retry resume. Public `resume()` progress still emits
-`resumed`; automatic step retry resume emits `retry_resumed`.
+After a prediction ID is recorded for the current invoke, automatic retries stay
+bound to that ID and do not fall back to a fresh submit, because a fresh submit
+can double-bill. If the step-level retry budget is exhausted while resuming, the
+provider logs that the resume budget was exhausted without re-submit and records
+`genblaze.step_retry.resume_exhausted` span metadata.
+
+Internal step retries use the protected `_resume_once()` / `_aresume_once()`
+hooks, which are also used by public `resume()` / `aresume()`, and share the
+same base poll/fetch helper. Provider authors normally customize shared resume
+behavior by overriding `poll()` / `fetch_output()`. Public `resume()` progress
+still emits `resumed`; automatic step retry resume emits `retry_resumed`.
 
 Each step-level retry logs its route at INFO (`route=resume` or
 `route=submit`) and records `genblaze.step_retry.route` /
-`genblaze.step_retry.resumed` span attributes. Upstream prediction IDs are not
-included in retry route logs.
+`genblaze.step_retry.resumed` span attributes. The route log includes `step_id`
+and `run_id` when available. Upstream prediction IDs are not included in retry
+route logs to keep logs concise, but Genblaze treats prediction IDs as
+observability identifiers rather than secrets. They remain available in
+`step.metadata["upstream_id"]`, `ProgressEvent.request_id`, and stream
+completion/failure event `request_id` fields for checkpointing and UI
+correlation.
 
 ## Idempotency keys
 

--- a/docs/features/retry-policy.md
+++ b/docs/features/retry-policy.md
@@ -55,11 +55,14 @@ There are two retry layers. Most users only need to think about the first.
    long-running video generation. The new policy controls **all of these**.
 2. **Step-level retries** (`config["max_retries"]` passed to `Pipeline.run()`)
    — retry the step after a phase-level budget is exhausted. If the failed
-   attempt already reached poll/fetch and has an upstream prediction ID, the
-   retry resumes that existing job instead of calling `submit()` again. Only
-   failures before an upstream ID exists use a fresh submit. The retryable-codes
-   set is now also taken from the policy, so tuning `RetryPolicy.retryable_codes`
-   affects both layers consistently.
+   attempt already produced an upstream prediction ID from the current
+   `submit()` call, the retry resumes that existing job instead of calling
+   `submit()` again. This also covers a transient `on_submit` checkpoint
+   failure after the upstream job was created. Caller-supplied
+   `step.metadata["upstream_id"]` is observability data and is not trusted as
+   retry authority. Only failures before a current upstream ID exists use a
+   fresh submit. The retryable-codes set is now also taken from the policy, so
+   tuning `RetryPolicy.retryable_codes` affects both layers consistently.
 
 Submit retries have a special rule: only **pre-response** exception types
 (httpx `ConnectError`, `ConnectTimeout`, `PoolTimeout`) are eligible by
@@ -67,10 +70,19 @@ default — replaying a request that may already have hit the server could
 double-bill. Once a provider opts into idempotency-key injection, this
 restriction is safe to widen via your own subclass.
 
-Fetch-phase failures have the opposite safety rule: the upstream generation
-already exists, so step-level retries call `resume(prediction_id, step, config)`
-and re-run poll/fetch against the same prediction. This avoids duplicate renders
-and duplicate charges when the transient error happened after generation started.
+Poll/fetch failures have the opposite safety rule: the upstream generation
+already exists, so step-level retries re-run the base poll/fetch resume loop
+against the same in-process prediction ID. This avoids duplicate renders and
+duplicate charges when the transient error happened after generation started.
+Internal step retries do not call provider overrides of the public `resume()`
+method; override `poll()` / `fetch_output()` for behavior shared by public
+resume and automatic retry resume. Public `resume()` progress still emits
+`resumed`; automatic step retry resume emits `retry_resumed`.
+
+Each step-level retry logs its route at INFO (`route=resume` or
+`route=submit`) and records `genblaze.step_retry.route` /
+`genblaze.step_retry.resumed` span attributes. Upstream prediction IDs are not
+included in retry route logs.
 
 ## Idempotency keys
 

--- a/docs/features/retry-policy.md
+++ b/docs/features/retry-policy.md
@@ -64,8 +64,10 @@ There are two retry layers. Most users only need to think about the first.
    given `(step_id, prediction_id)`. Caller-supplied
    `step.metadata["upstream_id"]` is observability data and is not trusted as
    retry authority. Only failures before a current upstream ID exists use a
-   fresh submit. The retryable-codes set is now also taken from the policy, so
-   tuning `RetryPolicy.retryable_codes` affects both layers consistently.
+   fresh submit. If `submit()` returns `None` or an empty prediction ID, the
+   step fails without polling, fetching, or trusting stale metadata. The
+   retryable-codes set is now also taken from the policy, so tuning
+   `RetryPolicy.retryable_codes` affects both layers consistently.
 
 Submit retries have a special rule: only **pre-response** exception types
 (httpx `ConnectError`, `ConnectTimeout`, `PoolTimeout`) are eligible by

--- a/docs/features/retry-policy.md
+++ b/docs/features/retry-policy.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-25 -->
+<!-- last_verified: 2026-06-17 -->
 # Retry Policy
 
 `RetryPolicy` is the user-tunable knob for how `BaseProvider` retries transient
@@ -54,15 +54,23 @@ There are two retry layers. Most users only need to think about the first.
    of `submit / poll / fetch_output` so a single 5xx mid-poll doesn't fail a
    long-running video generation. The new policy controls **all of these**.
 2. **Step-level retries** (`config["max_retries"]` passed to `Pipeline.run()`)
-   — restart the *whole* step from scratch (state reset, fresh prediction
-   ID). The retryable-codes set is now also taken from the policy, so tuning
-   `RetryPolicy.retryable_codes` affects both layers consistently.
+   — retry the step after a phase-level budget is exhausted. If the failed
+   attempt already reached poll/fetch and has an upstream prediction ID, the
+   retry resumes that existing job instead of calling `submit()` again. Only
+   failures before an upstream ID exists use a fresh submit. The retryable-codes
+   set is now also taken from the policy, so tuning `RetryPolicy.retryable_codes`
+   affects both layers consistently.
 
 Submit retries have a special rule: only **pre-response** exception types
 (httpx `ConnectError`, `ConnectTimeout`, `PoolTimeout`) are eligible by
 default — replaying a request that may already have hit the server could
 double-bill. Once a provider opts into idempotency-key injection, this
 restriction is safe to widen via your own subclass.
+
+Fetch-phase failures have the opposite safety rule: the upstream generation
+already exists, so step-level retries call `resume(prediction_id, step, config)`
+and re-run poll/fetch against the same prediction. This avoids duplicate renders
+and duplicate charges when the transient error happened after generation started.
 
 ## Idempotency keys
 

--- a/libs/core/genblaze_core/models/step.py
+++ b/libs/core/genblaze_core/models/step.py
@@ -23,6 +23,10 @@ from genblaze_core.models.enums import (
 # step types (everything else) MUST have a provider.
 _PROVIDERLESS_STEP_TYPES = frozenset({StepType.INGEST, StepType.IMPORT})
 
+# Metadata key used to surface provider prediction/job ids to progress and
+# streaming consumers. The value is observability data, not retry authority.
+UPSTREAM_ID_KEY = "upstream_id"
+
 
 class Step(BaseModel):
     """A single generation step within a run."""

--- a/libs/core/genblaze_core/observability/span.py
+++ b/libs/core/genblaze_core/observability/span.py
@@ -37,6 +37,8 @@ class StepSpan:
                 self._otel_span.set_attribute("genblaze.step_id", self.step_id)
             if self.run_id:
                 self._otel_span.set_attribute("genblaze.run_id", self.run_id)
+            for key, value in self.attributes.items():
+                self._otel_span.set_attribute(key, value)
         except ImportError:
             pass
         return self
@@ -55,6 +57,8 @@ class StepSpan:
                 self._otel_span.set_attribute("genblaze.retries", self.retries)
                 if self.cost is not None:
                     self._otel_span.set_attribute("genblaze.cost_usd", self.cost)
+                for key, value in self.attributes.items():
+                    self._otel_span.set_attribute(key, value)
                 # Record exception if one occurred
                 if exc_val is not None:
                     self._otel_span.record_exception(exc_val)
@@ -68,3 +72,12 @@ class StepSpan:
     @property
     def duration_ms(self) -> float:
         return (self.end_time - self.start_time) * 1000
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Record a span attribute locally and on the active OTel span."""
+        self.attributes[key] = value
+        if self._otel_span is not None:
+            try:
+                self._otel_span.set_attribute(key, value)
+            except Exception:  # noqa: S110
+                pass

--- a/libs/core/genblaze_core/observability/span.py
+++ b/libs/core/genblaze_core/observability/span.py
@@ -57,6 +57,9 @@ class StepSpan:
                 self._set_otel_attribute("genblaze.retries", self.retries)
                 if self.cost is not None:
                     self._set_otel_attribute("genblaze.cost_usd", self.cost)
+                # Safety net for attributes populated before the OTel span
+                # existed, or mutated directly by callers that already hold
+                # the span object. set_attribute() remains write-through.
                 for key, value in self.attributes.items():
                     self._set_otel_attribute(key, value)
                 # Record exception if one occurred

--- a/libs/core/genblaze_core/observability/span.py
+++ b/libs/core/genblaze_core/observability/span.py
@@ -34,9 +34,9 @@ class StepSpan:
             tracer = trace.get_tracer("genblaze")
             self._otel_span = tracer.start_span(self.name)
             if self.step_id:
-                self._otel_span.set_attribute("genblaze.step_id", self.step_id)
+                self._set_otel_attribute("genblaze.step_id", self.step_id)
             if self.run_id:
-                self._otel_span.set_attribute("genblaze.run_id", self.run_id)
+                self._set_otel_attribute("genblaze.run_id", self.run_id)
             for key, value in self.attributes.items():
                 self._set_otel_attribute(key, value)
         except ImportError:

--- a/libs/core/genblaze_core/observability/span.py
+++ b/libs/core/genblaze_core/observability/span.py
@@ -38,7 +38,7 @@ class StepSpan:
             if self.run_id:
                 self._otel_span.set_attribute("genblaze.run_id", self.run_id)
             for key, value in self.attributes.items():
-                self._otel_span.set_attribute(key, value)
+                self._set_otel_attribute(key, value)
         except ImportError:
             pass
         return self
@@ -53,21 +53,28 @@ class StepSpan:
         # End the OTel span with final attributes
         if self._otel_span is not None:
             try:
-                self._otel_span.set_attribute("genblaze.duration_ms", self.duration_ms)
-                self._otel_span.set_attribute("genblaze.retries", self.retries)
+                self._set_otel_attribute("genblaze.duration_ms", self.duration_ms)
+                self._set_otel_attribute("genblaze.retries", self.retries)
                 if self.cost is not None:
-                    self._otel_span.set_attribute("genblaze.cost_usd", self.cost)
+                    self._set_otel_attribute("genblaze.cost_usd", self.cost)
                 for key, value in self.attributes.items():
-                    self._otel_span.set_attribute(key, value)
+                    self._set_otel_attribute(key, value)
                 # Record exception if one occurred
                 if exc_val is not None:
-                    self._otel_span.record_exception(exc_val)
-                    from opentelemetry.trace import StatusCode
+                    try:
+                        self._otel_span.record_exception(exc_val)
+                        from opentelemetry.trace import StatusCode
 
-                    self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
-                self._otel_span.end()
+                        self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
+                    except Exception:  # noqa: S110
+                        pass
             except Exception:  # noqa: S110
                 pass
+            finally:
+                try:
+                    self._otel_span.end()
+                except Exception:  # noqa: S110
+                    pass
 
     @property
     def duration_ms(self) -> float:
@@ -76,6 +83,10 @@ class StepSpan:
     def set_attribute(self, key: str, value: Any) -> None:
         """Record a span attribute locally and on the active OTel span."""
         self.attributes[key] = value
+        self._set_otel_attribute(key, value)
+
+    def _set_otel_attribute(self, key: str, value: Any) -> None:
+        """Best-effort OTel attribute write; tracing must not break execution."""
         if self._otel_span is not None:
             try:
                 self._otel_span.set_attribute(key, value)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -1103,8 +1103,10 @@ class Pipeline(Runnable[None, PipelineResult]):
             or has_tracer
             or self._event_emitter is not None
         )
+        merged: RunnableConfig = RunnableConfig(**config) if config else RunnableConfig()
+        merged["run_id"] = run_id
         if not needs_install:
-            return config
+            return merged
 
         def _composite_progress(ev: Any) -> None:
             # User callback first so their side effects see the raw ProgressEvent
@@ -1117,7 +1119,6 @@ class Pipeline(Runnable[None, PipelineResult]):
             self._call_user_callback(user_on_retry, ev, "on_retry")
             self._emit_event(ev)
 
-        merged: RunnableConfig = RunnableConfig(**config) if config else RunnableConfig()
         merged["on_progress"] = _composite_progress
         merged["on_retry"] = _composite_retry
         return merged

--- a/libs/core/genblaze_core/pipeline/streaming.py
+++ b/libs/core/genblaze_core/pipeline/streaming.py
@@ -12,6 +12,7 @@ import asyncio
 import queue
 from typing import TYPE_CHECKING
 
+from genblaze_core.models.step import UPSTREAM_ID_KEY
 from genblaze_core.observability.events import (
     StepCompletedEvent,
     StepFailedEvent,
@@ -58,7 +59,7 @@ def step_complete_to_stream_event(ev: StepCompleteEvent, run_id: str | None = No
     step_status = str(ev.step.status)
     # Mirror the upstream prediction id onto the wire-format event so
     # consumers reading the JSON surface (no in-process Step) still see it.
-    request_id = ev.step.metadata.get("upstream_id")
+    request_id = ev.step.metadata.get(UPSTREAM_ID_KEY)
     if failed:
         return StepFailedEvent(
             run_id=run_id,

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -1588,6 +1588,8 @@ class BaseProvider(Runnable[Step, Step]):
         progress_status: str = "resumed",
     ) -> Step:
         """Resume polling an in-flight job, raising errors to the caller."""
+        # Keep this poll/fetch body aligned with _attempt_once() and the async
+        # twins below; the async copies differ only in to_thread/await plumbing.
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -1688,6 +1688,7 @@ class BaseProvider(Runnable[Step, Step]):
         progress_status: str = "resumed",
     ) -> Step:
         """Resume polling an in-flight job, raising errors to the caller."""
+        step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()
@@ -1735,6 +1736,7 @@ class BaseProvider(Runnable[Step, Step]):
         progress_status: str = "resumed",
     ) -> Step:
         """Async resume path that raises errors to the caller."""
+        step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -1520,6 +1520,62 @@ class BaseProvider(Runnable[Step, Step]):
         logger.warning("Resume failed: %s (code=%s)", step.error, step.error_code)
         return step
 
+    @staticmethod
+    def _step_retry_prediction_id(step: Step) -> Any | None:
+        """Return the upstream id when a step-level retry should resume.
+
+        The status guard keeps submit/pre-submit failures on the full re-submit
+        path. `_attempt_once()` only switches to PROCESSING after submit returned
+        an upstream id and the checkpoint callback completed.
+        """
+        if step.status != StepStatus.PROCESSING:
+            return None
+        return step.metadata.get("upstream_id")
+
+    def _resume_once(
+        self,
+        prediction_id: Any,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+    ) -> Step:
+        """Resume polling an in-flight job, raising errors to the caller."""
+        step.status = StepStatus.PROCESSING
+        if step.started_at is None:
+            step.started_at = utc_now()
+        self._fire_progress(step, config, "resumed", start_time)
+
+        while True:
+            done = self._retry_phase(
+                lambda: self.poll(prediction_id, config),
+                phase="poll",
+                step=step,
+                config=config,
+                start_time=start_time,
+                timeout=timeout,
+            )
+            if done:
+                break
+            elapsed = time.monotonic() - start_time
+            if elapsed >= timeout:
+                msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
+                raise ProviderError(msg)
+            self._fire_poll_progress(prediction_id, step, config, start_time)
+            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
+            self._sleep_with_heartbeats(interval, step, config, start_time)
+
+        step = self._retry_phase(
+            lambda: self.fetch_output(prediction_id, step),
+            phase="fetch",
+            step=step,
+            config=config,
+            start_time=start_time,
+            timeout=timeout,
+        )
+        self._apply_registry_pricing(step)
+        return self._finalize_resume_step(step, config, start_time)
+
     def resume(
         self,
         prediction_id: Any,
@@ -1536,43 +1592,54 @@ class BaseProvider(Runnable[Step, Step]):
         timeout = (config or {}).get("timeout", DEFAULT_TIMEOUT)
         start_time = time.monotonic()
 
+        try:
+            return self._resume_once(prediction_id, step, config, timeout, start_time)
+        except Exception as exc:
+            return self._handle_resume_error(step, exc, config, start_time)
+
+    async def _aresume_once(
+        self,
+        prediction_id: Any,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+    ) -> Step:
+        """Async resume path that raises errors to the caller."""
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()
         self._fire_progress(step, config, "resumed", start_time)
 
-        try:
-            while True:
-                done = self._retry_phase(
-                    lambda: self.poll(prediction_id, config),
-                    phase="poll",
-                    step=step,
-                    config=config,
-                    start_time=start_time,
-                    timeout=timeout,
-                )
-                if done:
-                    break
-                elapsed = time.monotonic() - start_time
-                if elapsed >= timeout:
-                    msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
-                    raise ProviderError(msg)
-                self._fire_poll_progress(prediction_id, step, config, start_time)
-                interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-                self._sleep_with_heartbeats(interval, step, config, start_time)
-
-            step = self._retry_phase(
-                lambda: self.fetch_output(prediction_id, step),
-                phase="fetch",
+        while True:
+            done = await self._aretry_phase(
+                lambda: asyncio.to_thread(self.poll, prediction_id, config),
+                phase="poll",
                 step=step,
                 config=config,
                 start_time=start_time,
                 timeout=timeout,
             )
-            self._apply_registry_pricing(step)
-            return self._finalize_resume_step(step, config, start_time)
-        except Exception as exc:
-            return self._handle_resume_error(step, exc, config, start_time)
+            if done:
+                break
+            elapsed = time.monotonic() - start_time
+            if elapsed >= timeout:
+                msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
+                raise ProviderError(msg)
+            self._fire_poll_progress(prediction_id, step, config, start_time)
+            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
+            await self._asleep_with_heartbeats(interval, step, config, start_time)
+
+        step = await self._aretry_phase(
+            lambda: asyncio.to_thread(self.fetch_output, prediction_id, step),
+            phase="fetch",
+            step=step,
+            config=config,
+            start_time=start_time,
+            timeout=timeout,
+        )
+        self._apply_registry_pricing(step)
+        return self._finalize_resume_step(step, config, start_time)
 
     async def aresume(
         self,
@@ -1588,41 +1655,8 @@ class BaseProvider(Runnable[Step, Step]):
         timeout = (config or {}).get("timeout", DEFAULT_TIMEOUT)
         start_time = time.monotonic()
 
-        step.status = StepStatus.PROCESSING
-        if step.started_at is None:
-            step.started_at = utc_now()
-        self._fire_progress(step, config, "resumed", start_time)
-
         try:
-            while True:
-                done = await self._aretry_phase(
-                    lambda: asyncio.to_thread(self.poll, prediction_id, config),
-                    phase="poll",
-                    step=step,
-                    config=config,
-                    start_time=start_time,
-                    timeout=timeout,
-                )
-                if done:
-                    break
-                elapsed = time.monotonic() - start_time
-                if elapsed >= timeout:
-                    msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
-                    raise ProviderError(msg)
-                self._fire_poll_progress(prediction_id, step, config, start_time)
-                interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-                await self._asleep_with_heartbeats(interval, step, config, start_time)
-
-            step = await self._aretry_phase(
-                lambda: asyncio.to_thread(self.fetch_output, prediction_id, step),
-                phase="fetch",
-                step=step,
-                config=config,
-                start_time=start_time,
-                timeout=timeout,
-            )
-            self._apply_registry_pricing(step)
-            return self._finalize_resume_step(step, config, start_time)
+            return await self._aresume_once(prediction_id, step, config, timeout, start_time)
         except Exception as exc:
             return self._handle_resume_error(step, exc, config, start_time)
 
@@ -1638,6 +1672,9 @@ class BaseProvider(Runnable[Step, Step]):
         with span:
             for attempt in range(max_retries + 1):
                 try:
+                    resume_prediction_id = (
+                        self._step_retry_prediction_id(step) if attempt > 0 else None
+                    )
                     if attempt > 0:
                         # Reset step state for retry
                         step.status = StepStatus.PENDING
@@ -1645,7 +1682,13 @@ class BaseProvider(Runnable[Step, Step]):
                         step.error_code = None
                         step.assets = []
 
-                    step = self._attempt_once(step, config, timeout, start_time)
+                    if resume_prediction_id is not None:
+                        logger.debug("Resuming %s prediction %s", self.name, resume_prediction_id)
+                        step = self._resume_once(
+                            resume_prediction_id, step, config, timeout, start_time
+                        )
+                    else:
+                        step = self._attempt_once(step, config, timeout, start_time)
                     span.retries = step.retries
                     # Copy cost from span to step if provider set it
                     if span.cost is not None:
@@ -1810,13 +1853,22 @@ class BaseProvider(Runnable[Step, Step]):
         with span:
             for attempt in range(max_retries + 1):
                 try:
+                    resume_prediction_id = (
+                        self._step_retry_prediction_id(step) if attempt > 0 else None
+                    )
                     if attempt > 0:
                         step.status = StepStatus.PENDING
                         step.error = None
                         step.error_code = None
                         step.assets = []
 
-                    step = await self._attempt_once_async(step, config, timeout, start_time)
+                    if resume_prediction_id is not None:
+                        logger.debug("Resuming %s prediction %s", self.name, resume_prediction_id)
+                        step = await self._aresume_once(
+                            resume_prediction_id, step, config, timeout, start_time
+                        )
+                    else:
+                        step = await self._attempt_once_async(step, config, timeout, start_time)
                     span.retries = step.retries
                     if span.cost is not None:
                         step.cost_usd = span.cost

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -24,7 +24,7 @@ from genblaze_core.models.enums import (
     ProviderErrorCode,
     StepStatus,
 )
-from genblaze_core.models.step import Step
+from genblaze_core.models.step import UPSTREAM_ID_KEY, Step
 from genblaze_core.observability.span import StepSpan
 from genblaze_core.providers.discovery import DiscoveryResult
 from genblaze_core.providers.family import (
@@ -104,6 +104,27 @@ class SubmitResult:
 
     prediction_id: Any
     estimated_seconds: float | None = field(default=None)
+
+
+_NO_PREDICTION = object()
+
+
+@dataclass
+class _StepRetryState:
+    """Per-invocation authority for post-submit step retries."""
+
+    prediction_id: Any = field(default=_NO_PREDICTION)
+
+    @property
+    def can_resume(self) -> bool:
+        return self.prediction_id is not _NO_PREDICTION
+
+    def clear(self) -> None:
+        self.prediction_id = _NO_PREDICTION
+
+    def record_submit(self, prediction_id: Any) -> None:
+        if prediction_id is not None:
+            self.prediction_id = prediction_id
 
 
 def _adaptive_poll_interval(elapsed: float, base: float, max_interval: float = 30.0) -> float:
@@ -1078,7 +1099,7 @@ class BaseProvider(Runnable[Step, Step]):
                     # it on the step. Pre-submit ticks ("submitted" status
                     # fired before submit returns) carry None — that's
                     # accurate, the id doesn't exist yet.
-                    request_id=step.metadata.get("upstream_id"),
+                    request_id=step.metadata.get(UPSTREAM_ID_KEY),
                     is_heartbeat=is_heartbeat,
                 )
             )
@@ -1399,11 +1420,19 @@ class BaseProvider(Runnable[Step, Step]):
             await asyncio.to_thread(self._run_preflight_once)
 
     def _attempt_once(
-        self, step: Step, config: RunnableConfig | None, timeout: float, start_time: float
+        self,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+        retry_state: _StepRetryState | None = None,
     ) -> Step:
         """Execute a single submit→poll→fetch attempt with adaptive polling."""
         self._cleanup_poll_cache()
         self._run_preflight_once()
+        step.metadata.pop(UPSTREAM_ID_KEY, None)
+        if retry_state is not None:
+            retry_state.clear()
         step.started_at = utc_now()
         step.status = StepStatus.SUBMITTED
         self._fire_progress(step, config, "submitted", start_time)
@@ -1431,7 +1460,9 @@ class BaseProvider(Runnable[Step, Step]):
         # request_id field) can surface the upstream id. Stored under
         # metadata to keep it out of the canonical manifest hash payload.
         if prediction_id is not None:
-            step.metadata["upstream_id"] = str(prediction_id)
+            step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
+            if retry_state is not None:
+                retry_state.record_submit(prediction_id)
 
         # Fire checkpoint callback so callers can persist prediction_id before polling
         on_submit = (config or {}).get("on_submit")
@@ -1521,16 +1552,31 @@ class BaseProvider(Runnable[Step, Step]):
         return step
 
     @staticmethod
-    def _step_retry_prediction_id(step: Step) -> Any | None:
-        """Return the upstream id when a step-level retry should resume.
-
-        The status guard keeps submit/pre-submit failures on the full re-submit
-        path. `_attempt_once()` only switches to PROCESSING after submit returned
-        an upstream id and the checkpoint callback completed.
-        """
-        if step.status != StepStatus.PROCESSING:
+    def _step_retry_prediction_id(retry_state: _StepRetryState) -> Any | None:
+        """Return the trusted upstream id when a step-level retry should resume."""
+        if not retry_state.can_resume:
             return None
-        return step.metadata.get("upstream_id")
+        return retry_state.prediction_id
+
+    def _record_step_retry_route(
+        self,
+        span: StepSpan,
+        *,
+        attempt: int,
+        max_retries: int,
+        resumed: bool,
+    ) -> None:
+        """Record whether a step-level retry resumed or re-submitted."""
+        route = "resume" if resumed else "submit"
+        span.set_attribute("genblaze.step_retry.route", route)
+        span.set_attribute("genblaze.step_retry.resumed", resumed)
+        logger.info(
+            "Step retry %d/%d for %s route=%s",
+            attempt,
+            max_retries,
+            span.name,
+            route,
+        )
 
     def _resume_once(
         self,
@@ -1539,12 +1585,13 @@ class BaseProvider(Runnable[Step, Step]):
         config: RunnableConfig | None,
         timeout: float,
         start_time: float,
+        progress_status: str = "resumed",
     ) -> Step:
         """Resume polling an in-flight job, raising errors to the caller."""
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()
-        self._fire_progress(step, config, "resumed", start_time)
+        self._fire_progress(step, config, progress_status, start_time)
 
         while True:
             done = self._retry_phase(
@@ -1604,12 +1651,13 @@ class BaseProvider(Runnable[Step, Step]):
         config: RunnableConfig | None,
         timeout: float,
         start_time: float,
+        progress_status: str = "resumed",
     ) -> Step:
         """Async resume path that raises errors to the caller."""
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()
-        self._fire_progress(step, config, "resumed", start_time)
+        self._fire_progress(step, config, progress_status, start_time)
 
         while True:
             done = await self._aretry_phase(
@@ -1668,12 +1716,13 @@ class BaseProvider(Runnable[Step, Step]):
         start_time = time.monotonic()
 
         span = StepSpan(name=f"{self.name}/{step.model}", step_id=step.step_id)
+        retry_state = _StepRetryState()
 
         with span:
             for attempt in range(max_retries + 1):
                 try:
                     resume_prediction_id = (
-                        self._step_retry_prediction_id(step) if attempt > 0 else None
+                        self._step_retry_prediction_id(retry_state) if attempt > 0 else None
                     )
                     if attempt > 0:
                         # Reset step state for retry
@@ -1681,14 +1730,24 @@ class BaseProvider(Runnable[Step, Step]):
                         step.error = None
                         step.error_code = None
                         step.assets = []
+                        self._record_step_retry_route(
+                            span,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            resumed=resume_prediction_id is not None,
+                        )
 
                     if resume_prediction_id is not None:
-                        logger.debug("Resuming %s prediction %s", self.name, resume_prediction_id)
                         step = self._resume_once(
-                            resume_prediction_id, step, config, timeout, start_time
+                            resume_prediction_id,
+                            step,
+                            config,
+                            timeout,
+                            start_time,
+                            "retry_resumed",
                         )
                     else:
-                        step = self._attempt_once(step, config, timeout, start_time)
+                        step = self._attempt_once(step, config, timeout, start_time, retry_state)
                     span.retries = step.retries
                     # Copy cost from span to step if provider set it
                     if span.cost is not None:
@@ -1748,7 +1807,12 @@ class BaseProvider(Runnable[Step, Step]):
         return step  # pragma: no cover
 
     async def _attempt_once_async(
-        self, step: Step, config: RunnableConfig | None, timeout: float, start_time: float
+        self,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+        retry_state: _StepRetryState | None = None,
     ) -> Step:
         """Execute a single submit→poll→fetch attempt without blocking the event loop."""
         self._cleanup_poll_cache()
@@ -1762,6 +1826,9 @@ class BaseProvider(Runnable[Step, Step]):
                 # Custom preflight does I/O; the locked async runner ensures
                 # concurrent coroutines on the same loop only invoke it once.
                 await self._arun_preflight_once()
+        step.metadata.pop(UPSTREAM_ID_KEY, None)
+        if retry_state is not None:
+            retry_state.clear()
         step.started_at = utc_now()
         step.status = StepStatus.SUBMITTED
         self._fire_progress(step, config, "submitted", start_time)
@@ -1789,7 +1856,9 @@ class BaseProvider(Runnable[Step, Step]):
         # request_id field) can surface the upstream id. Stored under
         # metadata to keep it out of the canonical manifest hash payload.
         if prediction_id is not None:
-            step.metadata["upstream_id"] = str(prediction_id)
+            step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
+            if retry_state is not None:
+                retry_state.record_submit(prediction_id)
 
         # Fire checkpoint callback so callers can persist prediction_id before polling
         on_submit = (config or {}).get("on_submit")
@@ -1849,26 +1918,39 @@ class BaseProvider(Runnable[Step, Step]):
         start_time = time.monotonic()
 
         span = StepSpan(name=f"{self.name}/{step.model}", step_id=step.step_id)
+        retry_state = _StepRetryState()
 
         with span:
             for attempt in range(max_retries + 1):
                 try:
                     resume_prediction_id = (
-                        self._step_retry_prediction_id(step) if attempt > 0 else None
+                        self._step_retry_prediction_id(retry_state) if attempt > 0 else None
                     )
                     if attempt > 0:
                         step.status = StepStatus.PENDING
                         step.error = None
                         step.error_code = None
                         step.assets = []
+                        self._record_step_retry_route(
+                            span,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            resumed=resume_prediction_id is not None,
+                        )
 
                     if resume_prediction_id is not None:
-                        logger.debug("Resuming %s prediction %s", self.name, resume_prediction_id)
                         step = await self._aresume_once(
-                            resume_prediction_id, step, config, timeout, start_time
+                            resume_prediction_id,
+                            step,
+                            config,
+                            timeout,
+                            start_time,
+                            "retry_resumed",
                         )
                     else:
-                        step = await self._attempt_once_async(step, config, timeout, start_time)
+                        step = await self._attempt_once_async(
+                            step, config, timeout, start_time, retry_state
+                        )
                     span.retries = step.retries
                     if span.cost is not None:
                         step.cost_usd = span.cost

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -113,10 +113,6 @@ class _StepRetryState:
     prediction_id: Any | None = None
     resume_failures: int = 0
 
-    @property
-    def resume_prediction_id(self) -> Any | None:
-        return self.prediction_id
-
     def clear(self) -> None:
         self.prediction_id = None
         self.resume_failures = 0
@@ -1433,6 +1429,25 @@ class BaseProvider(Runnable[Step, Step]):
         if on_submit is not None:
             on_submit(step.step_id, prediction_id)
 
+    def _require_prediction_id(self, prediction_id: Any) -> Any:
+        """Reject submit results that cannot identify an upstream job."""
+        if prediction_id is None:
+            raise ProviderError(
+                "submit() returned no upstream prediction id",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        if isinstance(prediction_id, str) and prediction_id == "":
+            raise ProviderError(
+                "submit() returned an empty upstream prediction id",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        if isinstance(prediction_id, (bytes, bytearray)) and len(prediction_id) == 0:
+            raise ProviderError(
+                "submit() returned an empty upstream prediction id",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        return prediction_id
+
     def _poll_fetch_once(
         self,
         prediction_id: Any,
@@ -1554,13 +1569,14 @@ class BaseProvider(Runnable[Step, Step]):
             prediction_id = raw
             estimated_seconds = None
 
+        prediction_id = self._require_prediction_id(prediction_id)
+
         # Stash on the step so subsequent progress events (and the wire-side
         # request_id field) can surface the upstream id. Stored under
         # metadata to keep it out of the canonical manifest hash payload.
-        if prediction_id is not None:
-            step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
-            if retry_state is not None:
-                retry_state.record_submit(prediction_id)
+        step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
+        if retry_state is not None:
+            retry_state.record_submit(prediction_id)
 
         self._checkpoint_submit(step, config, prediction_id)
 
@@ -1768,11 +1784,11 @@ class BaseProvider(Runnable[Step, Step]):
         retry_state = _StepRetryState()
 
         with span:
+            # Keep the retry route decision aligned with ainvoke(); only the
+            # fresh-attempt and resume helpers differ by await plumbing.
             for attempt in range(max_retries + 1):
                 try:
-                    resume_prediction_id = (
-                        retry_state.resume_prediction_id if attempt > 0 else None
-                    )
+                    resume_prediction_id = retry_state.prediction_id if attempt > 0 else None
                     if attempt > 0:
                         # Reset step state for retry
                         step.status = StepStatus.PENDING
@@ -1909,13 +1925,14 @@ class BaseProvider(Runnable[Step, Step]):
             prediction_id = raw
             estimated_seconds = None
 
+        prediction_id = self._require_prediction_id(prediction_id)
+
         # Stash on the step so subsequent progress events (and the wire-side
         # request_id field) can surface the upstream id. Stored under
         # metadata to keep it out of the canonical manifest hash payload.
-        if prediction_id is not None:
-            step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
-            if retry_state is not None:
-                retry_state.record_submit(prediction_id)
+        step.metadata[UPSTREAM_ID_KEY] = str(prediction_id)
+        if retry_state is not None:
+            retry_state.record_submit(prediction_id)
 
         self._checkpoint_submit(step, config, prediction_id)
 
@@ -1953,11 +1970,11 @@ class BaseProvider(Runnable[Step, Step]):
         retry_state = _StepRetryState()
 
         with span:
+            # Keep the retry route decision aligned with invoke(); only the
+            # fresh-attempt and resume helpers differ by await plumbing.
             for attempt in range(max_retries + 1):
                 try:
-                    resume_prediction_id = (
-                        retry_state.resume_prediction_id if attempt > 0 else None
-                    )
+                    resume_prediction_id = retry_state.prediction_id if attempt > 0 else None
                     if attempt > 0:
                         step.status = StepStatus.PENDING
                         step.error = None

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -106,25 +106,28 @@ class SubmitResult:
     estimated_seconds: float | None = field(default=None)
 
 
-_NO_PREDICTION = object()
-
-
 @dataclass
 class _StepRetryState:
     """Per-invocation authority for post-submit step retries."""
 
-    prediction_id: Any = field(default=_NO_PREDICTION)
+    prediction_id: Any | None = None
+    resume_failures: int = 0
 
     @property
-    def can_resume(self) -> bool:
-        return self.prediction_id is not _NO_PREDICTION
+    def resume_prediction_id(self) -> Any | None:
+        return self.prediction_id
 
     def clear(self) -> None:
-        self.prediction_id = _NO_PREDICTION
+        self.prediction_id = None
+        self.resume_failures = 0
 
     def record_submit(self, prediction_id: Any) -> None:
         if prediction_id is not None:
             self.prediction_id = prediction_id
+            self.resume_failures = 0
+
+    def record_resume_failure(self) -> None:
+        self.resume_failures += 1
 
 
 def _adaptive_poll_interval(elapsed: float, base: float, max_interval: float = 30.0) -> float:
@@ -1419,6 +1422,101 @@ class BaseProvider(Runnable[Step, Step]):
                 return
             await asyncio.to_thread(self._run_preflight_once)
 
+    def _checkpoint_submit(
+        self,
+        step: Step,
+        config: RunnableConfig | None,
+        prediction_id: Any,
+    ) -> None:
+        """Fire the submit checkpoint callback before polling an upstream job."""
+        on_submit = (config or {}).get("on_submit")
+        if on_submit is not None:
+            on_submit(step.step_id, prediction_id)
+
+    def _poll_fetch_once(
+        self,
+        prediction_id: Any,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+        *,
+        timeout_label: str = "Poll",
+    ) -> Step:
+        """Run the shared sync poll-until-done loop and fetch the result."""
+        while True:
+            done = self._retry_phase(
+                lambda: self.poll(prediction_id, config),
+                phase="poll",
+                step=step,
+                config=config,
+                start_time=start_time,
+                timeout=timeout,
+            )
+            if done:
+                break
+            elapsed = time.monotonic() - start_time
+            if elapsed >= timeout:
+                raise ProviderError(
+                    f"{timeout_label} timeout after {elapsed:.1f}s (limit: {timeout}s)"
+                )
+            self._fire_poll_progress(prediction_id, step, config, start_time)
+            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
+            self._sleep_with_heartbeats(interval, step, config, start_time)
+
+        step = self._retry_phase(
+            lambda: self.fetch_output(prediction_id, step),
+            phase="fetch",
+            step=step,
+            config=config,
+            start_time=start_time,
+            timeout=timeout,
+        )
+        self._apply_registry_pricing(step)
+        return step
+
+    async def _apoll_fetch_once(
+        self,
+        prediction_id: Any,
+        step: Step,
+        config: RunnableConfig | None,
+        timeout: float,
+        start_time: float,
+        *,
+        timeout_label: str = "Poll",
+    ) -> Step:
+        """Run the shared async poll-until-done loop and fetch the result."""
+        while True:
+            done = await self._aretry_phase(
+                lambda: asyncio.to_thread(self.poll, prediction_id, config),
+                phase="poll",
+                step=step,
+                config=config,
+                start_time=start_time,
+                timeout=timeout,
+            )
+            if done:
+                break
+            elapsed = time.monotonic() - start_time
+            if elapsed >= timeout:
+                raise ProviderError(
+                    f"{timeout_label} timeout after {elapsed:.1f}s (limit: {timeout}s)"
+                )
+            self._fire_poll_progress(prediction_id, step, config, start_time)
+            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
+            await self._asleep_with_heartbeats(interval, step, config, start_time)
+
+        step = await self._aretry_phase(
+            lambda: asyncio.to_thread(self.fetch_output, prediction_id, step),
+            phase="fetch",
+            step=step,
+            config=config,
+            start_time=start_time,
+            timeout=timeout,
+        )
+        self._apply_registry_pricing(step)
+        return step
+
     def _attempt_once(
         self,
         step: Step,
@@ -1464,10 +1562,7 @@ class BaseProvider(Runnable[Step, Step]):
             if retry_state is not None:
                 retry_state.record_submit(prediction_id)
 
-        # Fire checkpoint callback so callers can persist prediction_id before polling
-        on_submit = (config or {}).get("on_submit")
-        if on_submit is not None:
-            on_submit(step.step_id, prediction_id)
+        self._checkpoint_submit(step, config, prediction_id)
 
         step.status = StepStatus.PROCESSING
 
@@ -1480,33 +1575,7 @@ class BaseProvider(Runnable[Step, Step]):
             if initial_delay > 0:
                 time.sleep(initial_delay)
 
-        while True:
-            done = self._retry_phase(
-                lambda: self.poll(prediction_id, config),
-                phase="poll",
-                step=step,
-                config=config,
-                start_time=start_time,
-                timeout=timeout,
-            )
-            if done:
-                break
-            elapsed = time.monotonic() - start_time
-            if elapsed >= timeout:
-                raise ProviderError(f"Poll timeout after {elapsed:.1f}s (limit: {timeout}s)")
-            self._fire_poll_progress(prediction_id, step, config, start_time)
-            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-            self._sleep_with_heartbeats(interval, step, config, start_time)
-
-        step = self._retry_phase(
-            lambda: self.fetch_output(prediction_id, step),
-            phase="fetch",
-            step=step,
-            config=config,
-            start_time=start_time,
-            timeout=timeout,
-        )
-        self._apply_registry_pricing(step)
+        step = self._poll_fetch_once(prediction_id, step, config, timeout, start_time)
         # Only mark succeeded if fetch_output didn't signal failure
         if step.status != StepStatus.FAILED:
             step.status = StepStatus.SUCCEEDED
@@ -1551,13 +1620,6 @@ class BaseProvider(Runnable[Step, Step]):
         logger.warning("Resume failed: %s (code=%s)", step.error, step.error_code)
         return step
 
-    @staticmethod
-    def _step_retry_prediction_id(retry_state: _StepRetryState) -> Any | None:
-        """Return the trusted upstream id when a step-level retry should resume."""
-        if not retry_state.can_resume:
-            return None
-        return retry_state.prediction_id
-
     def _record_step_retry_route(
         self,
         span: StepSpan,
@@ -1571,11 +1633,32 @@ class BaseProvider(Runnable[Step, Step]):
         span.set_attribute("genblaze.step_retry.route", route)
         span.set_attribute("genblaze.step_retry.resumed", resumed)
         logger.info(
-            "Step retry %d/%d for %s route=%s",
+            "Step retry %d/%d for %s step_id=%s run_id=%s route=%s",
             attempt,
             max_retries,
             span.name,
+            span.step_id,
+            span.run_id,
             route,
+        )
+
+    def _record_resume_budget_exhausted(
+        self,
+        span: StepSpan,
+        retry_state: _StepRetryState,
+    ) -> None:
+        """Record that retry budget ended while bound to an existing prediction."""
+        if retry_state.resume_failures == 0:
+            return
+        span.set_attribute("genblaze.step_retry.resume_exhausted", True)
+        span.set_attribute("genblaze.step_retry.resume_failures", retry_state.resume_failures)
+        logger.warning(
+            "Resume retry budget exhausted for %s step_id=%s run_id=%s "
+            "resume_failures=%d no_resubmit=true",
+            span.name,
+            span.step_id,
+            span.run_id,
+            retry_state.resume_failures,
         )
 
     def _resume_once(
@@ -1585,44 +1668,23 @@ class BaseProvider(Runnable[Step, Step]):
         config: RunnableConfig | None,
         timeout: float,
         start_time: float,
+        *,
         progress_status: str = "resumed",
     ) -> Step:
         """Resume polling an in-flight job, raising errors to the caller."""
-        # Keep this poll/fetch body aligned with _attempt_once() and the async
-        # twins below; the async copies differ only in to_thread/await plumbing.
         step.status = StepStatus.PROCESSING
         if step.started_at is None:
             step.started_at = utc_now()
         self._fire_progress(step, config, progress_status, start_time)
 
-        while True:
-            done = self._retry_phase(
-                lambda: self.poll(prediction_id, config),
-                phase="poll",
-                step=step,
-                config=config,
-                start_time=start_time,
-                timeout=timeout,
-            )
-            if done:
-                break
-            elapsed = time.monotonic() - start_time
-            if elapsed >= timeout:
-                msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
-                raise ProviderError(msg)
-            self._fire_poll_progress(prediction_id, step, config, start_time)
-            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-            self._sleep_with_heartbeats(interval, step, config, start_time)
-
-        step = self._retry_phase(
-            lambda: self.fetch_output(prediction_id, step),
-            phase="fetch",
-            step=step,
-            config=config,
-            start_time=start_time,
-            timeout=timeout,
+        step = self._poll_fetch_once(
+            prediction_id,
+            step,
+            config,
+            timeout,
+            start_time,
+            timeout_label="Resume poll",
         )
-        self._apply_registry_pricing(step)
         return self._finalize_resume_step(step, config, start_time)
 
     def resume(
@@ -1653,6 +1715,7 @@ class BaseProvider(Runnable[Step, Step]):
         config: RunnableConfig | None,
         timeout: float,
         start_time: float,
+        *,
         progress_status: str = "resumed",
     ) -> Step:
         """Async resume path that raises errors to the caller."""
@@ -1661,34 +1724,14 @@ class BaseProvider(Runnable[Step, Step]):
             step.started_at = utc_now()
         self._fire_progress(step, config, progress_status, start_time)
 
-        while True:
-            done = await self._aretry_phase(
-                lambda: asyncio.to_thread(self.poll, prediction_id, config),
-                phase="poll",
-                step=step,
-                config=config,
-                start_time=start_time,
-                timeout=timeout,
-            )
-            if done:
-                break
-            elapsed = time.monotonic() - start_time
-            if elapsed >= timeout:
-                msg = f"Resume poll timeout after {elapsed:.1f}s (limit: {timeout}s)"
-                raise ProviderError(msg)
-            self._fire_poll_progress(prediction_id, step, config, start_time)
-            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-            await self._asleep_with_heartbeats(interval, step, config, start_time)
-
-        step = await self._aretry_phase(
-            lambda: asyncio.to_thread(self.fetch_output, prediction_id, step),
-            phase="fetch",
-            step=step,
-            config=config,
-            start_time=start_time,
-            timeout=timeout,
+        step = await self._apoll_fetch_once(
+            prediction_id,
+            step,
+            config,
+            timeout,
+            start_time,
+            timeout_label="Resume poll",
         )
-        self._apply_registry_pricing(step)
         return self._finalize_resume_step(step, config, start_time)
 
     async def aresume(
@@ -1717,14 +1760,18 @@ class BaseProvider(Runnable[Step, Step]):
         max_retries = (config or {}).get("max_retries", 0)
         start_time = time.monotonic()
 
-        span = StepSpan(name=f"{self.name}/{step.model}", step_id=step.step_id)
+        span = StepSpan(
+            name=f"{self.name}/{step.model}",
+            run_id=(config or {}).get("run_id"),
+            step_id=step.step_id,
+        )
         retry_state = _StepRetryState()
 
         with span:
             for attempt in range(max_retries + 1):
                 try:
                     resume_prediction_id = (
-                        self._step_retry_prediction_id(retry_state) if attempt > 0 else None
+                        retry_state.resume_prediction_id if attempt > 0 else None
                     )
                     if attempt > 0:
                         # Reset step state for retry
@@ -1740,13 +1787,14 @@ class BaseProvider(Runnable[Step, Step]):
                         )
 
                     if resume_prediction_id is not None:
+                        self._checkpoint_submit(step, config, resume_prediction_id)
                         step = self._resume_once(
                             resume_prediction_id,
                             step,
                             config,
                             timeout,
                             start_time,
-                            "retry_resumed",
+                            progress_status="retry_resumed",
                         )
                     else:
                         step = self._attempt_once(step, config, timeout, start_time, retry_state)
@@ -1762,6 +1810,8 @@ class BaseProvider(Runnable[Step, Step]):
                         if isinstance(exc, ProviderError) and exc.error_code is not None
                         else classify_api_error(exc)
                     )
+                    if resume_prediction_id is not None:
+                        retry_state.record_resume_failure()
 
                     # Step-level retry: budget from config.max_retries (caller-driven),
                     # retryable codes from the unified RetryPolicy so users tune one knob.
@@ -1773,6 +1823,7 @@ class BaseProvider(Runnable[Step, Step]):
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
                         logger.warning("Step failed: %s (code=%s)", step.error, step.error_code)
+                        self._record_resume_budget_exhausted(span, retry_state)
                         span.retries = step.retries
                         return step
 
@@ -1784,9 +1835,12 @@ class BaseProvider(Runnable[Step, Step]):
                     )
                     backoff = self.retry_policy.compute_delay(attempt + 1, retry_after=retry_after)
                     logger.info(
-                        "Retry %d/%d after %s (backoff=%.1fs)",
+                        "Retry %d/%d for %s step_id=%s run_id=%s after %s (backoff=%.1fs)",
                         attempt + 1,
                         max_retries,
+                        span.name,
+                        span.step_id,
+                        span.run_id,
                         error_code,
                         backoff,
                     )
@@ -1800,6 +1854,7 @@ class BaseProvider(Runnable[Step, Step]):
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
                         logger.warning("Retry aborted: global timeout would be exceeded")
+                        self._record_resume_budget_exhausted(span, retry_state)
                         span.retries = step.retries
                         return step
 
@@ -1862,10 +1917,7 @@ class BaseProvider(Runnable[Step, Step]):
             if retry_state is not None:
                 retry_state.record_submit(prediction_id)
 
-        # Fire checkpoint callback so callers can persist prediction_id before polling
-        on_submit = (config or {}).get("on_submit")
-        if on_submit is not None:
-            on_submit(step.step_id, prediction_id)
+        self._checkpoint_submit(step, config, prediction_id)
 
         step.status = StepStatus.PROCESSING
 
@@ -1878,33 +1930,7 @@ class BaseProvider(Runnable[Step, Step]):
             if initial_delay > 0:
                 await asyncio.sleep(initial_delay)
 
-        while True:
-            done = await self._aretry_phase(
-                lambda: asyncio.to_thread(self.poll, prediction_id, config),
-                phase="poll",
-                step=step,
-                config=config,
-                start_time=start_time,
-                timeout=timeout,
-            )
-            if done:
-                break
-            elapsed = time.monotonic() - start_time
-            if elapsed >= timeout:
-                raise ProviderError(f"Poll timeout after {elapsed:.1f}s (limit: {timeout}s)")
-            self._fire_poll_progress(prediction_id, step, config, start_time)
-            interval = _adaptive_poll_interval(elapsed, self.poll_interval)
-            await self._asleep_with_heartbeats(interval, step, config, start_time)
-
-        step = await self._aretry_phase(
-            lambda: asyncio.to_thread(self.fetch_output, prediction_id, step),
-            phase="fetch",
-            step=step,
-            config=config,
-            start_time=start_time,
-            timeout=timeout,
-        )
-        self._apply_registry_pricing(step)
+        step = await self._apoll_fetch_once(prediction_id, step, config, timeout, start_time)
         if step.status != StepStatus.FAILED:
             step.status = StepStatus.SUCCEEDED
             step.completed_at = utc_now()
@@ -1919,14 +1945,18 @@ class BaseProvider(Runnable[Step, Step]):
         max_retries = (config or {}).get("max_retries", 0)
         start_time = time.monotonic()
 
-        span = StepSpan(name=f"{self.name}/{step.model}", step_id=step.step_id)
+        span = StepSpan(
+            name=f"{self.name}/{step.model}",
+            run_id=(config or {}).get("run_id"),
+            step_id=step.step_id,
+        )
         retry_state = _StepRetryState()
 
         with span:
             for attempt in range(max_retries + 1):
                 try:
                     resume_prediction_id = (
-                        self._step_retry_prediction_id(retry_state) if attempt > 0 else None
+                        retry_state.resume_prediction_id if attempt > 0 else None
                     )
                     if attempt > 0:
                         step.status = StepStatus.PENDING
@@ -1941,13 +1971,14 @@ class BaseProvider(Runnable[Step, Step]):
                         )
 
                     if resume_prediction_id is not None:
+                        self._checkpoint_submit(step, config, resume_prediction_id)
                         step = await self._aresume_once(
                             resume_prediction_id,
                             step,
                             config,
                             timeout,
                             start_time,
-                            "retry_resumed",
+                            progress_status="retry_resumed",
                         )
                     else:
                         step = await self._attempt_once_async(
@@ -1964,6 +1995,8 @@ class BaseProvider(Runnable[Step, Step]):
                         if isinstance(exc, ProviderError) and exc.error_code is not None
                         else classify_api_error(exc)
                     )
+                    if resume_prediction_id is not None:
+                        retry_state.record_resume_failure()
 
                     retryable = error_code in self.retry_policy.retryable_codes
                     if not retryable or attempt >= max_retries:
@@ -1973,6 +2006,7 @@ class BaseProvider(Runnable[Step, Step]):
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
                         logger.warning("Step failed: %s (code=%s)", step.error, step.error_code)
+                        self._record_resume_budget_exhausted(span, retry_state)
                         span.retries = step.retries
                         return step
 
@@ -1984,9 +2018,12 @@ class BaseProvider(Runnable[Step, Step]):
                     )
                     backoff = self.retry_policy.compute_delay(attempt + 1, retry_after=retry_after)
                     logger.info(
-                        "Retry %d/%d after %s (backoff=%.1fs)",
+                        "Retry %d/%d for %s step_id=%s run_id=%s after %s (backoff=%.1fs)",
                         attempt + 1,
                         max_retries,
+                        span.name,
+                        span.step_id,
+                        span.run_id,
                         error_code,
                         backoff,
                     )
@@ -1999,6 +2036,7 @@ class BaseProvider(Runnable[Step, Step]):
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
                         logger.warning("Retry aborted: global timeout would be exceeded")
+                        self._record_resume_budget_exhausted(span, retry_state)
                         span.retries = step.retries
                         return step
 

--- a/libs/core/genblaze_core/providers/progress.py
+++ b/libs/core/genblaze_core/providers/progress.py
@@ -13,7 +13,8 @@ class ProgressEvent:
         step_id: ID of the step being executed.
         provider: Provider name (e.g. "runway", "luma").
         model: Model identifier.
-        status: Current status — "submitted", "processing", "succeeded", "failed".
+        status: Current status — "submitted", "processing", "resumed",
+            "retry_resumed", "succeeded", "failed".
         progress_pct: 0.0–1.0 if the provider reports progress, else None.
         elapsed_sec: Seconds elapsed since step start.
         message: Optional human-readable status message.

--- a/libs/core/tests/unit/test_moderation.py
+++ b/libs/core/tests/unit/test_moderation.py
@@ -212,6 +212,36 @@ class TestPreStepModeration:
         assert len(hook.prompt_calls) == 1
         assert hook.prompt_calls[0][0] == "blocked user text"
 
+    def test_url_borne_and_non_text_metadata_inputs_are_not_pre_moderated(self):
+        hook = RejectContainingHook("blocked user text")
+        provider = MockProvider()
+        text_asset = Asset(
+            url="https://input.test/blocked-user-text.txt",
+            media_type="text/plain",
+            metadata={"caption": "blocked user text"},
+        )
+        result = (
+            Pipeline("test", moderation=hook)
+            .step(
+                provider,
+                model="m",
+                prompt=None,
+                modality=Modality.IMAGE,
+                external_inputs=[text_asset],
+            )
+            .run()
+        )
+
+        assert provider.call_count == 1
+        assert result.run.steps[0].status == StepStatus.SUCCEEDED
+        assert len(hook.prompt_calls) == 0
+        assert (
+            _pre_moderation_payload(
+                Step(provider="mock", model="m", prompt=None, inputs=[text_asset])
+            )
+            is None
+        )
+
     def test_prompt_and_input_text_combined_into_single_payload(self):
         hook = TrackingHook()
         provider = MockProvider()

--- a/libs/core/tests/unit/test_observability.py
+++ b/libs/core/tests/unit/test_observability.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
+import types
 from typing import Any
 
 from genblaze_core.models.asset import Asset
@@ -32,6 +34,43 @@ class MockProvider(BaseProvider):
         return step
 
 
+class _FailingAttributeSpan:
+    """Fake OTel span that can reject selected attributes."""
+
+    def __init__(self, fail_keys: set[str]) -> None:
+        self.fail_keys = fail_keys
+        self.attributes: dict[str, Any] = {}
+        self.ended = False
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        if key in self.fail_keys:
+            raise TypeError(f"unsupported attribute {key}")
+        self.attributes[key] = value
+
+    def record_exception(self, exc: BaseException) -> None:
+        self.attributes["recorded_exception"] = type(exc).__name__
+
+    def set_status(self, status: Any, description: str) -> None:
+        self.attributes["status"] = (status, description)
+
+    def end(self) -> None:
+        self.ended = True
+
+
+class _FakeTracer:
+    def __init__(self, span: _FailingAttributeSpan) -> None:
+        self.span = span
+
+    def start_span(self, name: str) -> _FailingAttributeSpan:
+        self.span.attributes["span_name"] = name
+        return self.span
+
+
+def _install_fake_otel(monkeypatch, span: _FailingAttributeSpan) -> None:
+    trace = types.SimpleNamespace(get_tracer=lambda name: _FakeTracer(span))
+    monkeypatch.setitem(sys.modules, "opentelemetry", types.SimpleNamespace(trace=trace))
+
+
 def test_step_span_captures_timing() -> None:
     """StepSpan records start/end times and computes duration."""
     with StepSpan(name="test-span") as span:
@@ -46,6 +85,30 @@ def test_step_span_attributes() -> None:
     assert span.name == "test"
     assert span.step_id == "abc-123"
     assert span.attributes["custom"] is True
+
+
+def test_step_span_enter_ignores_bad_otel_attributes(monkeypatch) -> None:
+    """Bad OTel attributes should not break entering or ending a span."""
+    otel_span = _FailingAttributeSpan(fail_keys={"bad"})
+    _install_fake_otel(monkeypatch, otel_span)
+
+    with StepSpan(name="test", attributes={"bad": object(), "good": True}):
+        pass
+
+    assert otel_span.attributes["good"] is True
+    assert otel_span.ended is True
+
+
+def test_step_span_exit_ends_after_bad_otel_attribute(monkeypatch) -> None:
+    """A bad final attribute should not leave the OTel span open."""
+    otel_span = _FailingAttributeSpan(fail_keys={"genblaze.duration_ms"})
+    _install_fake_otel(monkeypatch, otel_span)
+
+    with StepSpan(name="test", attributes={"good": True}):
+        pass
+
+    assert otel_span.attributes["genblaze.retries"] == 0
+    assert otel_span.ended is True
 
 
 def test_structured_logger_emits_json(capfd) -> None:

--- a/libs/core/tests/unit/test_observability.py
+++ b/libs/core/tests/unit/test_observability.py
@@ -99,6 +99,17 @@ def test_step_span_enter_ignores_bad_otel_attributes(monkeypatch) -> None:
     assert otel_span.ended is True
 
 
+def test_step_span_enter_ignores_bad_otel_ids(monkeypatch) -> None:
+    """Bad OTel base IDs should not break entering or ending a span."""
+    otel_span = _FailingAttributeSpan(fail_keys={"genblaze.step_id", "genblaze.run_id"})
+    _install_fake_otel(monkeypatch, otel_span)
+
+    with StepSpan(name="test", step_id="step-123", run_id="run-123"):
+        pass
+
+    assert otel_span.ended is True
+
+
 def test_step_span_exit_ends_after_bad_otel_attribute(monkeypatch) -> None:
     """A bad final attribute should not leave the OTel span open."""
     otel_span = _FailingAttributeSpan(fail_keys={"genblaze.duration_ms"})

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -30,6 +30,18 @@ class MockProvider(BaseProvider):
         return step
 
 
+class ConfigCaptureProvider(MockProvider):
+    """Provider that records the config passed into submit()."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.submit_config: RunnableConfig | None = None
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        self.submit_config = config
+        return super().submit(step, config)
+
+
 def test_pipeline_single_step() -> None:
     provider = MockProvider()
     result = Pipeline("test").step(provider, model="test-model", prompt="a cat").run()
@@ -631,6 +643,15 @@ def test_pipeline_run_max_retries_kwarg() -> None:
     provider = MockProvider()
     result = Pipeline("retries").step(provider, model="m", prompt="p").run(max_retries=2)
     assert result.run.steps[0].status == StepStatus.SUCCEEDED
+
+
+def test_pipeline_run_injects_run_id_into_provider_config() -> None:
+    """Pipeline.run() passes the active run_id to provider spans and retry logs."""
+    provider = ConfigCaptureProvider()
+    result = Pipeline("run-id").step(provider, model="m", prompt="p").run()
+
+    assert provider.submit_config is not None
+    assert provider.submit_config["run_id"] == result.run.run_id
 
 
 # --- Runnable conformance tests ---

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
@@ -119,15 +118,6 @@ class _PostSubmitRetryProvider(BaseProvider):
         return step
 
 
-def _failing_on_submit(fail_count: int, calls: list[Any]) -> Callable[[str, Any], None]:
-    def on_submit(step_id: str, prediction_id: Any) -> None:
-        calls.append((step_id, prediction_id))
-        if len(calls) <= fail_count:
-            raise RuntimeError("server error 500 during checkpoint")
-
-    return on_submit
-
-
 @patch("genblaze_core.providers.base.time.sleep")
 def test_resume_skips_submit(mock_sleep) -> None:
     """resume() polls and fetches without calling submit()."""
@@ -159,14 +149,21 @@ def test_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep) -> No
     """A checkpoint failure after submit resumes the submitted prediction."""
     provider = _PostSubmitRetryProvider(fail_phase="none", fail_count=0)
     on_submit_calls: list[Any] = []
+    persisted: dict[str, Any] = {}
     progress_statuses: list[str] = []
+
+    def on_submit(step_id: str, prediction_id: Any) -> None:
+        on_submit_calls.append((step_id, prediction_id))
+        if len(on_submit_calls) == 1:
+            raise RuntimeError("server error 500 during checkpoint")
+        persisted[step_id] = prediction_id
 
     result = provider.invoke(
         _make_step(),
         {
             "timeout": 60,
             "max_retries": 1,
-            "on_submit": _failing_on_submit(1, on_submit_calls),
+            "on_submit": on_submit,
             "on_progress": lambda event: progress_statuses.append(event.status),
         },
     )
@@ -176,8 +173,17 @@ def test_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep) -> No
     assert provider.submit_calls == 1
     assert provider.poll_calls == 1
     assert provider.fetch_calls == 1
-    assert on_submit_calls == [(result.step_id, "pred-1")]
+    assert on_submit_calls == [(result.step_id, "pred-1"), (result.step_id, "pred-1")]
+    assert persisted[result.step_id] == "pred-1"
     assert progress_statuses == ["submitted", "retry_resumed", "succeeded"]
+
+    restarted_provider = _PostSubmitRetryProvider(fail_phase="none", fail_count=0)
+    restarted = restarted_provider.resume(persisted[result.step_id], _make_step(), {"timeout": 60})
+
+    assert restarted.status == StepStatus.SUCCEEDED
+    assert restarted_provider.submit_calls == 0
+    assert restarted_provider.polled_prediction_ids == ["pred-1"]
+    assert restarted_provider.fetched_prediction_ids == ["pred-1"]
 
 
 @patch("genblaze_core.providers.base.time.sleep")
@@ -225,6 +231,28 @@ def test_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
     assert provider.polled_prediction_ids == ["pred-1", "pred-1"]
     assert "foreign-prediction" not in provider.polled_prediction_ids
     assert "foreign-prediction" not in provider.fetched_prediction_ids
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_ignores_poisoned_upstream_id_when_submit_returns_none(mock_sleep) -> None:
+    """Caller metadata is ignored even when submit returns no current id."""
+    provider = _PostSubmitRetryProvider(
+        fail_phase="poll",
+        fail_count=1,
+        prediction_ids=[None, None],
+    )
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+
+    result = provider.invoke(step, {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert provider.submit_calls == 2
+    assert provider.polled_prediction_ids == [None, None]
+    assert provider.fetched_prediction_ids == [None]
+    assert "foreign-prediction" not in provider.polled_prediction_ids
+    assert "foreign-prediction" not in provider.fetched_prediction_ids
+    assert UPSTREAM_ID_KEY not in result.metadata
 
 
 @patch("genblaze_core.providers.base.time.sleep")
@@ -296,7 +324,14 @@ def test_async_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep)
     """Async checkpoint failure after submit resumes the submitted prediction."""
     provider = _PostSubmitRetryProvider(fail_phase="none", fail_count=0)
     on_submit_calls: list[Any] = []
+    persisted: dict[str, Any] = {}
     progress_statuses: list[str] = []
+
+    def on_submit(step_id: str, prediction_id: Any) -> None:
+        on_submit_calls.append((step_id, prediction_id))
+        if len(on_submit_calls) == 1:
+            raise RuntimeError("server error 500 during checkpoint")
+        persisted[step_id] = prediction_id
 
     result = asyncio.run(
         provider.ainvoke(
@@ -304,7 +339,7 @@ def test_async_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep)
             {
                 "timeout": 60,
                 "max_retries": 1,
-                "on_submit": _failing_on_submit(1, on_submit_calls),
+                "on_submit": on_submit,
                 "on_progress": lambda event: progress_statuses.append(event.status),
             },
         )
@@ -315,7 +350,8 @@ def test_async_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep)
     assert provider.submit_calls == 1
     assert provider.poll_calls == 1
     assert provider.fetch_calls == 1
-    assert on_submit_calls == [(result.step_id, "pred-1")]
+    assert on_submit_calls == [(result.step_id, "pred-1"), (result.step_id, "pred-1")]
+    assert persisted[result.step_id] == "pred-1"
     assert progress_statuses == ["submitted", "retry_resumed", "succeeded"]
 
 
@@ -335,22 +371,74 @@ def test_async_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
     assert "foreign-prediction" not in provider.fetched_prediction_ids
 
 
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_ignores_poisoned_upstream_id_when_submit_returns_none(
+    mock_sleep,
+) -> None:
+    """Async retries ignore caller metadata when submit returns no current id."""
+    provider = _PostSubmitRetryProvider(
+        fail_phase="poll",
+        fail_count=1,
+        prediction_ids=[None, None],
+    )
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+
+    result = asyncio.run(provider.ainvoke(step, {"timeout": 60, "max_retries": 1}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert provider.submit_calls == 2
+    assert provider.polled_prediction_ids == [None, None]
+    assert provider.fetched_prediction_ids == [None]
+    assert "foreign-prediction" not in provider.polled_prediction_ids
+    assert "foreign-prediction" not in provider.fetched_prediction_ids
+    assert UPSTREAM_ID_KEY not in result.metadata
+
+
 @patch("genblaze_core.providers.base.time.sleep")
-def test_step_retry_route_log_redacts_prediction_id(mock_sleep, caplog) -> None:
-    """Resume retry logs do not include raw upstream prediction IDs."""
-    prediction_id = "signed-output-url?token=credential-fixture"
+def test_step_retry_route_log_omits_prediction_id(mock_sleep, caplog) -> None:
+    """Route logs omit upstream IDs, but progress surfaces keep request_id."""
+    prediction_id = "pred-id-with-query-fragment"
     provider = _PostSubmitRetryProvider(
         fail_phase="fetch",
         fail_count=1,
         prediction_ids=[prediction_id],
     )
+    progress_events: list[Any] = []
 
     with caplog.at_level(logging.DEBUG, logger="genblaze.provider"):
-        result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+        result = provider.invoke(
+            _make_step(),
+            {
+                "timeout": 60,
+                "max_retries": 1,
+                "run_id": "run-123",
+                "on_progress": progress_events.append,
+            },
+        )
 
     assert result.status == StepStatus.SUCCEEDED
     assert "route=resume" in caplog.text
+    assert f"step_id={result.step_id}" in caplog.text
+    assert "run_id=run-123" in caplog.text
     assert prediction_id not in caplog.text
+    assert result.metadata[UPSTREAM_ID_KEY] == prediction_id
+    assert any(event.request_id == prediction_id for event in progress_events)
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_resume_budget_exhaustion_is_logged_without_resubmit(mock_sleep, caplog) -> None:
+    """A stuck resumed prediction fails visibly instead of fresh-submitting."""
+    provider = _PostSubmitRetryProvider(fail_phase="fetch", fail_count=99)
+
+    with caplog.at_level(logging.WARNING, logger="genblaze.provider"):
+        result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.FAILED
+    assert provider.submit_calls == 1
+    assert provider.fetched_prediction_ids == ["pred-1", "pred-1"]
+    assert "Resume retry budget exhausted" in caplog.text
+    assert "no_resubmit=true" in caplog.text
 
 
 @patch("genblaze_core.providers.base.time.sleep")

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import patch
 
 from genblaze_core.models.enums import ProviderErrorCode, StepStatus
@@ -45,6 +45,35 @@ class _RetryProvider(BaseProvider):
 
 def _make_step() -> Step:
     return Step(provider="retry-test", model="test-model", prompt="hello")
+
+
+class _CaptureStepSpan:
+    """Test span that captures attributes set by BaseProvider."""
+
+    instances: ClassVar[list[_CaptureStepSpan]] = []
+
+    def __init__(
+        self,
+        name: str,
+        run_id: str | None = None,
+        step_id: str | None = None,
+    ) -> None:
+        self.name = name
+        self.run_id = run_id
+        self.step_id = step_id
+        self.retries = 0
+        self.cost = None
+        self.attributes: dict[str, Any] = {}
+        self.instances.append(self)
+
+    def __enter__(self) -> _CaptureStepSpan:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
 
 
 class _ResumableProvider(BaseProvider):
@@ -234,25 +263,27 @@ def test_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
 
 
 @patch("genblaze_core.providers.base.time.sleep")
-def test_step_retry_ignores_poisoned_upstream_id_when_submit_returns_none(mock_sleep) -> None:
-    """Caller metadata is ignored even when submit returns no current id."""
-    provider = _PostSubmitRetryProvider(
-        fail_phase="poll",
-        fail_count=1,
-        prediction_ids=[None, None],
-    )
-    step = _make_step()
-    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+def test_step_retry_fails_safely_when_submit_returns_no_prediction_id(mock_sleep) -> None:
+    """Caller metadata is ignored when submit returns no usable upstream id."""
+    for invalid_id in (None, ""):
+        provider = _PostSubmitRetryProvider(
+            fail_phase="none",
+            fail_count=0,
+            prediction_ids=[invalid_id],
+        )
+        step = _make_step()
+        step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
 
-    result = provider.invoke(step, {"timeout": 60, "max_retries": 1})
+        result = provider.invoke(step, {"timeout": 60, "max_retries": 1})
 
-    assert result.status == StepStatus.SUCCEEDED
-    assert provider.submit_calls == 2
-    assert provider.polled_prediction_ids == [None, None]
-    assert provider.fetched_prediction_ids == [None]
-    assert "foreign-prediction" not in provider.polled_prediction_ids
-    assert "foreign-prediction" not in provider.fetched_prediction_ids
-    assert UPSTREAM_ID_KEY not in result.metadata
+        assert result.status == StepStatus.FAILED
+        assert result.error_code == ProviderErrorCode.INVALID_INPUT
+        assert provider.submit_calls == 1
+        assert provider.poll_calls == 0
+        assert provider.fetch_calls == 0
+        assert "foreign-prediction" not in provider.polled_prediction_ids
+        assert "foreign-prediction" not in provider.fetched_prediction_ids
+        assert UPSTREAM_ID_KEY not in result.metadata
 
 
 @patch("genblaze_core.providers.base.time.sleep")
@@ -285,6 +316,23 @@ def test_async_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> 
     assert provider.poll_calls == 3
     assert provider.fetch_calls == 3
     assert provider.fetched_prediction_ids == ["pred-1", "pred-1", "pred-1"]
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_preserves_native_prediction_id_type(mock_sleep) -> None:
+    """Async in-process resume uses the native id returned by submit()."""
+    provider = _PostSubmitRetryProvider(
+        fail_phase="fetch",
+        fail_count=1,
+        prediction_ids=[101],
+    )
+    result = asyncio.run(provider.ainvoke(_make_step(), {"timeout": 60, "max_retries": 1}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata[UPSTREAM_ID_KEY] == "101"
+    assert provider.submit_calls == 1
+    assert provider.polled_prediction_ids == [101, 101]
+    assert provider.fetched_prediction_ids == [101, 101]
 
 
 @patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
@@ -372,31 +420,33 @@ def test_async_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
 
 
 @patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
-def test_async_step_retry_ignores_poisoned_upstream_id_when_submit_returns_none(
+def test_async_step_retry_fails_safely_when_submit_returns_no_prediction_id(
     mock_sleep,
 ) -> None:
-    """Async retries ignore caller metadata when submit returns no current id."""
-    provider = _PostSubmitRetryProvider(
-        fail_phase="poll",
-        fail_count=1,
-        prediction_ids=[None, None],
-    )
-    step = _make_step()
-    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+    """Async retries ignore caller metadata when submit returns no usable id."""
+    for invalid_id in (None, ""):
+        provider = _PostSubmitRetryProvider(
+            fail_phase="none",
+            fail_count=0,
+            prediction_ids=[invalid_id],
+        )
+        step = _make_step()
+        step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
 
-    result = asyncio.run(provider.ainvoke(step, {"timeout": 60, "max_retries": 1}))
+        result = asyncio.run(provider.ainvoke(step, {"timeout": 60, "max_retries": 1}))
 
-    assert result.status == StepStatus.SUCCEEDED
-    assert provider.submit_calls == 2
-    assert provider.polled_prediction_ids == [None, None]
-    assert provider.fetched_prediction_ids == [None]
-    assert "foreign-prediction" not in provider.polled_prediction_ids
-    assert "foreign-prediction" not in provider.fetched_prediction_ids
-    assert UPSTREAM_ID_KEY not in result.metadata
+        assert result.status == StepStatus.FAILED
+        assert result.error_code == ProviderErrorCode.INVALID_INPUT
+        assert provider.submit_calls == 1
+        assert provider.poll_calls == 0
+        assert provider.fetch_calls == 0
+        assert "foreign-prediction" not in provider.polled_prediction_ids
+        assert "foreign-prediction" not in provider.fetched_prediction_ids
+        assert UPSTREAM_ID_KEY not in result.metadata
 
 
 @patch("genblaze_core.providers.base.time.sleep")
-def test_step_retry_route_log_omits_prediction_id(mock_sleep, caplog) -> None:
+def test_step_retry_route_log_omits_prediction_id(mock_sleep, caplog, monkeypatch) -> None:
     """Route logs omit upstream IDs, but progress surfaces keep request_id."""
     prediction_id = "pred-id-with-query-fragment"
     provider = _PostSubmitRetryProvider(
@@ -405,6 +455,8 @@ def test_step_retry_route_log_omits_prediction_id(mock_sleep, caplog) -> None:
         prediction_ids=[prediction_id],
     )
     progress_events: list[Any] = []
+    _CaptureStepSpan.instances.clear()
+    monkeypatch.setattr("genblaze_core.providers.base.StepSpan", _CaptureStepSpan)
 
     with caplog.at_level(logging.DEBUG, logger="genblaze.provider"):
         result = provider.invoke(
@@ -424,12 +476,20 @@ def test_step_retry_route_log_omits_prediction_id(mock_sleep, caplog) -> None:
     assert prediction_id not in caplog.text
     assert result.metadata[UPSTREAM_ID_KEY] == prediction_id
     assert any(event.request_id == prediction_id for event in progress_events)
+    assert _CaptureStepSpan.instances[-1].attributes["genblaze.step_retry.route"] == "resume"
+    assert _CaptureStepSpan.instances[-1].attributes["genblaze.step_retry.resumed"] is True
 
 
 @patch("genblaze_core.providers.base.time.sleep")
-def test_resume_budget_exhaustion_is_logged_without_resubmit(mock_sleep, caplog) -> None:
+def test_resume_budget_exhaustion_is_logged_without_resubmit(
+    mock_sleep,
+    caplog,
+    monkeypatch,
+) -> None:
     """A stuck resumed prediction fails visibly instead of fresh-submitting."""
     provider = _PostSubmitRetryProvider(fail_phase="fetch", fail_count=99)
+    _CaptureStepSpan.instances.clear()
+    monkeypatch.setattr("genblaze_core.providers.base.StepSpan", _CaptureStepSpan)
 
     with caplog.at_level(logging.WARNING, logger="genblaze.provider"):
         result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
@@ -439,6 +499,10 @@ def test_resume_budget_exhaustion_is_logged_without_resubmit(mock_sleep, caplog)
     assert provider.fetched_prediction_ids == ["pred-1", "pred-1"]
     assert "Resume retry budget exhausted" in caplog.text
     assert "no_resubmit=true" in caplog.text
+    assert (
+        _CaptureStepSpan.instances[-1].attributes["genblaze.step_retry.resume_exhausted"] is True
+    )
+    assert _CaptureStepSpan.instances[-1].attributes["genblaze.step_retry.resume_failures"] == 1
 
 
 @patch("genblaze_core.providers.base.time.sleep")

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -14,6 +14,7 @@ from genblaze_core.providers.base import (
     _adaptive_poll_interval,
     classify_api_error,
 )
+from genblaze_core.providers.retry import RetryPolicy
 from genblaze_core.runnable.config import RunnableConfig
 
 
@@ -71,6 +72,42 @@ class _ResumableProvider(BaseProvider):
         return step
 
 
+class _PostSubmitRetryProvider(BaseProvider):
+    """Provider that can fail after or before submit for retry regression tests."""
+
+    name = "post-submit-retry"
+
+    def __init__(self, *, fail_phase: str, fail_count: int) -> None:
+        super().__init__(retry_policy=RetryPolicy(max_attempts=1, jitter="none"))
+        self._fail_phase = fail_phase
+        self._fail_count = fail_count
+        self.submit_calls = 0
+        self.poll_calls = 0
+        self.fetch_calls = 0
+        self.polled_prediction_ids: list[Any] = []
+        self.fetched_prediction_ids: list[Any] = []
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        self.submit_calls += 1
+        if self._fail_phase == "submit" and self.submit_calls <= self._fail_count:
+            raise RuntimeError("server error 500 during submit")
+        return f"pred-{self.submit_calls}"
+
+    def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
+        self.poll_calls += 1
+        self.polled_prediction_ids.append(prediction_id)
+        if self._fail_phase == "poll" and self.poll_calls <= self._fail_count:
+            raise RuntimeError("server error 500 during poll")
+        return True
+
+    def fetch_output(self, prediction_id: Any, step: Step) -> Step:
+        self.fetch_calls += 1
+        self.fetched_prediction_ids.append(prediction_id)
+        if self._fail_phase == "fetch" and self.fetch_calls <= self._fail_count:
+            raise RuntimeError("server error 500 during fetch")
+        return step
+
+
 @patch("genblaze_core.providers.base.time.sleep")
 def test_resume_skips_submit(mock_sleep) -> None:
     """resume() polls and fetches without calling submit()."""
@@ -81,6 +118,62 @@ def test_resume_skips_submit(mock_sleep) -> None:
     assert result.status == StepStatus.SUCCEEDED
     assert not provider.submit_called
     assert len(result.assets) == 1
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """A fetch-phase step retry resumes the submitted prediction."""
+    provider = _PostSubmitRetryProvider(fail_phase="fetch", fail_count=2)
+    result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 2})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 2
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 3
+    assert provider.fetch_calls == 3
+    assert provider.fetched_prediction_ids == ["pred-1", "pred-1", "pred-1"]
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_poll_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """A poll-phase step retry resumes the submitted prediction."""
+    provider = _PostSubmitRetryProvider(fail_phase="poll", fail_count=2)
+    result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 2})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 2
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 3
+    assert provider.fetch_calls == 1
+    assert provider.polled_prediction_ids == ["pred-1", "pred-1", "pred-1"]
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_submit_failure_resubmits(mock_sleep) -> None:
+    """A failure before an upstream id exists still uses the submit path."""
+    provider = _PostSubmitRetryProvider(fail_phase="submit", fail_count=1)
+    result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 1
+    assert provider.submit_calls == 2
+    assert provider.poll_calls == 1
+    assert provider.fetch_calls == 1
+    assert result.metadata["upstream_id"] == "pred-2"
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """Async step retry mirrors sync behavior for post-submit failures."""
+    provider = _PostSubmitRetryProvider(fail_phase="fetch", fail_count=2)
+    result = asyncio.run(provider.ainvoke(_make_step(), {"timeout": 60, "max_retries": 2}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 2
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 3
+    assert provider.fetch_calls == 3
+    assert provider.fetched_prediction_ids == ["pred-1", "pred-1", "pred-1"]
 
 
 @patch("genblaze_core.providers.base.time.sleep")

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
 from genblaze_core.models.enums import ProviderErrorCode, StepStatus
-from genblaze_core.models.step import Step
+from genblaze_core.models.step import UPSTREAM_ID_KEY, Step
 from genblaze_core.providers.base import (
     BaseProvider,
     _adaptive_poll_interval,
@@ -77,10 +79,17 @@ class _PostSubmitRetryProvider(BaseProvider):
 
     name = "post-submit-retry"
 
-    def __init__(self, *, fail_phase: str, fail_count: int) -> None:
+    def __init__(
+        self,
+        *,
+        fail_phase: str,
+        fail_count: int,
+        prediction_ids: list[Any] | None = None,
+    ) -> None:
         super().__init__(retry_policy=RetryPolicy(max_attempts=1, jitter="none"))
         self._fail_phase = fail_phase
         self._fail_count = fail_count
+        self._prediction_ids = prediction_ids
         self.submit_calls = 0
         self.poll_calls = 0
         self.fetch_calls = 0
@@ -91,6 +100,8 @@ class _PostSubmitRetryProvider(BaseProvider):
         self.submit_calls += 1
         if self._fail_phase == "submit" and self.submit_calls <= self._fail_count:
             raise RuntimeError("server error 500 during submit")
+        if self._prediction_ids is not None:
+            return self._prediction_ids[self.submit_calls - 1]
         return f"pred-{self.submit_calls}"
 
     def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
@@ -106,6 +117,15 @@ class _PostSubmitRetryProvider(BaseProvider):
         if self._fail_phase == "fetch" and self.fetch_calls <= self._fail_count:
             raise RuntimeError("server error 500 during fetch")
         return step
+
+
+def _failing_on_submit(fail_count: int, calls: list[Any]) -> Callable[[str, Any], None]:
+    def on_submit(step_id: str, prediction_id: Any) -> None:
+        calls.append((step_id, prediction_id))
+        if len(calls) <= fail_count:
+            raise RuntimeError("server error 500 during checkpoint")
+
+    return on_submit
 
 
 @patch("genblaze_core.providers.base.time.sleep")
@@ -135,6 +155,32 @@ def test_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> None:
 
 
 @patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """A checkpoint failure after submit resumes the submitted prediction."""
+    provider = _PostSubmitRetryProvider(fail_phase="none", fail_count=0)
+    on_submit_calls: list[Any] = []
+    progress_statuses: list[str] = []
+
+    result = provider.invoke(
+        _make_step(),
+        {
+            "timeout": 60,
+            "max_retries": 1,
+            "on_submit": _failing_on_submit(1, on_submit_calls),
+            "on_progress": lambda event: progress_statuses.append(event.status),
+        },
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 1
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 1
+    assert provider.fetch_calls == 1
+    assert on_submit_calls == [(result.step_id, "pred-1")]
+    assert progress_statuses == ["submitted", "retry_resumed", "succeeded"]
+
+
+@patch("genblaze_core.providers.base.time.sleep")
 def test_step_retry_poll_failure_resumes_without_resubmit(mock_sleep) -> None:
     """A poll-phase step retry resumes the submitted prediction."""
     provider = _PostSubmitRetryProvider(fail_phase="poll", fail_count=2)
@@ -149,17 +195,54 @@ def test_step_retry_poll_failure_resumes_without_resubmit(mock_sleep) -> None:
 
 
 @patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_preserves_native_prediction_id_type(mock_sleep) -> None:
+    """The in-process resume path uses the native id returned by submit()."""
+    provider = _PostSubmitRetryProvider(
+        fail_phase="fetch",
+        fail_count=1,
+        prediction_ids=[101],
+    )
+    result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata[UPSTREAM_ID_KEY] == "101"
+    assert provider.submit_calls == 1
+    assert provider.polled_prediction_ids == [101, 101]
+    assert provider.fetched_prediction_ids == [101, 101]
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
+    """Caller-seeded metadata cannot select the prediction polled on retry."""
+    provider = _PostSubmitRetryProvider(fail_phase="poll", fail_count=1)
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+
+    result = provider.invoke(step, {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert provider.submit_calls == 1
+    assert provider.polled_prediction_ids == ["pred-1", "pred-1"]
+    assert "foreign-prediction" not in provider.polled_prediction_ids
+    assert "foreign-prediction" not in provider.fetched_prediction_ids
+
+
+@patch("genblaze_core.providers.base.time.sleep")
 def test_step_retry_submit_failure_resubmits(mock_sleep) -> None:
     """A failure before an upstream id exists still uses the submit path."""
     provider = _PostSubmitRetryProvider(fail_phase="submit", fail_count=1)
-    result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+    result = provider.invoke(step, {"timeout": 60, "max_retries": 1})
 
     assert result.status == StepStatus.SUCCEEDED
     assert result.retries == 1
     assert provider.submit_calls == 2
     assert provider.poll_calls == 1
     assert provider.fetch_calls == 1
-    assert result.metadata["upstream_id"] == "pred-2"
+    assert result.metadata[UPSTREAM_ID_KEY] == "pred-2"
+    assert provider.polled_prediction_ids == ["pred-2"]
+    assert provider.fetched_prediction_ids == ["pred-2"]
 
 
 @patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
@@ -174,6 +257,100 @@ def test_async_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> 
     assert provider.poll_calls == 3
     assert provider.fetch_calls == 3
     assert provider.fetched_prediction_ids == ["pred-1", "pred-1", "pred-1"]
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_poll_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """Async poll-phase step retry resumes the submitted prediction."""
+    provider = _PostSubmitRetryProvider(fail_phase="poll", fail_count=2)
+    result = asyncio.run(provider.ainvoke(_make_step(), {"timeout": 60, "max_retries": 2}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 2
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 3
+    assert provider.fetch_calls == 1
+    assert provider.polled_prediction_ids == ["pred-1", "pred-1", "pred-1"]
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_submit_failure_resubmits(mock_sleep) -> None:
+    """Async submit failure still uses the fresh submit path."""
+    provider = _PostSubmitRetryProvider(fail_phase="submit", fail_count=1)
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+    result = asyncio.run(provider.ainvoke(step, {"timeout": 60, "max_retries": 1}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 1
+    assert provider.submit_calls == 2
+    assert provider.poll_calls == 1
+    assert provider.fetch_calls == 1
+    assert result.metadata[UPSTREAM_ID_KEY] == "pred-2"
+    assert provider.polled_prediction_ids == ["pred-2"]
+    assert provider.fetched_prediction_ids == ["pred-2"]
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_on_submit_failure_resumes_without_resubmit(mock_sleep) -> None:
+    """Async checkpoint failure after submit resumes the submitted prediction."""
+    provider = _PostSubmitRetryProvider(fail_phase="none", fail_count=0)
+    on_submit_calls: list[Any] = []
+    progress_statuses: list[str] = []
+
+    result = asyncio.run(
+        provider.ainvoke(
+            _make_step(),
+            {
+                "timeout": 60,
+                "max_retries": 1,
+                "on_submit": _failing_on_submit(1, on_submit_calls),
+                "on_progress": lambda event: progress_statuses.append(event.status),
+            },
+        )
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.retries == 1
+    assert provider.submit_calls == 1
+    assert provider.poll_calls == 1
+    assert provider.fetch_calls == 1
+    assert on_submit_calls == [(result.step_id, "pred-1")]
+    assert progress_statuses == ["submitted", "retry_resumed", "succeeded"]
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_async_step_retry_ignores_poisoned_upstream_id(mock_sleep) -> None:
+    """Async retries never poll a caller-seeded upstream id."""
+    provider = _PostSubmitRetryProvider(fail_phase="poll", fail_count=1)
+    step = _make_step()
+    step.metadata[UPSTREAM_ID_KEY] = "foreign-prediction"
+
+    result = asyncio.run(provider.ainvoke(step, {"timeout": 60, "max_retries": 1}))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert provider.submit_calls == 1
+    assert provider.polled_prediction_ids == ["pred-1", "pred-1"]
+    assert "foreign-prediction" not in provider.polled_prediction_ids
+    assert "foreign-prediction" not in provider.fetched_prediction_ids
+
+
+@patch("genblaze_core.providers.base.time.sleep")
+def test_step_retry_route_log_redacts_prediction_id(mock_sleep, caplog) -> None:
+    """Resume retry logs do not include raw upstream prediction IDs."""
+    prediction_id = "signed-output-url?token=credential-fixture"
+    provider = _PostSubmitRetryProvider(
+        fail_phase="fetch",
+        fail_count=1,
+        prediction_ids=[prediction_id],
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="genblaze.provider"):
+        result = provider.invoke(_make_step(), {"timeout": 60, "max_retries": 1})
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert "route=resume" in caplog.text
+    assert prediction_id not in caplog.text
 
 
 @patch("genblaze_core.providers.base.time.sleep")

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -160,6 +160,44 @@ def test_resume_skips_submit(mock_sleep) -> None:
 
 
 @patch("genblaze_core.providers.base.time.sleep")
+def test_resume_progress_includes_prediction_id_for_fresh_step(mock_sleep) -> None:
+    """resume() populates request_id even when step metadata starts empty."""
+    provider = _ResumableProvider(polls_until_done=1)
+    progress_events: list[Any] = []
+
+    result = provider.resume(
+        "pred-resume",
+        _make_step(),
+        {"timeout": 60, "on_progress": progress_events.append},
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata[UPSTREAM_ID_KEY] == "pred-resume"
+    assert progress_events[0].status == "resumed"
+    assert progress_events[0].request_id == "pred-resume"
+
+
+@patch("genblaze_core.providers.base.asyncio.sleep", return_value=None)
+def test_aresume_progress_includes_prediction_id_for_fresh_step(mock_sleep) -> None:
+    """aresume() populates request_id even when step metadata starts empty."""
+    provider = _ResumableProvider(polls_until_done=1)
+    progress_events: list[Any] = []
+
+    result = asyncio.run(
+        provider.aresume(
+            "pred-resume",
+            _make_step(),
+            {"timeout": 60, "on_progress": progress_events.append},
+        )
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata[UPSTREAM_ID_KEY] == "pred-resume"
+    assert progress_events[0].status == "resumed"
+    assert progress_events[0].request_id == "pred-resume"
+
+
+@patch("genblaze_core.providers.base.time.sleep")
 def test_step_retry_fetch_failure_resumes_without_resubmit(mock_sleep) -> None:
     """A fetch-phase step retry resumes the submitted prediction."""
     provider = _PostSubmitRetryProvider(fail_phase="fetch", fail_count=2)


### PR DESCRIPTION
## Summary
- Reworked `BaseProvider` step-level retries so post-submit failures resume only the native prediction ID produced by the current `submit()` call, never caller-seeded `step.metadata["upstream_id"]`.
- Replayed the idempotent `on_submit(step_id, prediction_id)` checkpoint before automatic retry resume so transient checkpoint failures can persist the existing upstream job before polling or fetching.
- Rejected missing or empty submit prediction IDs before polling or fetching, so stale `upstream_id` metadata cannot become retry authority.
- Kept failures before a current upstream ID on the fresh submit path, while post-submit retries stay bound to the existing upstream ID and emit warning/span telemetry when the resume retry budget is exhausted without re-submit.
- Shared the sync and async poll/fetch loop between fresh attempts and resume paths, documented the protected resume hooks, and kept public `resume()` / `aresume()` behavior aligned with automatic retry resume.
- Populated resume metadata before progress emission so fresh-step `resume()` / `aresume()` progress and stream events include the known upstream `request_id`.
- Added production-visible retry route observability with `route=resume` / `route=submit`, `step_id`, `run_id`, and span attributes while omitting raw upstream IDs from retry route logs.
- Propagated `run_id` from `Pipeline.run()` into provider config so retry logs and spans correlate during normal pipeline execution.
- Clarified moderation scope: pre-step moderation screens prompt text, negative prompts, and `Asset.metadata["text"]`; it does not dereference `Asset.url` or scan arbitrary metadata keys.
- Synced the branch with `main` so current Hume connector files, direct dependencies, and package metadata remain intact.
- Hardened `StepSpan` OpenTelemetry forwarding so custom attributes plus base `step_id` / `run_id` writes are best-effort, and bad OTel calls cannot break execution or leave spans open.

## Linked issue
Fixes #70

## Tests run
- `pytest libs/core/tests/unit/test_provider_retry.py libs/core/tests/unit/test_moderation.py libs/core/tests/unit/test_pipeline.py libs/core/tests/unit/test_observability.py -q`
- `cd libs/core && pytest tests/unit/test_provider_retry.py -v`
- `cd libs/core && pytest tests/unit/test_provider_retry.py -q`
- `cd libs/core && pytest tests/unit/test_observability.py tests/unit/test_provider_retry.py -q`
- `pytest libs/core/tests/unit/test_observability.py -q`
- `make lint`
- `make test`

## Follow-up notes
- Review comments have been replied to and resolved.
