### PR TITLE
Fix replay exit code for failed runs

### DIFF
--- a/cli/genblaze_cli/commands/replay.py
+++ b/cli/genblaze_cli/commands/replay.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import click
-from genblaze_core.models.enums import PromptVisibility
+from genblaze_core.models.enums import PromptVisibility, RunStatus
 
 
 def _load_provider(provider_name: str, allowed: tuple[str, ...] | None):
@@ -202,10 +202,17 @@ def replay(
         )
 
     try:
-        result = pipe.run()
+        result = pipe.run(raise_on_failure=False)
         click.echo()
+        if result.run.status in {RunStatus.FAILED, RunStatus.CANCELLED}:
+            click.echo(f"Replay failed. New run ID: {result.run.run_id}", err=True)
+            click.echo(f"Hash: {result.manifest.canonical_hash}", err=True)
+            click.echo(f"Status: {result.run.status}", err=True)
+            raise click.exceptions.Exit(1)
         click.echo(f"Replay complete. New run ID: {result.run.run_id}")
         click.echo(f"Hash: {result.manifest.canonical_hash}")
         click.echo(f"Status: {result.run.status}")
+    except click.exceptions.Exit:
+        raise
     except Exception as exc:
         raise click.ClickException(f"Replay failed: {exc}") from exc

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -9,8 +9,9 @@ from click.testing import CliRunner
 from genblaze_cli.main import cli
 from genblaze_core.builders import RunBuilder, StepBuilder
 from genblaze_core.media.png import PngHandler
-from genblaze_core.models.enums import Modality
+from genblaze_core.models.enums import Modality, ProviderErrorCode
 from genblaze_core.models.manifest import Manifest
+from genblaze_core.testing import MockProvider
 from PIL import Image
 
 
@@ -132,6 +133,38 @@ def test_replay_aborts_when_no_allowlist_and_declined(tmp_path: Path) -> None:
     result = runner.invoke(cli, ["replay", str(manifest_path), "--no-dry-run"], input="n\n")
     assert result.exit_code != 0
     assert "Aborted" in result.output or "Execute with provider" in result.output
+
+
+def test_replay_no_dry_run_exits_nonzero_when_run_fails(tmp_path: Path, monkeypatch) -> None:
+    """A replayed failed run must not look successful to automation."""
+
+    class FailingReplayProvider(MockProvider):
+        def __init__(self) -> None:
+            super().__init__(
+                name="test",
+                should_fail=True,
+                error_code=ProviderErrorCode.AUTH_FAILURE,
+                error_message="missing credentials",
+            )
+
+    import genblaze_core.providers.registry as provider_registry
+
+    monkeypatch.setattr(
+        provider_registry,
+        "discover_providers",
+        lambda: {"test": FailingReplayProvider},
+    )
+    manifest_path = _create_manifest_json(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["replay", str(manifest_path), "--no-dry-run", "--allow-provider", "test"],
+    )
+
+    assert result.exit_code != 0
+    assert "Replay failed" in result.output
+    assert "Replay complete" not in result.output
 
 
 def test_index(tmp_path: Path) -> None:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -163,8 +163,9 @@ def test_replay_no_dry_run_exits_nonzero_when_run_fails(tmp_path: Path, monkeypa
     )
 
     assert result.exit_code != 0
-    assert "Replay failed" in result.output
-    assert "Replay complete" not in result.output
+    assert "Replay failed" in result.stderr
+    assert "Replay failed" not in result.stdout
+    assert "Replay complete" not in result.stdout
 
 
 def test_index(tmp_path: Path) -> None:

--- a/docs/exec-plans/completed/issue-59-replay-exit-code.md
+++ b/docs/exec-plans/completed/issue-59-replay-exit-code.md
@@ -1,0 +1,17 @@
+<!-- completed: 2026-06-18 -->
+# Plan: Issue 59 Replay Failure Exit Code
+
+## Summary
+Ensure `genblaze replay --no-dry-run` exits non-zero when the replayed pipeline
+finishes with a failed or cancelled run status.
+
+## Scope
+- Inspect replay execution status after `Pipeline.run()`.
+- Return exit code 1 for failed or cancelled replay runs.
+- Add a CLI regression test for a replayed provider failure.
+
+## Verification
+- `cd cli && pytest tests/test_cli.py::test_replay_no_dry_run_exits_nonzero_when_run_fails -q`
+- `cd cli && pytest tests/test_cli.py -q`
+- `make lint`
+- `make test`


### PR DESCRIPTION
## Summary
- Makes `genblaze replay --no-dry-run` inspect the replayed run status and exit 1 when the status is failed or cancelled.
- Keeps successful replay output unchanged, prints failure details to stderr, and leaves stdout free of success text on failure.
- Adds and tightens CLI regression coverage for replayed provider failures, including explicit stdout/stderr assertions.

## Linked issue
Closes #59

## Tests
- `cd cli && pytest tests/test_cli.py::test_replay_no_dry_run_exits_nonzero_when_run_fails -q` (failed before the fix, passes after)
- `cd cli && pytest tests/test_cli.py -q`
- `ruff check cli/tests/test_cli.py`
- `make lint`
- `make test`

## Follow-up notes
- Added completed execution plan: `docs/exec-plans/completed/issue-59-replay-exit-code.md`.
