### PR TITLE
Fix fan-in consumers on failed inputs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-15 -->
+<!-- last_verified: 2026-06-20 -->
 # Architecture
 
 ## Components

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,6 +92,7 @@
 - Pipeline: `batch_run`/`abatch_run` for multi-prompt execution with semaphore-based concurrency control
 - Pipeline concurrency: `arun()` with `chain=False` runs steps concurrently; `max_concurrency` limits parallelism
 - Pipeline fan-in: `input_from` on `.step()` routes outputs from specific prior steps (by index) into a later step, enabling AV mux patterns
+- Pipeline fan-in safety: `input_from` dependencies must point at succeeded steps with assets; missing producer outputs fail the consumer before provider invocation
 - Pipeline-level timeout: `pipeline_timeout` raises `PipelineTimeoutError` when wall-clock time exceeds limit
 - `on_submit` callback: fires after `submit()` with `(step_id, prediction_id)` for crash-recovery checkpointing
 - Parameter normalization: `provider.normalize_params()` maps standard names (duration, resolution) to native ones

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@
 - Pipeline: `batch_run`/`abatch_run` for multi-prompt execution with semaphore-based concurrency control
 - Pipeline concurrency: `arun()` with `chain=False` runs steps concurrently; `max_concurrency` limits parallelism
 - Pipeline fan-in: `input_from` on `.step()` routes outputs from specific prior steps (by index) into a later step, enabling AV mux patterns
-- Pipeline fan-in safety: `input_from` dependencies must point at succeeded steps with assets; missing producer outputs fail the consumer before provider invocation
+- Pipeline fan-in safety: `input_from` dependencies must point at succeeded steps with assets; missing producer outputs fail the consumer with `INVALID_INPUT` before provider invocation
 - Pipeline-level timeout: `pipeline_timeout` raises `PipelineTimeoutError` when wall-clock time exceeds limit
 - `on_submit` callback: fires after `submit()` with `(step_id, prediction_id)` for crash-recovery checkpointing
 - Parameter normalization: `provider.normalize_params()` maps standard names (duration, resolution) to native ones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,18 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `genblaze-core`: fan-in consumers using `input_from` now fail before provider
-  invocation when a referenced producer step failed or produced no assets,
-  preventing a downstream step from reporting success with empty declared inputs
-  (#69). Affected pipelines that previously appeared green can now report
-  `FAILED`/`INVALID_INPUT`, which may increase status-based alerts and change
-  manifest hashes for those runs. These pre-failed steps carry
-  `metadata.failure_reason="input_resolution"` and
-  `metadata.provider_invoked=false` for telemetry filtering.
-- `genblaze-core`: failed `Step.error` values are uniformly redacted for
+  invocation when a referenced producer step failed, produced no assets, or
+  points at an out-of-range prior step, preventing a downstream step from
+  reporting success with empty declared inputs (#69). Affected pipelines that
+  previously appeared green can now report `FAILED`/`INVALID_INPUT`, which may
+  increase status-based alerts and change manifest hashes once during rollout.
+  Route or re-baseline those alerts using
+  `metadata.failure_reason="input_resolution"`; these pre-failed steps also
+  carry `metadata.provider_invoked=false` for telemetry filtering.
+- `genblaze-core`: failed `Step.error` values now use the shared sanitizer for
   OpenAI/Anthropic/Google/Replicate keys, AWS access key IDs and secret access
   keys, Backblaze B2 application keys, JWTs, bearer/token headers, API-key
-  assignments, and basic-auth URL credentials, then truncated to 500 characters
-  before manifest, log, or stream-event emission.
+  assignments, and basic-auth URL credentials, then truncate to 500 characters
+  before manifest, log, or stream-event emission. This redaction hardening ships
+  with #69 because fan-in pre-fail telemetry can otherwise re-surface untrusted
+  upstream provider errors on dependent steps.
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `genblaze-core`: fan-in consumers using `input_from` now fail before provider
+  invocation when a referenced producer step failed or produced no assets,
+  preventing a downstream step from reporting success with empty declared inputs
+  (#69).
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `genblaze-core`: fan-in consumers using `input_from` now fail before provider
   invocation when a referenced producer step failed or produced no assets,
   preventing a downstream step from reporting success with empty declared inputs
-  (#69).
+  (#69). Affected pipelines that previously appeared green can now report
+  `FAILED`/`INVALID_INPUT`, which may increase status-based alerts and changes
+  manifest hashes for those runs.
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invocation when a referenced producer step failed or produced no assets,
   preventing a downstream step from reporting success with empty declared inputs
   (#69). Affected pipelines that previously appeared green can now report
-  `FAILED`/`INVALID_INPUT`, which may increase status-based alerts and changes
+  `FAILED`/`INVALID_INPUT`, which may increase status-based alerts and change
   manifest hashes for those runs. These pre-failed steps carry
   `metadata.failure_reason="input_resolution"` and
   `metadata.provider_invoked=false` for telemetry filtering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preventing a downstream step from reporting success with empty declared inputs
   (#69). Affected pipelines that previously appeared green can now report
   `FAILED`/`INVALID_INPUT`, which may increase status-based alerts and changes
-  manifest hashes for those runs.
+  manifest hashes for those runs. These pre-failed steps carry
+  `metadata.failure_reason="input_resolution"` and
+  `metadata.provider_invoked=false` for telemetry filtering.
+- `genblaze-core`: failed `Step.error` values are uniformly redacted for
+  OpenAI/Anthropic/Google/Replicate keys, AWS access key IDs and secret access
+  keys, Backblaze B2 application keys, JWTs, bearer/token headers, API-key
+  assignments, and basic-auth URL credentials, then truncated to 500 characters
+  before manifest, log, or stream-event emission.
 - `genblaze-core`: `StepCache` now partitions the step cache key by `tenant_id`
   when a tenant is set (via `Pipeline(tenant_id=...)`, or passed to
   `StepCache.get`/`put`), so a cache shared across tenants no longer serves one

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -48,6 +48,10 @@ Fluent API for building and executing multi-step generative media workflows with
 
 Precedence inside `_resolve_inputs`: **external_inputs > input_from > chain mode > none**.
 
+For `input_from`, every referenced prior step must have succeeded and produced at least one
+asset. If a referenced producer failed or returned no assets, the dependent step is marked
+`failed` before its provider is invoked.
+
 `external_inputs` and `input_from` are mutually exclusive at construction (raises `GenblazeError`). Pass an Asset with `sha256` populated; without it, both the step cache key and the manifest canonical hash will drift across reruns when the URL rotates (e.g., presigned). The reserved kwargs `inputs=` and `input=` raise a friendly error pointing at `external_inputs=`.
 
 ## Outputs

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -48,9 +48,10 @@ Fluent API for building and executing multi-step generative media workflows with
 
 Precedence inside `_resolve_inputs`: **external_inputs > input_from > chain mode > none**.
 
-For `input_from`, every referenced prior step must have succeeded and produced at least one
-asset. If a referenced producer failed or returned no assets, the dependent step is marked
-`FAILED` with `error_code=INVALID_INPUT` before its provider is invoked. The pre-failed
+For `input_from`, every referenced index must point to a prior step that succeeded and
+produced at least one asset. If a reference is out of range, a producer failed, or a
+producer returned no assets, the dependent step is marked `FAILED` with
+`error_code=INVALID_INPUT` before its provider is invoked. The pre-failed
 consumer records `metadata.failure_reason="input_resolution"` and
 `metadata.provider_invoked=false`, so telemetry can separate zero-duration pre-fail spans
 from real provider calls.

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -50,7 +50,7 @@ Precedence inside `_resolve_inputs`: **external_inputs > input_from > chain mode
 
 For `input_from`, every referenced prior step must have succeeded and produced at least one
 asset. If a referenced producer failed or returned no assets, the dependent step is marked
-`failed` before its provider is invoked.
+`FAILED` before its provider is invoked.
 
 `external_inputs` and `input_from` are mutually exclusive at construction (raises `GenblazeError`). Pass an Asset with `sha256` populated; without it, both the step cache key and the manifest canonical hash will drift across reruns when the URL rotates (e.g., presigned). The reserved kwargs `inputs=` and `input=` raise a friendly error pointing at `external_inputs=`.
 

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-03-16 -->
+<!-- last_verified: 2026-06-20 -->
 # Feature: Pipeline
 
 ## Purpose
@@ -50,7 +50,10 @@ Precedence inside `_resolve_inputs`: **external_inputs > input_from > chain mode
 
 For `input_from`, every referenced prior step must have succeeded and produced at least one
 asset. If a referenced producer failed or returned no assets, the dependent step is marked
-`FAILED` with `error_code=INVALID_INPUT` before its provider is invoked.
+`FAILED` with `error_code=INVALID_INPUT` before its provider is invoked. The pre-failed
+consumer records `metadata.failure_reason="input_resolution"` and
+`metadata.provider_invoked=false`, so telemetry can separate zero-duration pre-fail spans
+from real provider calls.
 
 `external_inputs` and `input_from` are mutually exclusive at construction (raises `GenblazeError`). Pass an Asset with `sha256` populated; without it, both the step cache key and the manifest canonical hash will drift across reruns when the URL rotates (e.g., presigned). The reserved kwargs `inputs=` and `input=` raise a friendly error pointing at `external_inputs=`.
 

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -50,7 +50,7 @@ Precedence inside `_resolve_inputs`: **external_inputs > input_from > chain mode
 
 For `input_from`, every referenced prior step must have succeeded and produced at least one
 asset. If a referenced producer failed or returned no assets, the dependent step is marked
-`FAILED` before its provider is invoked.
+`FAILED` with `error_code=INVALID_INPUT` before its provider is invoked.
 
 `external_inputs` and `input_from` are mutually exclusive at construction (raises `GenblazeError`). Pass an Asset with `sha256` populated; without it, both the step cache key and the manifest canonical hash will drift across reruns when the URL rotates (e.g., presigned). The reserved kwargs `inputs=` and `input=` raise a friendly error pointing at `external_inputs=`.
 

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -7,6 +7,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "Pipeline": ("genblaze_core.pipeline.pipeline", "Pipeline"),
     "PipelineResult": ("genblaze_core.pipeline.result", "PipelineResult"),
     "StepCompleteEvent": ("genblaze_core.pipeline.result", "StepCompleteEvent"),
+    "sanitize_error": ("genblaze_core._utils", "sanitize_error"),
     # pipeline cache
     "StepCache": ("genblaze_core.pipeline.cache", "StepCache"),
     # pipeline templates

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -7,7 +7,6 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "Pipeline": ("genblaze_core.pipeline.pipeline", "Pipeline"),
     "PipelineResult": ("genblaze_core.pipeline.result", "PipelineResult"),
     "StepCompleteEvent": ("genblaze_core.pipeline.result", "StepCompleteEvent"),
-    "sanitize_error": ("genblaze_core._utils", "sanitize_error"),
     # pipeline cache
     "StepCache": ("genblaze_core.pipeline.cache", "StepCache"),
     # pipeline templates

--- a/libs/core/genblaze_core/_utils.py
+++ b/libs/core/genblaze_core/_utils.py
@@ -127,21 +127,36 @@ MAX_MANIFEST_BYTES = 16 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
-# Credential pattern detection — used by error sanitization (providers/base.py)
+# Credential pattern detection — used by shared error sanitization
 # AND by Pipeline.step build-time rejection of secret-shaped params values.
 # Centralized here so both call sites share one regex of record.
 # ---------------------------------------------------------------------------
+MAX_ERROR_LENGTH = 500
+
 _SECRET_PATTERNS = re.compile(
     r"(r8_[A-Za-z0-9]{20,})"  # Replicate tokens
     r"|(sk-ant-[A-Za-z0-9\-]{20,})"  # Anthropic API keys (before generic sk-)
     r"|(sk-[A-Za-z0-9]{20,})"  # OpenAI-style keys
     r"|(AIza[A-Za-z0-9_\-]{30,})"  # Google API keys
     r"|(AKIA[A-Z0-9]{16})"  # AWS access key IDs
+    r"|(\b(?:aws[_-]?secret[_-]?access[_-]?key|secret[_-]?access[_-]?key)"
+    r"\s*[=:]\s*[A-Za-z0-9/+]{40})"  # AWS secret access keys with label
+    r"|(\bK[0-9]{3}[A-Za-z0-9+/]{20,})"  # Backblaze B2 application keys
+    r"|(https?://[^/\s:@]+:[^/\s@]+@)"  # Basic-auth URL credentials
+    r"|(\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b)"  # JWTs
     r"|(Bearer\s+[A-Za-z0-9._\-]{20,})"  # Bearer tokens
     r"|(Token\s+[A-Za-z0-9._\-]{20,})"  # Token auth headers
     r"|(\bapi[_-]key[=:]\s*[A-Za-z0-9._\-]{20,})",  # api_key=... / api-key:...
     re.IGNORECASE,
 )
+
+
+def sanitize_error(msg: str) -> str:
+    """Redact potential secrets and truncate error messages for safe storage."""
+    sanitized = _SECRET_PATTERNS.sub("[REDACTED]", msg)
+    if len(sanitized) > MAX_ERROR_LENGTH:
+        sanitized = sanitized[:MAX_ERROR_LENGTH] + "...(truncated)"
+    return sanitized
 
 
 def jittered_backoff(attempt: int) -> float:

--- a/libs/core/genblaze_core/_utils.py
+++ b/libs/core/genblaze_core/_utils.py
@@ -132,6 +132,16 @@ MAX_MANIFEST_BYTES = 16 * 1024 * 1024
 # Centralized here so both call sites share one regex of record.
 # ---------------------------------------------------------------------------
 MAX_ERROR_LENGTH = 500
+TRUNCATION_MARKER = "...(truncated)"
+_SANITIZE_SCAN_LIMIT = MAX_ERROR_LENGTH * 4
+_AWS_CREDENTIAL_VALUE_RE = (
+    r"(?<![A-Za-z0-9/+])"
+    r"(?=[A-Za-z0-9/+]{40}(?![A-Za-z0-9/+]))"
+    r"(?=[A-Za-z0-9/+]*[+/])"
+    r"(?=[A-Za-z0-9/+]*[A-Z])"
+    r"(?=[A-Za-z0-9/+]*[a-z])"
+    r"[A-Za-z0-9/+]{40}"
+)
 
 _SECRET_PATTERNS = re.compile(
     r"(r8_[A-Za-z0-9]{20,})"  # Replicate tokens
@@ -139,10 +149,9 @@ _SECRET_PATTERNS = re.compile(
     r"|(sk-[A-Za-z0-9]{20,})"  # OpenAI-style keys
     r"|(AIza[A-Za-z0-9_\-]{30,})"  # Google API keys
     r"|(AKIA[A-Z0-9]{16})"  # AWS access key IDs
-    r"|(\b(?:aws[_-]?secret[_-]?access[_-]?key|secret[_-]?access[_-]?key)"
-    r"\s*[=:]\s*[A-Za-z0-9/+]{40})"  # AWS secret access keys with label
-    r"|(\bK[0-9]{3}[A-Za-z0-9+/]{20,})"  # Backblaze B2 application keys
-    r"|(https?://[^/\s:@]+:[^/\s@]+@)"  # Basic-auth URL credentials
+    rf"|({_AWS_CREDENTIAL_VALUE_RE})"  # AWS secret access keys
+    r"|(\bK005[A-Za-z0-9+/]{20,})"  # Backblaze B2 application keys
+    r"|(https?://[^/\s:@]+:[^/\s@]{12,}@)"  # Basic-auth URL credentials
     r"|(\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b)"  # JWTs
     r"|(Bearer\s+[A-Za-z0-9._\-]{20,})"  # Bearer tokens
     r"|(Token\s+[A-Za-z0-9._\-]{20,})"  # Token auth headers
@@ -153,9 +162,11 @@ _SECRET_PATTERNS = re.compile(
 
 def sanitize_error(msg: str) -> str:
     """Redact potential secrets and truncate error messages for safe storage."""
-    sanitized = _SECRET_PATTERNS.sub("[REDACTED]", msg)
-    if len(sanitized) > MAX_ERROR_LENGTH:
-        sanitized = sanitized[:MAX_ERROR_LENGTH] + "...(truncated)"
+    bounded = msg[:_SANITIZE_SCAN_LIMIT]
+    input_truncated = len(msg) > _SANITIZE_SCAN_LIMIT
+    sanitized = _SECRET_PATTERNS.sub("[REDACTED]", bounded)
+    if input_truncated or len(sanitized) > MAX_ERROR_LENGTH:
+        sanitized = sanitized[:MAX_ERROR_LENGTH] + TRUNCATION_MARKER
     return sanitized
 
 

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -63,6 +63,14 @@ class _InputResolutionError(GenblazeError):
     """Raised when declared upstream step outputs cannot be used as inputs."""
 
 
+@dataclass(frozen=True)
+class _PreparedStep:
+    """A step plus the internal routing decision for runner dispatch."""
+
+    step: Step
+    prefailed: bool = False
+
+
 _INPUT_RESOLUTION_FAILURE_REASON = "input_resolution"
 
 
@@ -717,9 +725,6 @@ class Pipeline(Runnable[None, PipelineResult]):
             for idx in ps.input_from:
                 upstream = completed_steps[idx]
                 if upstream.status != StepStatus.SUCCEEDED:
-                    detail = (
-                        f"; upstream error summary: {upstream.error}" if upstream.error else ""
-                    )
                     upstream_label = (
                         "failed upstream step"
                         if upstream.status == StepStatus.FAILED
@@ -728,7 +733,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                     msg = (
                         f"input_from index {idx} for step {step_index} points to "
                         f"{upstream_label} {idx} ({upstream.step_id}) with status "
-                        f"{upstream.status.value}{detail}"
+                        f"{upstream.status.value}"
                     )
                     raise _InputResolutionError(msg)
                 if not upstream.assets:
@@ -751,20 +756,14 @@ class Pipeline(Runnable[None, PipelineResult]):
         prev_assets: list[Asset],
         *,
         step_id: str | None = None,
-    ) -> Step:
+    ) -> _PreparedStep:
         """Build a runnable step or a FAILED step for unavailable input_from assets."""
         try:
             inputs = self._resolve_inputs(ps, step_index, completed_steps, prev_assets)
         except _InputResolutionError as exc:
-            return self._build_input_resolution_failure_step(ps, exc, step_id=step_id)
-        return self._build_step(ps, inputs, step_id=step_id)
-
-    def _is_input_resolution_failure_step(self, step: Step) -> bool:
-        """Return True for steps prefailed by _build_or_prefail_step."""
-        return (
-            step.metadata.get("failure_reason") == _INPUT_RESOLUTION_FAILURE_REASON
-            and step.metadata.get("provider_invoked") is False
-        )
+            step = self._build_input_resolution_failure_step(ps, exc, step_id=step_id)
+            return _PreparedStep(step=step, prefailed=True)
+        return _PreparedStep(step=self._build_step(ps, inputs, step_id=step_id))
 
     def _build_input_resolution_failure_step(
         self,
@@ -774,16 +773,47 @@ class Pipeline(Runnable[None, PipelineResult]):
         step_id: str | None = None,
     ) -> Step:
         """Build a failed Step when declared input dependencies are unavailable."""
+        if isinstance(ps.prompt, PromptTemplate):
+            msg = (
+                "Step prompt is a PromptTemplate but was not rendered. "
+                "Use batch_run() with dicts or call template.render() "
+                "before passing to step()."
+            )
+            raise GenblazeError(msg)
+
         # Input resolution failed before a provider input list exists, so this
-        # intentionally records no Step.inputs. Exception failures use
-        # _make_failed_step(), which preserves caller-supplied external_inputs.
-        step = self._build_step(ps, None, step_id=step_id)
-        step.status = StepStatus.FAILED
-        step.error = sanitize_error(str(error))
-        step.error_code = ProviderErrorCode.INVALID_INPUT
-        step.metadata["failure_reason"] = _INPUT_RESOLUTION_FAILURE_REASON
-        step.metadata["provider_invoked"] = False
-        return step
+        # intentionally records no Step.inputs and never calls provider hooks
+        # such as normalize_params(). Exception failures use _make_failed_step(),
+        # which preserves caller-supplied external_inputs.
+        params = dict(ps.params)
+        _reject_credentials_in_params(params, ps.provider.name, ps.model)
+        seed = params.pop("seed", None)
+        negative_prompt = params.pop("negative_prompt", None)
+        metadata = self._build_step_metadata(ps)
+        metadata["failure_reason"] = _INPUT_RESOLUTION_FAILURE_REASON
+        metadata["provider_invoked"] = False
+        now = utc_now()
+        step_kwargs: dict[str, Any] = dict(
+            provider=ps.provider.name,
+            model=ps.model,
+            prompt=ps.prompt,
+            negative_prompt=negative_prompt,
+            seed=seed,
+            params=params,
+            modality=ps.modality,
+            step_type=ps.step_type,
+            status=StepStatus.FAILED,
+            inputs=[],
+            assets=[],
+            error=sanitize_error(str(error)),
+            error_code=ProviderErrorCode.INVALID_INPUT,
+            started_at=now,
+            completed_at=now,
+            metadata=metadata,
+        )
+        if step_id is not None:
+            step_kwargs["step_id"] = step_id
+        return Step(**step_kwargs)
 
     def _emit_tracer_step_start(self, step: Step, ctx: _StepContext) -> None:
         """Emit the tracer start hook with the shared step lifecycle shape."""
@@ -829,6 +859,15 @@ class Pipeline(Runnable[None, PipelineResult]):
         self._emit_tracer_step_end(step, ctx, duration_ms=0.0)
         return step
 
+    def _build_step_metadata(self, ps: _PipelineStep) -> dict[str, Any]:
+        """Build persisted pipeline graph metadata for a deferred step."""
+        metadata: dict[str, Any] = {}
+        if ps.fallback_models:
+            metadata["_fallback_models"] = ps.fallback_models
+        if ps.input_from is not None:
+            metadata["_input_from"] = ps.input_from
+        return metadata
+
     def _build_step(
         self,
         ps: _PipelineStep,
@@ -867,11 +906,7 @@ class Pipeline(Runnable[None, PipelineResult]):
         negative_prompt = normalized.pop("negative_prompt", None)
 
         # Persist pipeline graph info in metadata for faithful replay
-        metadata: dict[str, Any] = {}
-        if ps.fallback_models:
-            metadata["_fallback_models"] = ps.fallback_models
-        if ps.input_from is not None:
-            metadata["_input_from"] = ps.input_from
+        metadata = self._build_step_metadata(ps)
 
         step_kwargs: dict[str, Any] = dict(
             provider=ps.provider.name,
@@ -1575,13 +1610,14 @@ class Pipeline(Runnable[None, PipelineResult]):
                         raise PipelineTimeoutError(msg)
 
                 ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
-                step = self._build_or_prefail_step(
+                prepared = self._build_or_prefail_step(
                     ps,
                     i - 1,
                     completed_steps,
                     prev_assets,
                     step_id=step_ids[i - 1],
                 )
+                step = prepared.step
                 logger.debug(
                     "Executing step %d/%d: %s/%s",
                     i,
@@ -1600,7 +1636,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                     )
                 # Input-resolution prefail handling is shared; the runner call
                 # site only differs in sync vs async provider invocation.
-                if self._is_input_resolution_failure_step(step):
+                if prepared.prefailed:
                     result = self._record_prefailed_step(step, ctx)
                 else:
                     result = self._execute_step(ps, step, config, ctx)
@@ -1781,13 +1817,14 @@ class Pipeline(Runnable[None, PipelineResult]):
                             raise PipelineTimeoutError(msg)
 
                     ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
-                    step = self._build_or_prefail_step(
+                    prepared = self._build_or_prefail_step(
                         ps,
                         i - 1,
                         completed_steps,
                         prev_assets,
                         step_id=step_ids[i - 1],
                     )
+                    step = prepared.step
                     logger.debug(
                         "Executing step %d/%d: %s/%s",
                         i,
@@ -1806,7 +1843,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                         )
                     # Input-resolution prefail handling is shared; the runner call
                     # site only differs in sync vs async provider invocation.
-                    if self._is_input_resolution_failure_step(step):
+                    if prepared.prefailed:
                         result = self._record_prefailed_step(step, ctx)
                     else:
                         result = await self._execute_step_async(ps, step, config, ctx)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -53,6 +53,10 @@ from genblaze_core.runnable.config import RunnableConfig
 logger = logging.getLogger("genblaze.pipeline")
 
 
+class _InputResolutionError(GenblazeError):
+    """Raised when declared upstream step outputs cannot be used as inputs."""
+
+
 # Sentinel for ``raise_on_failure``. ``None`` means "caller didn't pass it,
 # warn about the upcoming default flip"; ``True`` / ``False`` are explicit.
 # In genblaze-core 0.4.0 the default becomes ``True`` and the sentinel is
@@ -702,11 +706,44 @@ class Pipeline(Runnable[None, PipelineResult]):
                     raise GenblazeError(msg)
             assets: list[Asset] = []
             for idx in ps.input_from:
-                assets.extend(completed_steps[idx].assets)
+                upstream = completed_steps[idx]
+                if upstream.status != StepStatus.SUCCEEDED:
+                    detail = f": {upstream.error}" if upstream.error else ""
+                    upstream_label = (
+                        "failed upstream step"
+                        if upstream.status == StepStatus.FAILED
+                        else "upstream step"
+                    )
+                    msg = (
+                        f"input_from index {idx} for step {step_index} points to "
+                        f"{upstream_label} {idx} with status {upstream.status.value}{detail}"
+                    )
+                    raise _InputResolutionError(msg)
+                if not upstream.assets:
+                    msg = (
+                        f"input_from index {idx} for step {step_index} resolved no assets "
+                        f"from upstream step {idx}"
+                    )
+                    raise _InputResolutionError(msg)
+                assets.extend(upstream.assets)
             return assets
         if self._chain:
             return prev_assets
         return None
+
+    def _build_input_resolution_failure_step(
+        self,
+        ps: _PipelineStep,
+        error: _InputResolutionError,
+        *,
+        step_id: str | None = None,
+    ) -> Step:
+        """Build a failed Step when declared input dependencies are unavailable."""
+        step = self._build_step(ps, None, step_id=step_id)
+        step.status = StepStatus.FAILED
+        step.error = str(error)
+        step.error_code = ProviderErrorCode.INVALID_INPUT
+        return step
 
     def _build_step(
         self,
@@ -1466,8 +1503,17 @@ class Pipeline(Runnable[None, PipelineResult]):
                         )
                         raise PipelineTimeoutError(msg)
 
-                inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
-                step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
+                ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
+                try:
+                    inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
+                except _InputResolutionError as exc:
+                    step = self._build_input_resolution_failure_step(
+                        ps, exc, step_id=step_ids[i - 1]
+                    )
+                    input_resolution_error = True
+                else:
+                    step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
+                    input_resolution_error = False
                 logger.debug(
                     "Executing step %d/%d: %s/%s",
                     i,
@@ -1475,7 +1521,6 @@ class Pipeline(Runnable[None, PipelineResult]):
                     ps.provider.name,
                     ps.model,
                 )
-                ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
                 self._emit_step_start(ctx, step, ps)
                 if spinner is not None:
                     spinner.step_starting(
@@ -1485,7 +1530,10 @@ class Pipeline(Runnable[None, PipelineResult]):
                         step_index=i - 1,
                         total=total_steps,
                     )
-                result = self._execute_step(ps, step, config, ctx)
+                if input_resolution_error:
+                    result = step
+                else:
+                    result = self._execute_step(ps, step, config, ctx)
                 if spinner is not None:
                     spinner.step_done(ok=result.status == StepStatus.SUCCEEDED)
                 completed_steps.append(result)
@@ -1662,8 +1710,17 @@ class Pipeline(Runnable[None, PipelineResult]):
                             )
                             raise PipelineTimeoutError(msg)
 
-                    inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
-                    step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
+                    ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
+                    try:
+                        inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
+                    except _InputResolutionError as exc:
+                        step = self._build_input_resolution_failure_step(
+                            ps, exc, step_id=step_ids[i - 1]
+                        )
+                        input_resolution_error = True
+                    else:
+                        step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
+                        input_resolution_error = False
                     logger.debug(
                         "Executing step %d/%d: %s/%s",
                         i,
@@ -1671,7 +1728,6 @@ class Pipeline(Runnable[None, PipelineResult]):
                         ps.provider.name,
                         ps.model,
                     )
-                    ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
                     self._emit_step_start(ctx, step, ps)
                     if spinner is not None:
                         spinner.step_starting(
@@ -1681,7 +1737,10 @@ class Pipeline(Runnable[None, PipelineResult]):
                             step_index=i - 1,
                             total=total_steps,
                         )
-                    result = await self._execute_step_async(ps, step, config, ctx)
+                    if input_resolution_error:
+                        result = step
+                    else:
+                        result = await self._execute_step_async(ps, step, config, ctx)
                     if spinner is not None:
                         spinner.step_done(ok=result.status == StepStatus.SUCCEEDED)
                     completed_steps.append(result)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -13,7 +13,13 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal
 
-from genblaze_core._utils import _SECRET_PATTERNS, new_id, normalize_tenant_id, utc_now
+from genblaze_core._utils import (
+    _SECRET_PATTERNS,
+    new_id,
+    normalize_tenant_id,
+    sanitize_error,
+    utc_now,
+)
 from genblaze_core.builders.run_builder import RunBuilder
 from genblaze_core.exceptions import (
     BatchPipelineError,
@@ -45,7 +51,7 @@ from genblaze_core.pipeline.moderation import ModerationHook, ModerationResult
 from genblaze_core.pipeline.result import PipelineResult, StepCompleteEvent
 from genblaze_core.pipeline.streaming import QueueEmitter, progress_to_stream_event
 from genblaze_core.progress_display import Spinner, should_auto_enable
-from genblaze_core.providers.base import BaseProvider, _sanitize_error
+from genblaze_core.providers.base import BaseProvider
 from genblaze_core.providers.validation import ValidationOutcome, ValidationResult
 from genblaze_core.runnable.base import Runnable
 from genblaze_core.runnable.config import RunnableConfig
@@ -55,6 +61,9 @@ logger = logging.getLogger("genblaze.pipeline")
 
 class _InputResolutionError(GenblazeError):
     """Raised when declared upstream step outputs cannot be used as inputs."""
+
+
+_INPUT_RESOLUTION_FAILURE_REASON = "input_resolution"
 
 
 # Sentinel for ``raise_on_failure``. ``None`` means "caller didn't pass it,
@@ -703,15 +712,13 @@ class Pipeline(Runnable[None, PipelineResult]):
                         f"input_from index {idx} is out of range for step {step_index}"
                         f" (only {step_index} prior steps completed)"
                     )
-                    raise GenblazeError(msg)
+                    raise _InputResolutionError(msg)
             assets: list[Asset] = []
             for idx in ps.input_from:
                 upstream = completed_steps[idx]
                 if upstream.status != StepStatus.SUCCEEDED:
                     detail = (
-                        f"; upstream error summary: {_sanitize_error(upstream.error)}"
-                        if upstream.error
-                        else ""
+                        f"; upstream error summary: {upstream.error}" if upstream.error else ""
                     )
                     upstream_label = (
                         "failed upstream step"
@@ -755,7 +762,8 @@ class Pipeline(Runnable[None, PipelineResult]):
     def _is_input_resolution_failure_step(self, step: Step) -> bool:
         """Return True for steps prefailed by _build_or_prefail_step."""
         return (
-            step.status == StepStatus.FAILED and step.error_code == ProviderErrorCode.INVALID_INPUT
+            step.metadata.get("failure_reason") == _INPUT_RESOLUTION_FAILURE_REASON
+            and step.metadata.get("provider_invoked") is False
         )
 
     def _build_input_resolution_failure_step(
@@ -766,10 +774,15 @@ class Pipeline(Runnable[None, PipelineResult]):
         step_id: str | None = None,
     ) -> Step:
         """Build a failed Step when declared input dependencies are unavailable."""
+        # Input resolution failed before a provider input list exists, so this
+        # intentionally records no Step.inputs. Exception failures use
+        # _make_failed_step(), which preserves caller-supplied external_inputs.
         step = self._build_step(ps, None, step_id=step_id)
         step.status = StepStatus.FAILED
-        step.error = _sanitize_error(str(error))
+        step.error = sanitize_error(str(error))
         step.error_code = ProviderErrorCode.INVALID_INPUT
+        step.metadata["failure_reason"] = _INPUT_RESOLUTION_FAILURE_REASON
+        step.metadata["provider_invoked"] = False
         return step
 
     def _emit_tracer_step_start(self, step: Step, ctx: _StepContext) -> None:
@@ -802,6 +815,16 @@ class Pipeline(Runnable[None, PipelineResult]):
 
     def _record_prefailed_step(self, step: Step, ctx: _StepContext) -> Step:
         """Emit tracer lifecycle hooks for a step that failed before provider invoke."""
+        logger.warning(
+            "step.prefailed run_id=%s step_index=%d reason=%s provider=%s model=%s "
+            "error_code=%s provider_invoked=false",
+            ctx.run_id,
+            ctx.step_index,
+            step.metadata.get("failure_reason"),
+            step.provider,
+            step.model,
+            step.error_code.value if step.error_code else None,
+        )
         self._emit_tracer_step_start(step, ctx)
         self._emit_tracer_step_end(step, ctx, duration_ms=0.0)
         return step
@@ -947,7 +970,10 @@ class Pipeline(Runnable[None, PipelineResult]):
             self._cache.put(cache_key_step, result, tenant_id=self._tenant_id)
 
         if result.status == StepStatus.FAILED and result.error:
-            result.error = _sanitize_error(result.error)
+            # Providers usually sanitize their own failures. This pipeline
+            # boundary backstops adapters that return failed Steps directly so
+            # manifests, logs, and stream events share the same redaction cap.
+            result.error = sanitize_error(result.error)
 
         return result
 
@@ -1937,13 +1963,13 @@ class Pipeline(Runnable[None, PipelineResult]):
 
     def _make_failed_step(self, ps: _PipelineStep, exc: Exception) -> Step:
         """Create a FAILED step from an unhandled exception."""
-        from genblaze_core.providers.base import _sanitize_error, classify_api_error
+        from genblaze_core.providers.base import classify_api_error
 
         # Preserve external_inputs on the failed-step record so the manifest
         # shows what the step was supposed to consume.
         step = self._build_step(ps, ps.external_inputs)
         step.status = StepStatus.FAILED
-        step.error = _sanitize_error(str(exc))
+        step.error = sanitize_error(str(exc))
         step.error_code = classify_api_error(exc)
         return step
 

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -45,7 +45,7 @@ from genblaze_core.pipeline.moderation import ModerationHook, ModerationResult
 from genblaze_core.pipeline.result import PipelineResult, StepCompleteEvent
 from genblaze_core.pipeline.streaming import QueueEmitter, progress_to_stream_event
 from genblaze_core.progress_display import Spinner, should_auto_enable
-from genblaze_core.providers.base import BaseProvider
+from genblaze_core.providers.base import BaseProvider, _sanitize_error
 from genblaze_core.providers.validation import ValidationOutcome, ValidationResult
 from genblaze_core.runnable.base import Runnable
 from genblaze_core.runnable.config import RunnableConfig
@@ -708,7 +708,11 @@ class Pipeline(Runnable[None, PipelineResult]):
             for idx in ps.input_from:
                 upstream = completed_steps[idx]
                 if upstream.status != StepStatus.SUCCEEDED:
-                    detail = f": {upstream.error}" if upstream.error else ""
+                    detail = (
+                        f"; upstream error summary: {_sanitize_error(upstream.error)}"
+                        if upstream.error
+                        else ""
+                    )
                     upstream_label = (
                         "failed upstream step"
                         if upstream.status == StepStatus.FAILED
@@ -716,7 +720,8 @@ class Pipeline(Runnable[None, PipelineResult]):
                     )
                     msg = (
                         f"input_from index {idx} for step {step_index} points to "
-                        f"{upstream_label} {idx} with status {upstream.status.value}{detail}"
+                        f"{upstream_label} {idx} ({upstream.step_id}) with status "
+                        f"{upstream.status.value}{detail}"
                     )
                     raise _InputResolutionError(msg)
                 if not upstream.assets:
@@ -731,6 +736,28 @@ class Pipeline(Runnable[None, PipelineResult]):
             return prev_assets
         return None
 
+    def _build_or_prefail_step(
+        self,
+        ps: _PipelineStep,
+        step_index: int,
+        completed_steps: list[Step],
+        prev_assets: list[Asset],
+        *,
+        step_id: str | None = None,
+    ) -> Step:
+        """Build a runnable step or a FAILED step for unavailable input_from assets."""
+        try:
+            inputs = self._resolve_inputs(ps, step_index, completed_steps, prev_assets)
+        except _InputResolutionError as exc:
+            return self._build_input_resolution_failure_step(ps, exc, step_id=step_id)
+        return self._build_step(ps, inputs, step_id=step_id)
+
+    def _is_input_resolution_failure_step(self, step: Step) -> bool:
+        """Return True for steps prefailed by _build_or_prefail_step."""
+        return (
+            step.status == StepStatus.FAILED and step.error_code == ProviderErrorCode.INVALID_INPUT
+        )
+
     def _build_input_resolution_failure_step(
         self,
         ps: _PipelineStep,
@@ -741,12 +768,12 @@ class Pipeline(Runnable[None, PipelineResult]):
         """Build a failed Step when declared input dependencies are unavailable."""
         step = self._build_step(ps, None, step_id=step_id)
         step.status = StepStatus.FAILED
-        step.error = str(error)
+        step.error = _sanitize_error(str(error))
         step.error_code = ProviderErrorCode.INVALID_INPUT
         return step
 
-    def _record_prefailed_step(self, step: Step, ctx: _StepContext) -> Step:
-        """Emit tracer lifecycle hooks for a step that failed before provider invoke."""
+    def _emit_tracer_step_start(self, step: Step, ctx: _StepContext) -> None:
+        """Emit the tracer start hook with the shared step lifecycle shape."""
         safe_call(
             self._tracer,
             "on_step_start",
@@ -755,15 +782,28 @@ class Pipeline(Runnable[None, PipelineResult]):
             step_index=ctx.step_index,
             total_steps=ctx.total_steps,
         )
-        t0 = time.monotonic()
+
+    def _emit_tracer_step_end(
+        self,
+        step: Step,
+        ctx: _StepContext,
+        *,
+        duration_ms: float,
+    ) -> None:
+        """Emit the tracer end hook with the shared step lifecycle shape."""
         safe_call(
             self._tracer,
             "on_step_end",
             ctx.run_id,
             step,
-            duration_ms=(time.monotonic() - t0) * 1000,
+            duration_ms=duration_ms,
             step_index=ctx.step_index,
         )
+
+    def _record_prefailed_step(self, step: Step, ctx: _StepContext) -> Step:
+        """Emit tracer lifecycle hooks for a step that failed before provider invoke."""
+        self._emit_tracer_step_start(step, ctx)
+        self._emit_tracer_step_end(step, ctx, duration_ms=0.0)
         return step
 
     def _build_step(
@@ -906,6 +946,9 @@ class Pipeline(Runnable[None, PipelineResult]):
         if self._cache is not None and result.status == StepStatus.SUCCEEDED:
             self._cache.put(cache_key_step, result, tenant_id=self._tenant_id)
 
+        if result.status == StepStatus.FAILED and result.error:
+            result.error = _sanitize_error(result.error)
+
         return result
 
     def _execute_step(
@@ -935,14 +978,7 @@ class Pipeline(Runnable[None, PipelineResult]):
             if cached is not None:
                 return cached
 
-        safe_call(
-            self._tracer,
-            "on_step_start",
-            ctx.run_id,
-            step,
-            step_index=ctx.step_index,
-            total_steps=ctx.total_steps,
-        )
+        self._emit_tracer_step_start(step, ctx)
         t0 = time.monotonic()
         final: Step = step  # fallback for on_step_end if provider.invoke raises
         try:
@@ -960,13 +996,10 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
             return final
         finally:
-            safe_call(
-                self._tracer,
-                "on_step_end",
-                ctx.run_id,
+            self._emit_tracer_step_end(
                 final,
+                ctx,
                 duration_ms=(time.monotonic() - t0) * 1000,
-                step_index=ctx.step_index,
             )
 
     async def _execute_step_async(
@@ -996,14 +1029,7 @@ class Pipeline(Runnable[None, PipelineResult]):
             if cached is not None:
                 return cached
 
-        safe_call(
-            self._tracer,
-            "on_step_start",
-            ctx.run_id,
-            step,
-            step_index=ctx.step_index,
-            total_steps=ctx.total_steps,
-        )
+        self._emit_tracer_step_start(step, ctx)
         t0 = time.monotonic()
         final: Step = step  # fallback for on_step_end if ainvoke raises
         try:
@@ -1058,13 +1084,10 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
             return final
         finally:
-            safe_call(
-                self._tracer,
-                "on_step_end",
-                ctx.run_id,
+            self._emit_tracer_step_end(
                 final,
+                ctx,
                 duration_ms=(time.monotonic() - t0) * 1000,
-                step_index=ctx.step_index,
             )
 
     def _finalize(
@@ -1238,7 +1261,8 @@ class Pipeline(Runnable[None, PipelineResult]):
         )
 
     def _emit_step_complete_event(self, step_event: StepCompleteEvent, run_id: str) -> None:
-        # Tracer already gets on_step_end inside _execute_step; emitter-only here.
+        # Tracer on_step_end is paired in _execute_step, _execute_step_async,
+        # and _record_prefailed_step via _emit_tracer_step_end; emitter-only here.
         if self._event_emitter is not None:
             self._event_emitter.on_step_complete(step_event)
 
@@ -1525,16 +1549,13 @@ class Pipeline(Runnable[None, PipelineResult]):
                         raise PipelineTimeoutError(msg)
 
                 ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
-                try:
-                    inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
-                except _InputResolutionError as exc:
-                    step = self._build_input_resolution_failure_step(
-                        ps, exc, step_id=step_ids[i - 1]
-                    )
-                    input_resolution_error = True
-                else:
-                    step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
-                    input_resolution_error = False
+                step = self._build_or_prefail_step(
+                    ps,
+                    i - 1,
+                    completed_steps,
+                    prev_assets,
+                    step_id=step_ids[i - 1],
+                )
                 logger.debug(
                     "Executing step %d/%d: %s/%s",
                     i,
@@ -1551,7 +1572,9 @@ class Pipeline(Runnable[None, PipelineResult]):
                         step_index=i - 1,
                         total=total_steps,
                     )
-                if input_resolution_error:
+                # Input-resolution prefail handling is shared; the runner call
+                # site only differs in sync vs async provider invocation.
+                if self._is_input_resolution_failure_step(step):
                     result = self._record_prefailed_step(step, ctx)
                 else:
                     result = self._execute_step(ps, step, config, ctx)
@@ -1732,16 +1755,13 @@ class Pipeline(Runnable[None, PipelineResult]):
                             raise PipelineTimeoutError(msg)
 
                     ctx = _StepContext(run_id=run_id, step_index=i - 1, total_steps=total_steps)
-                    try:
-                        inputs = self._resolve_inputs(ps, i - 1, completed_steps, prev_assets)
-                    except _InputResolutionError as exc:
-                        step = self._build_input_resolution_failure_step(
-                            ps, exc, step_id=step_ids[i - 1]
-                        )
-                        input_resolution_error = True
-                    else:
-                        step = self._build_step(ps, inputs, step_id=step_ids[i - 1])
-                        input_resolution_error = False
+                    step = self._build_or_prefail_step(
+                        ps,
+                        i - 1,
+                        completed_steps,
+                        prev_assets,
+                        step_id=step_ids[i - 1],
+                    )
                     logger.debug(
                         "Executing step %d/%d: %s/%s",
                         i,
@@ -1758,7 +1778,9 @@ class Pipeline(Runnable[None, PipelineResult]):
                             step_index=i - 1,
                             total=total_steps,
                         )
-                    if input_resolution_error:
+                    # Input-resolution prefail handling is shared; the runner call
+                    # site only differs in sync vs async provider invocation.
+                    if self._is_input_resolution_failure_step(step):
                         result = self._record_prefailed_step(step, ctx)
                     else:
                         result = await self._execute_step_async(ps, step, config, ctx)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -745,6 +745,27 @@ class Pipeline(Runnable[None, PipelineResult]):
         step.error_code = ProviderErrorCode.INVALID_INPUT
         return step
 
+    def _record_prefailed_step(self, step: Step, ctx: _StepContext) -> Step:
+        """Emit tracer lifecycle hooks for a step that failed before provider invoke."""
+        safe_call(
+            self._tracer,
+            "on_step_start",
+            ctx.run_id,
+            step,
+            step_index=ctx.step_index,
+            total_steps=ctx.total_steps,
+        )
+        t0 = time.monotonic()
+        safe_call(
+            self._tracer,
+            "on_step_end",
+            ctx.run_id,
+            step,
+            duration_ms=(time.monotonic() - t0) * 1000,
+            step_index=ctx.step_index,
+        )
+        return step
+
     def _build_step(
         self,
         ps: _PipelineStep,
@@ -1531,7 +1552,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                         total=total_steps,
                     )
                 if input_resolution_error:
-                    result = step
+                    result = self._record_prefailed_step(step, ctx)
                 else:
                     result = self._execute_step(ps, step, config, ctx)
                 if spinner is not None:
@@ -1738,7 +1759,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                             total=total_steps,
                         )
                     if input_resolution_error:
-                        result = step
+                        result = self._record_prefailed_step(step, ctx)
                     else:
                         result = await self._execute_step_async(ps, step, config, ctx)
                     if spinner is not None:

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import unquote, urlparse
 
-from genblaze_core._utils import _SECRET_PATTERNS, new_id, utc_now
+from genblaze_core._utils import new_id, sanitize_error, utc_now
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import (
@@ -65,9 +65,6 @@ DEFAULT_TIMEOUT = 600.0  # 10 minutes
 _HEARTBEAT_THRESHOLD_SEC = 15.0
 _HEARTBEAT_CHUNK_SEC = 10.0
 
-# Max error message length stored in step.error (prevents bloated manifests)
-_MAX_ERROR_LENGTH = 500
-
 # Max consecutive transient poll() errors tolerated inside a single invoke().
 # Guards against misclassification in connectors that wrap httpx/boto exceptions
 # opaquely — a single 503 mid-poll shouldn't fail a 10-minute video generation.
@@ -113,14 +110,6 @@ def _adaptive_poll_interval(elapsed: float, base: float, max_interval: float = 3
     """
     doublings = int(elapsed / 30)
     return min(base * (2**doublings), max_interval)
-
-
-def _sanitize_error(msg: str) -> str:
-    """Redact potential secrets and truncate error messages for safe storage."""
-    sanitized = _SECRET_PATTERNS.sub("[REDACTED]", msg)
-    if len(sanitized) > _MAX_ERROR_LENGTH:
-        sanitized = sanitized[:_MAX_ERROR_LENGTH] + "...(truncated)"
-    return sanitized
 
 
 def classify_api_error(exc: Exception | str) -> ProviderErrorCode:
@@ -1283,7 +1272,7 @@ class BaseProvider(Runnable[Step, Step]):
                 max_attempts=max_attempts,
                 delay_sec=delay,
                 error_code=str(code) if code else None,
-                error=_sanitize_error(str(exc)),
+                error=sanitize_error(str(exc)),
             )
         )
 
@@ -1513,7 +1502,7 @@ class BaseProvider(Runnable[Step, Step]):
             else classify_api_error(exc)
         )
         step.status = StepStatus.FAILED
-        step.error = _sanitize_error(str(exc))
+        step.error = sanitize_error(str(exc))
         step.error_code = error_code
         step.completed_at = utc_now()
         self._fire_progress(step, config, "failed", start_time)
@@ -1664,7 +1653,7 @@ class BaseProvider(Runnable[Step, Step]):
                     retryable = error_code in self.retry_policy.retryable_codes
                     if not retryable or attempt >= max_retries:
                         step.status = StepStatus.FAILED
-                        step.error = _sanitize_error(str(exc))
+                        step.error = sanitize_error(str(exc))
                         step.error_code = error_code
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
@@ -1691,7 +1680,7 @@ class BaseProvider(Runnable[Step, Step]):
                     elapsed = time.monotonic() - start_time
                     if elapsed + backoff >= timeout:
                         step.status = StepStatus.FAILED
-                        step.error = _sanitize_error(str(exc))
+                        step.error = sanitize_error(str(exc))
                         step.error_code = error_code
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
@@ -1832,7 +1821,7 @@ class BaseProvider(Runnable[Step, Step]):
                     retryable = error_code in self.retry_policy.retryable_codes
                     if not retryable or attempt >= max_retries:
                         step.status = StepStatus.FAILED
-                        step.error = _sanitize_error(str(exc))
+                        step.error = sanitize_error(str(exc))
                         step.error_code = error_code
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)
@@ -1858,7 +1847,7 @@ class BaseProvider(Runnable[Step, Step]):
                     elapsed = time.monotonic() - start_time
                     if elapsed + backoff >= timeout:
                         step.status = StepStatus.FAILED
-                        step.error = _sanitize_error(str(exc))
+                        step.error = sanitize_error(str(exc))
                         step.error_code = error_code
                         step.completed_at = utc_now()
                         self._fire_progress(step, config, "failed", start_time)

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -1285,6 +1285,51 @@ async def test_input_from_arun() -> None:
     assert "https://example.com/async1.png" in urls
 
 
+def test_input_from_failed_producer_fails_consumer() -> None:
+    """A fan-in consumer cannot succeed on assets from a failed producer."""
+    failing = FailingProvider()
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+
+    result = (
+        Pipeline("fan-in-failed-source")
+        .step(failing, model="m0", prompt="fails")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert len(result.run.steps) == 2
+    assert result.run.steps[0].status == StepStatus.FAILED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].assets == []
+    assert "input_from index 0" in (result.run.steps[1].error or "")
+    assert "failed upstream step 0" in (result.run.steps[1].error or "")
+    assert consumer.received_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_input_from_failed_producer_fails_consumer_async() -> None:
+    """Async fan-in also fails before invoking a consumer with missing inputs."""
+    failing = FailingProvider()
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+
+    result = await (
+        Pipeline("fan-in-failed-source-async")
+        .step(failing, model="m0", prompt="fails")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .arun(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert len(result.run.steps) == 2
+    assert result.run.steps[0].status == StepStatus.FAILED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].assets == []
+    assert "input_from index 0" in (result.run.steps[1].error or "")
+    assert "failed upstream step 0" in (result.run.steps[1].error or "")
+    assert consumer.received_inputs == []
+
+
 # --- Chain failure propagation tests (fail_fast=False) ---
 
 

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -1,12 +1,13 @@
 """Tests for Pipeline API."""
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import pytest
 from genblaze_core.exceptions import GenblazeError
 from genblaze_core.models.asset import Asset
-from genblaze_core.models.enums import RunStatus, StepStatus
+from genblaze_core.models.enums import ProviderErrorCode, RunStatus, StepStatus
 from genblaze_core.models.step import Step
 from genblaze_core.pipeline import Pipeline, StepCache
 from genblaze_core.pipeline.result import PipelineResult
@@ -338,6 +339,32 @@ class FailingProvider(BaseProvider):
 
     def fetch_output(self, prediction_id: Any, step: Step) -> Step:
         return step
+
+
+class RawFailedStepProvider(BaseProvider):
+    """Provider that returns a failed Step with an unsanitized error."""
+
+    name = "raw-failed"
+
+    def __init__(self, error: str) -> None:
+        super().__init__()
+        self.error = error
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        return "pred-raw-failed"
+
+    def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
+        return True
+
+    def fetch_output(self, prediction_id: Any, step: Step) -> Step:
+        return step
+
+    def invoke(self, step: Step, config: RunnableConfig | None = None) -> Step:
+        failed = step.model_copy()
+        failed.status = StepStatus.FAILED
+        failed.error = self.error
+        failed.error_code = ProviderErrorCode.SERVER_ERROR
+        return failed
 
 
 class EmptyAssetProvider(BaseProvider):
@@ -1316,9 +1343,9 @@ def test_input_from_failed_producer_fails_consumer() -> None:
     assert len(result.run.steps) == 2
     assert result.run.steps[0].status == StepStatus.FAILED
     assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
-    assert "input_from index 0" in (result.run.steps[1].error or "")
-    assert "failed upstream step 0" in (result.run.steps[1].error or "")
+    assert result.run.steps[1].error
     assert consumer.received_inputs == []
 
 
@@ -1339,9 +1366,9 @@ async def test_input_from_failed_producer_fails_consumer_async() -> None:
     assert len(result.run.steps) == 2
     assert result.run.steps[0].status == StepStatus.FAILED
     assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
-    assert "input_from index 0" in (result.run.steps[1].error or "")
-    assert "failed upstream step 0" in (result.run.steps[1].error or "")
+    assert result.run.steps[1].error
     assert consumer.received_inputs == []
 
 
@@ -1362,8 +1389,9 @@ def test_input_from_empty_producer_fails_consumer() -> None:
     assert result.run.steps[0].status == StepStatus.SUCCEEDED
     assert result.run.steps[0].assets == []
     assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
-    assert "resolved no assets from upstream step 0" in (result.run.steps[1].error or "")
+    assert result.run.steps[1].error
     assert consumer.received_inputs == []
 
 
@@ -1385,8 +1413,69 @@ async def test_input_from_empty_producer_fails_consumer_async() -> None:
     assert result.run.steps[0].status == StepStatus.SUCCEEDED
     assert result.run.steps[0].assets == []
     assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
-    assert "resolved no assets from upstream step 0" in (result.run.steps[1].error or "")
+    assert result.run.steps[1].error
+    assert consumer.received_inputs == []
+
+
+def test_input_from_mixed_producers_fails_consumer_before_invocation() -> None:
+    """A fan-in consumer fails if any declared producer failed."""
+    ok = ChainableProvider(output_url="https://example.com/ok.png")
+    failing = FailingProvider()
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+
+    result = (
+        Pipeline("fan-in-mixed-source")
+        .step(ok, model="m0", prompt="audio")
+        .step(failing, model="m1", prompt="video")
+        .step(consumer, model="m2", prompt="compose", input_from=[0, 1])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert result.run.steps[0].status == StepStatus.SUCCEEDED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[2].status == StepStatus.FAILED
+    assert result.run.steps[2].error_code == ProviderErrorCode.INVALID_INPUT
+    assert result.run.steps[2].assets == []
+    assert ok.received_inputs == [[]]
+    assert consumer.received_inputs == []
+
+
+def test_input_from_failure_sanitizes_upstream_error_surfaces(caplog) -> None:
+    """Unsafe upstream errors are not copied raw into fan-in telemetry."""
+    token = "tok_" + ("a" * 40)
+    oversized_tail = "Z" * 1000
+    raw_error = f"Authorization: Bearer {token}; {oversized_tail}"
+    upstream = RawFailedStepProvider(raw_error)
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+    caplog.set_level(logging.WARNING, logger="genblaze.pipeline")
+
+    events = list(
+        Pipeline("fan-in-sanitized-source")
+        .step(upstream, model="m0", prompt="fails")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .stream(heartbeats=False, fail_fast=False, raise_on_failure=False)
+    )
+
+    result = events[-1].result
+    assert result is not None
+    dependent = result.run.steps[1]
+    assert dependent.status == StepStatus.FAILED
+    assert dependent.error_code == ProviderErrorCode.INVALID_INPUT
+    assert dependent.error is not None
+    assert len(dependent.error) < 800
+
+    surfaces = [
+        dependent.error,
+        result.manifest.to_canonical_json(),
+        "\n".join(str(event.to_dict()) for event in events),
+        "\n".join(record.getMessage() for record in caplog.records),
+    ]
+    for surface in surfaces:
+        assert token not in surface
+        assert oversized_tail not in surface
     assert consumer.received_inputs == []
 
 

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -1273,18 +1273,25 @@ def test_input_from_overrides_chain_mode() -> None:
     assert p2.received_inputs[0][0].url == "https://example.com/step0.png"
 
 
-def test_input_from_invalid_index_raises() -> None:
-    """Referencing a step index beyond completed steps raises GenblazeError."""
+def test_input_from_invalid_index_prefails_consumer() -> None:
+    """Referencing a future/missing step fails only the dependent consumer."""
     p0 = ChainableProvider()
     p1 = ChainableProvider()
 
-    with pytest.raises(GenblazeError, match="input_from index 5 is out of range"):
-        (
-            Pipeline("fan-in-bad")
-            .step(p0, model="m0", prompt="zero")
-            .step(p1, model="m1", prompt="one", input_from=[5])
-            .run()
-        )
+    result = (
+        Pipeline("fan-in-bad")
+        .step(p0, model="m0", prompt="zero")
+        .step(p1, model="m1", prompt="one", input_from=[5])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert result.run.steps[0].status == StepStatus.SUCCEEDED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert result.run.steps[1].metadata["failure_reason"] == "input_resolution"
+    assert result.run.steps[1].metadata["provider_invoked"] is False
+    assert p1.received_inputs == []
 
 
 def test_input_from_none_preserves_existing_behavior() -> None:
@@ -1344,6 +1351,8 @@ def test_input_from_failed_producer_fails_consumer() -> None:
     assert result.run.steps[0].status == StepStatus.FAILED
     assert result.run.steps[1].status == StepStatus.FAILED
     assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert result.run.steps[1].metadata["failure_reason"] == "input_resolution"
+    assert result.run.steps[1].metadata["provider_invoked"] is False
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
     assert consumer.received_inputs == []
@@ -1367,6 +1376,8 @@ async def test_input_from_failed_producer_fails_consumer_async() -> None:
     assert result.run.steps[0].status == StepStatus.FAILED
     assert result.run.steps[1].status == StepStatus.FAILED
     assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert result.run.steps[1].metadata["failure_reason"] == "input_resolution"
+    assert result.run.steps[1].metadata["provider_invoked"] is False
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
     assert consumer.received_inputs == []
@@ -1445,9 +1456,21 @@ def test_input_from_mixed_producers_fails_consumer_before_invocation() -> None:
 
 def test_input_from_failure_sanitizes_upstream_error_surfaces(caplog) -> None:
     """Unsafe upstream errors are not copied raw into fan-in telemetry."""
-    token = "tok_" + ("a" * 40)
+    bearer = "tok_" + ("a" * 40)
+    aws_secret = "aBcD1234/+" * 4
+    b2_key = "K005" + ("B2keyValue/" * 3)
+    basic_auth_value = "pass" + "word-value-1234567890"
+    basic_url = f"https://user:{basic_auth_value}@example.com/object"
+    jwt = f"eyJ{'a' * 20}.{'b' * 20}.{'c' * 20}"
     oversized_tail = "Z" * 1000
-    raw_error = f"Authorization: Bearer {token}; {oversized_tail}"
+    raw_error = (
+        f"Authorization: Bearer {bearer}; "
+        f"AWS_SECRET_ACCESS_KEY={aws_secret}; "
+        f"B2_APPLICATION_KEY={b2_key}; "
+        f"url={basic_url}; "
+        f"jwt={jwt}; "
+        f"{oversized_tail}"
+    )
     upstream = RawFailedStepProvider(raw_error)
     consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
     caplog.set_level(logging.WARNING, logger="genblaze.pipeline")
@@ -1464,6 +1487,8 @@ def test_input_from_failure_sanitizes_upstream_error_surfaces(caplog) -> None:
     dependent = result.run.steps[1]
     assert dependent.status == StepStatus.FAILED
     assert dependent.error_code == ProviderErrorCode.INVALID_INPUT
+    assert dependent.metadata["failure_reason"] == "input_resolution"
+    assert dependent.metadata["provider_invoked"] is False
     assert dependent.error is not None
     assert len(dependent.error) < 800
 
@@ -1474,8 +1499,15 @@ def test_input_from_failure_sanitizes_upstream_error_surfaces(caplog) -> None:
         "\n".join(record.getMessage() for record in caplog.records),
     ]
     for surface in surfaces:
-        assert token not in surface
-        assert oversized_tail not in surface
+        for secret in [
+            bearer,
+            aws_secret,
+            b2_key,
+            basic_auth_value,
+            jwt,
+            oversized_tail,
+        ]:
+            assert secret not in surface
     assert consumer.received_inputs == []
 
 

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from genblaze_core._utils import MAX_ERROR_LENGTH, TRUNCATION_MARKER
 from genblaze_core.exceptions import GenblazeError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import ProviderErrorCode, RunStatus, StepStatus
@@ -496,6 +497,40 @@ class ChainableProvider(BaseProvider):
     def fetch_output(self, prediction_id: Any, step: Step) -> Step:
         step.assets.append(Asset(url=self.output_url, media_type="image/png"))
         return step
+
+
+class HookTrackingProvider(BaseProvider):
+    """Provider whose hooks must not run when a consumer is prefailed."""
+
+    name = "hook-tracking"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.hook_calls: list[str] = []
+
+    def normalize_params(self, params, modality=None):
+        self.hook_calls.append("normalize_params")
+        raise AssertionError("normalize_params should not run for prefailed consumers")
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        self.hook_calls.append("submit")
+        raise AssertionError("submit should not run for prefailed consumers")
+
+    def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
+        self.hook_calls.append("poll")
+        raise AssertionError("poll should not run for prefailed consumers")
+
+    def fetch_output(self, prediction_id: Any, step: Step) -> Step:
+        self.hook_calls.append("fetch_output")
+        raise AssertionError("fetch_output should not run for prefailed consumers")
+
+    def invoke(self, step: Step, config: RunnableConfig | None = None) -> Step:
+        self.hook_calls.append("invoke")
+        raise AssertionError("invoke should not run for prefailed consumers")
+
+    async def ainvoke(self, step: Step, config: RunnableConfig | None = None) -> Step:
+        self.hook_calls.append("ainvoke")
+        raise AssertionError("ainvoke should not run for prefailed consumers")
 
 
 def test_chain_passes_outputs_as_inputs() -> None:
@@ -1294,6 +1329,45 @@ def test_input_from_invalid_index_prefails_consumer() -> None:
     assert p1.received_inputs == []
 
 
+def test_input_from_invalid_index_default_run_returns_failed_result() -> None:
+    """Default run() treats invalid input_from as a failed step, not an exception."""
+    p0 = ChainableProvider()
+    p1 = ChainableProvider()
+
+    with pytest.warns(DeprecationWarning):
+        result = (
+            Pipeline("fan-in-bad-default")
+            .step(p0, model="m0", prompt="zero")
+            .step(p1, model="m1", prompt="one", input_from=[5])
+            .run()
+        )
+
+    assert result.run.status == RunStatus.FAILED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert p1.received_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_input_from_invalid_index_default_arun_returns_failed_result() -> None:
+    """Default arun() treats invalid input_from as a failed step, not an exception."""
+    p0 = ChainableProvider()
+    p1 = ChainableProvider()
+
+    with pytest.warns(DeprecationWarning):
+        result = await (
+            Pipeline("fan-in-bad-default-async")
+            .step(p0, model="m0", prompt="zero")
+            .step(p1, model="m1", prompt="one", input_from=[5])
+            .arun()
+        )
+
+    assert result.run.status == RunStatus.FAILED
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert p1.received_inputs == []
+
+
 def test_input_from_none_preserves_existing_behavior() -> None:
     """Chain mode works normally when input_from is not set."""
     p0 = ChainableProvider(output_url="https://example.com/chain0.png")
@@ -1355,6 +1429,8 @@ def test_input_from_failed_producer_fails_consumer() -> None:
     assert result.run.steps[1].metadata["provider_invoked"] is False
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
+    assert result.run.steps[1].started_at is not None
+    assert result.run.steps[1].completed_at is not None
     assert consumer.received_inputs == []
 
 
@@ -1380,6 +1456,8 @@ async def test_input_from_failed_producer_fails_consumer_async() -> None:
     assert result.run.steps[1].metadata["provider_invoked"] is False
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
+    assert result.run.steps[1].started_at is not None
+    assert result.run.steps[1].completed_at is not None
     assert consumer.received_inputs == []
 
 
@@ -1403,6 +1481,8 @@ def test_input_from_empty_producer_fails_consumer() -> None:
     assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
+    assert result.run.steps[1].started_at is not None
+    assert result.run.steps[1].completed_at is not None
     assert consumer.received_inputs == []
 
 
@@ -1427,7 +1507,44 @@ async def test_input_from_empty_producer_fails_consumer_async() -> None:
     assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
     assert result.run.steps[1].assets == []
     assert result.run.steps[1].error
+    assert result.run.steps[1].started_at is not None
+    assert result.run.steps[1].completed_at is not None
     assert consumer.received_inputs == []
+
+
+def test_input_from_prefail_does_not_call_consumer_provider_hooks() -> None:
+    """A prefailed consumer is built without downstream provider hooks."""
+    failing = FailingProvider()
+    consumer = HookTrackingProvider()
+
+    result = (
+        Pipeline("fan-in-no-consumer-hooks")
+        .step(failing, model="m0", prompt="fails")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert consumer.hook_calls == []
+
+
+@pytest.mark.asyncio
+async def test_input_from_prefail_does_not_call_consumer_provider_hooks_async() -> None:
+    """Async prefailed consumers also avoid downstream provider hooks."""
+    failing = FailingProvider()
+    consumer = HookTrackingProvider()
+
+    result = await (
+        Pipeline("fan-in-no-consumer-hooks-async")
+        .step(failing, model="m0", prompt="fails")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .arun(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].error_code == ProviderErrorCode.INVALID_INPUT
+    assert consumer.hook_calls == []
 
 
 def test_input_from_mixed_producers_fails_consumer_before_invocation() -> None:
@@ -1490,7 +1607,7 @@ def test_input_from_failure_sanitizes_upstream_error_surfaces(caplog) -> None:
     assert dependent.metadata["failure_reason"] == "input_resolution"
     assert dependent.metadata["provider_invoked"] is False
     assert dependent.error is not None
-    assert len(dependent.error) < 800
+    assert len(dependent.error) <= MAX_ERROR_LENGTH + len(TRUNCATION_MARKER)
 
     surfaces = [
         dependent.error,

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -340,6 +340,21 @@ class FailingProvider(BaseProvider):
         return step
 
 
+class EmptyAssetProvider(BaseProvider):
+    """Provider that succeeds without returning any assets."""
+
+    name = "empty"
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        return "pred-empty"
+
+    def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
+        return True
+
+    def fetch_output(self, prediction_id: Any, step: Step) -> Step:
+        return step
+
+
 def test_pipeline_fail_fast_stops_on_failure() -> None:
     """With fail_fast=True (default), pipeline stops after first failed step."""
     failing = FailingProvider()
@@ -1327,6 +1342,28 @@ async def test_input_from_failed_producer_fails_consumer_async() -> None:
     assert result.run.steps[1].assets == []
     assert "input_from index 0" in (result.run.steps[1].error or "")
     assert "failed upstream step 0" in (result.run.steps[1].error or "")
+    assert consumer.received_inputs == []
+
+
+def test_input_from_empty_producer_fails_consumer() -> None:
+    """A successful producer with no assets cannot feed a fan-in consumer."""
+    empty = EmptyAssetProvider()
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+
+    result = (
+        Pipeline("fan-in-empty-source")
+        .step(empty, model="m0", prompt="empty")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert len(result.run.steps) == 2
+    assert result.run.steps[0].status == StepStatus.SUCCEEDED
+    assert result.run.steps[0].assets == []
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].assets == []
+    assert "resolved no assets from upstream step 0" in (result.run.steps[1].error or "")
     assert consumer.received_inputs == []
 
 

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -1367,6 +1367,29 @@ def test_input_from_empty_producer_fails_consumer() -> None:
     assert consumer.received_inputs == []
 
 
+@pytest.mark.asyncio
+async def test_input_from_empty_producer_fails_consumer_async() -> None:
+    """Async fan-in fails before consuming an upstream step with no assets."""
+    empty = EmptyAssetProvider()
+    consumer = ChainableProvider(output_url="https://example.com/should-not-exist.png")
+
+    result = await (
+        Pipeline("fan-in-empty-source-async")
+        .step(empty, model="m0", prompt="empty")
+        .step(consumer, model="m1", prompt="consume", input_from=[0])
+        .arun(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert result.run.status == RunStatus.FAILED
+    assert len(result.run.steps) == 2
+    assert result.run.steps[0].status == StepStatus.SUCCEEDED
+    assert result.run.steps[0].assets == []
+    assert result.run.steps[1].status == StepStatus.FAILED
+    assert result.run.steps[1].assets == []
+    assert "resolved no assets from upstream step 0" in (result.run.steps[1].error or "")
+    assert consumer.received_inputs == []
+
+
 # --- Chain failure propagation tests (fail_fast=False) ---
 
 

--- a/libs/core/tests/unit/test_secret_redaction.py
+++ b/libs/core/tests/unit/test_secret_redaction.py
@@ -1,6 +1,10 @@
 """Tests for secret redaction in provider error messages."""
 
-from genblaze_core import sanitize_error
+from genblaze_core._utils import MAX_ERROR_LENGTH, TRUNCATION_MARKER, sanitize_error
+
+
+def _aws_credential_value() -> str:
+    return "wJalr" + "XUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
 
 class TestSecretRedaction:
@@ -59,8 +63,8 @@ class TestSecretRedaction:
     def test_truncation(self):
         msg = "x" * 600
         result = sanitize_error(msg)
-        assert len(result) < 600
-        assert "...(truncated)" in result
+        assert len(result) == MAX_ERROR_LENGTH + len(TRUNCATION_MARKER)
+        assert result.endswith(TRUNCATION_MARKER)
 
     def test_google_api_key_redacted(self):
         # Google-shaped key assembled at runtime so the literal isn't a static
@@ -88,10 +92,31 @@ class TestSecretRedaction:
         assert sanitize_error(msg) == msg
 
     def test_aws_secret_access_key_redacted(self):
-        secret = "aBcD1234/+" * 4
-        msg = f"AWS_SECRET_ACCESS_KEY={secret}"
+        credential = _aws_credential_value()
+        msg = f"AWS_SECRET_ACCESS_KEY={credential}"
         result = sanitize_error(msg)
-        assert secret not in result
+        assert credential not in result
+        assert "[REDACTED]" in result
+
+    def test_aws_secret_access_key_json_redacted(self):
+        credential = _aws_credential_value()
+        msg = f'{{"SecretAccessKey": "{credential}"}}'
+        result = sanitize_error(msg)
+        assert credential not in result
+        assert "[REDACTED]" in result
+
+    def test_aws_secret_access_key_repr_redacted(self):
+        credential = _aws_credential_value()
+        msg = f"aws_secret_access_key='{credential}'"
+        result = sanitize_error(msg)
+        assert credential not in result
+        assert "[REDACTED]" in result
+
+    def test_aws_secret_access_key_bare_redacted(self):
+        credential = _aws_credential_value()
+        msg = f"SignatureDoesNotMatch computed with key {credential}"
+        result = sanitize_error(msg)
+        assert credential not in result
         assert "[REDACTED]" in result
 
     def test_b2_application_key_redacted(self):
@@ -114,3 +139,26 @@ class TestSecretRedaction:
         result = sanitize_error(msg)
         assert token not in result
         assert "[REDACTED]" in result
+
+    def test_benign_k_token_not_redacted(self):
+        token = "K123" + ("A" * 24)
+        msg = f"Request id {token} was not found"
+        assert sanitize_error(msg) == msg
+
+    def test_short_userinfo_url_not_redacted(self):
+        msg = "Fetch failed: https://user:id@example.com/object"
+        assert sanitize_error(msg) == msg
+
+    def test_large_error_scans_bounded_window(self):
+        secret = "sk-" + ("a" * 40)
+        msg = f"prefix {secret} " + ("x" * (MAX_ERROR_LENGTH * 20))
+        result = sanitize_error(msg)
+        assert secret not in result
+        assert result.endswith(TRUNCATION_MARKER)
+        assert len(result) == MAX_ERROR_LENGTH + len(TRUNCATION_MARKER)
+
+    def test_sanitize_error_does_not_nest_truncation_marker(self):
+        msg = ("x" * MAX_ERROR_LENGTH) + TRUNCATION_MARKER
+        result = sanitize_error(msg)
+        assert result.endswith(TRUNCATION_MARKER)
+        assert result.count(TRUNCATION_MARKER) == 1

--- a/libs/core/tests/unit/test_secret_redaction.py
+++ b/libs/core/tests/unit/test_secret_redaction.py
@@ -1,6 +1,6 @@
 """Tests for secret redaction in provider error messages."""
 
-from genblaze_core.providers.base import _sanitize_error
+from genblaze_core import sanitize_error
 
 
 class TestSecretRedaction:
@@ -8,25 +8,25 @@ class TestSecretRedaction:
 
     def test_replicate_token_redacted(self):
         msg = "Auth failed: r8_abcdefghij1234567890"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "r8_" not in result
         assert "[REDACTED]" in result
 
     def test_openai_key_redacted(self):
         msg = "Invalid key: sk-abcdefghijklmnopqrstuvwxyz"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "sk-" not in result
         assert "[REDACTED]" in result
 
     def test_bearer_token_redacted(self):
         msg = "Header: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "eyJ" not in result
         assert "[REDACTED]" in result
 
     def test_token_auth_redacted(self):
         msg = "Header: Token abcdefghijklmnopqrstuvwxyz1234"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "abcdefghij" not in result
         assert "[REDACTED]" in result
 
@@ -35,30 +35,30 @@ class TestSecretRedaction:
         # secret for secret-scanning / push-protection (it's only test data).
         secret = "sk_live_" + "abcdefghijklmnopqrstuvwx"
         msg = f"Request failed: api_key={secret}"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "sk_live" not in result
         assert "[REDACTED]" in result
 
     def test_api_key_colon_redacted(self):
         msg = "Config: api-key: my_secret_key_value_1234567890"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "my_secret" not in result
         assert "[REDACTED]" in result
 
     def test_keyboard_false_positive_not_redacted(self):
         """Words starting with 'key' like 'keyboard' should NOT be redacted."""
         msg = "keyboardabcdefghijklmnopqrstuvwxyz is not a secret"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert result == msg
 
     def test_keyword_false_positive_not_redacted(self):
         msg = "keyword_for_search_in_the_database_query"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert result == msg
 
     def test_truncation(self):
         msg = "x" * 600
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert len(result) < 600
         assert "...(truncated)" in result
 
@@ -67,22 +67,50 @@ class TestSecretRedaction:
         # secret for secret-scanning / push-protection (it's only test data).
         secret = "AIza" + "SyA1234567890abcdefghijklmnopqrstuv"
         msg = f"Error: {secret}"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "AIza" not in result
         assert "[REDACTED]" in result
 
     def test_aws_access_key_redacted(self):
         msg = "Credential: AKIAIOSFODNN7EXAMPLE"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "AKIA" not in result
         assert "[REDACTED]" in result
 
     def test_anthropic_key_redacted(self):
         msg = "Auth failed: sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
-        result = _sanitize_error(msg)
+        result = sanitize_error(msg)
         assert "sk-ant-" not in result
         assert "[REDACTED]" in result
 
     def test_clean_message_unchanged(self):
         msg = "Connection refused: timeout after 30s"
-        assert _sanitize_error(msg) == msg
+        assert sanitize_error(msg) == msg
+
+    def test_aws_secret_access_key_redacted(self):
+        secret = "aBcD1234/+" * 4
+        msg = f"AWS_SECRET_ACCESS_KEY={secret}"
+        result = sanitize_error(msg)
+        assert secret not in result
+        assert "[REDACTED]" in result
+
+    def test_b2_application_key_redacted(self):
+        secret = "K005" + ("B2keyValue/" * 3)
+        msg = f"B2 application key leaked: {secret}"
+        result = sanitize_error(msg)
+        assert secret not in result
+        assert "[REDACTED]" in result
+
+    def test_basic_auth_url_credentials_redacted(self):
+        basic_auth_value = "pass" + "word-value-1234567890"
+        msg = f"Fetch failed: https://user:{basic_auth_value}@example.com/object"
+        result = sanitize_error(msg)
+        assert basic_auth_value not in result
+        assert "[REDACTED]example.com/object" in result
+
+    def test_jwt_redacted(self):
+        token = f"eyJ{'a' * 20}.{'b' * 20}.{'c' * 20}"
+        msg = f"Provider returned token {token}"
+        result = sanitize_error(msg)
+        assert token not in result
+        assert "[REDACTED]" in result

--- a/libs/core/tests/unit/test_tracer.py
+++ b/libs/core/tests/unit/test_tracer.py
@@ -235,6 +235,12 @@ def test_tracer_hooks_fire_for_input_resolution_failure() -> None:
     ]
     assert start_indices == [0, 1]
     assert end_indices == [0, 1]
+    prefailed_end = [
+        kwargs
+        for name, _, kwargs in tracer.calls
+        if name == "on_step_end" and kwargs["step_index"] == 1
+    ][0]
+    assert prefailed_end["duration_ms"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -261,6 +267,12 @@ async def test_tracer_hooks_fire_for_input_resolution_failure_async() -> None:
     ]
     assert start_indices == [0, 1]
     assert end_indices == [0, 1]
+    prefailed_end = [
+        kwargs
+        for name, _, kwargs in tracer.calls
+        if name == "on_step_end" and kwargs["step_index"] == 1
+    ][0]
+    assert prefailed_end["duration_ms"] == 0.0
 
 
 def test_on_run_end_fires_on_pipeline_timeout() -> None:

--- a/libs/core/tests/unit/test_tracer.py
+++ b/libs/core/tests/unit/test_tracer.py
@@ -236,11 +236,14 @@ def test_tracer_hooks_fire_for_input_resolution_failure() -> None:
     assert start_indices == [0, 1]
     assert end_indices == [0, 1]
     prefailed_end = [
-        kwargs
-        for name, _, kwargs in tracer.calls
+        (args[1], kwargs)
+        for name, args, kwargs in tracer.calls
         if name == "on_step_end" and kwargs["step_index"] == 1
     ][0]
-    assert prefailed_end["duration_ms"] == 0.0
+    prefailed_step, prefailed_kwargs = prefailed_end
+    assert prefailed_kwargs["duration_ms"] == 0.0
+    assert prefailed_step.metadata["failure_reason"] == "input_resolution"
+    assert prefailed_step.metadata["provider_invoked"] is False
 
 
 @pytest.mark.asyncio
@@ -268,11 +271,14 @@ async def test_tracer_hooks_fire_for_input_resolution_failure_async() -> None:
     assert start_indices == [0, 1]
     assert end_indices == [0, 1]
     prefailed_end = [
-        kwargs
-        for name, _, kwargs in tracer.calls
+        (args[1], kwargs)
+        for name, args, kwargs in tracer.calls
         if name == "on_step_end" and kwargs["step_index"] == 1
     ][0]
-    assert prefailed_end["duration_ms"] == 0.0
+    prefailed_step, prefailed_kwargs = prefailed_end
+    assert prefailed_kwargs["duration_ms"] == 0.0
+    assert prefailed_step.metadata["failure_reason"] == "input_resolution"
+    assert prefailed_step.metadata["provider_invoked"] is False
 
 
 def test_on_run_end_fires_on_pipeline_timeout() -> None:

--- a/libs/core/tests/unit/test_tracer.py
+++ b/libs/core/tests/unit/test_tracer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import StepStatus
 from genblaze_core.observability.events import StepProgressEvent
@@ -209,6 +210,57 @@ def test_on_step_end_fires_when_step_fails() -> None:
 
     seq = _hook_sequence(tracer)
     assert seq.count("on_step_start") == seq.count("on_step_end") == 1
+
+
+def test_tracer_hooks_fire_for_input_resolution_failure() -> None:
+    """Input resolution failures still produce paired step tracer hooks."""
+    tracer = _RecordingTracer()
+
+    result = (
+        Pipeline("t", tracer=tracer)
+        .step(_RaisingProvider(), model="m0", prompt="fails")
+        .step(_OKProvider(), model="m1", prompt="consume", input_from=[0])
+        .run(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert [step.status for step in result.run.steps] == [
+        StepStatus.FAILED,
+        StepStatus.FAILED,
+    ]
+    start_indices = [
+        kwargs["step_index"] for name, _, kwargs in tracer.calls if name == "on_step_start"
+    ]
+    end_indices = [
+        kwargs["step_index"] for name, _, kwargs in tracer.calls if name == "on_step_end"
+    ]
+    assert start_indices == [0, 1]
+    assert end_indices == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_tracer_hooks_fire_for_input_resolution_failure_async() -> None:
+    """Async input resolution failures still produce paired step tracer hooks."""
+    tracer = _RecordingTracer()
+
+    result = await (
+        Pipeline("t", tracer=tracer)
+        .step(_RaisingProvider(), model="m0", prompt="fails")
+        .step(_OKProvider(), model="m1", prompt="consume", input_from=[0])
+        .arun(fail_fast=False, raise_on_failure=False)
+    )
+
+    assert [step.status for step in result.run.steps] == [
+        StepStatus.FAILED,
+        StepStatus.FAILED,
+    ]
+    start_indices = [
+        kwargs["step_index"] for name, _, kwargs in tracer.calls if name == "on_step_start"
+    ]
+    end_indices = [
+        kwargs["step_index"] for name, _, kwargs in tracer.calls if name == "on_step_end"
+    ]
+    assert start_indices == [0, 1]
+    assert end_indices == [0, 1]
 
 
 def test_on_run_end_fires_on_pipeline_timeout() -> None:


### PR DESCRIPTION
## Summary
- Fail `input_from` consumers before provider invocation when a referenced producer failed, produced no assets, or points at an out-of-range prior step, recording the dependent step as `FAILED` with `INVALID_INPUT` instead of allowing empty declared inputs to succeed or aborting the whole run.
- Build input-resolution pre-failed consumer steps entirely in core without downstream provider hooks, populate durable `started_at`/`completed_at` timestamps, and route sync/async runners through an internal prepared-step result instead of inspecting manifest metadata.
- Mark pre-fails with `metadata.failure_reason="input_resolution"` and `metadata.provider_invoked=false`, emit a structured `step.prefailed` log line, and keep paired tracer hooks with intentional `0.0` ms spans that telemetry can filter.
- Never copy raw upstream provider error text into dependent fan-in errors; failed `Step.error` values are sanitized and length-capped before manifest, log, or stream-event emission, with bounded sanitizer scan work and expanded internal coverage for AWS secret keys, Backblaze B2 application keys, basic-auth URL credentials, JWTs, bearer/token headers, API-key assignments, and existing provider key shapes.
- Keep the feature docs, architecture notes, and changelog aligned with the expected rollout impact: affected fan-in pipelines that previously appeared green can now report `FAILED`/`INVALID_INPUT`, changing alert baselines and manifest hashes for those runs. Operators can route or re-baseline using the input-resolution metadata marker.

## Linked issue
Closes #69

## Tests run
- `cd libs/core && pytest tests/unit/test_secret_redaction.py tests/unit/test_pipeline.py::test_input_from_failure_sanitizes_upstream_error_surfaces tests/unit/test_pipeline.py::test_input_from_prefail_does_not_call_consumer_provider_hooks tests/unit/test_pipeline.py::test_input_from_prefail_does_not_call_consumer_provider_hooks_async tests/unit/test_pipeline.py::test_input_from_failed_producer_fails_consumer tests/unit/test_pipeline.py::test_input_from_failed_producer_fails_consumer_async tests/unit/test_pipeline.py::test_input_from_empty_producer_fails_consumer tests/unit/test_pipeline.py::test_input_from_empty_producer_fails_consumer_async tests/unit/test_pipeline.py::test_input_from_invalid_index_default_run_returns_failed_result tests/unit/test_pipeline.py::test_input_from_invalid_index_default_arun_returns_failed_result -q`
- `cd libs/core && pytest tests/unit/test_pipeline.py tests/unit/test_tracer.py tests/unit/test_secret_redaction.py -q`
- `make test`
- `make lint`

## Follow-up notes
- None.
