### PR TITLE
chore(deps): add deptry gate, declare urllib3/botocore, advertise soft extras

### DIFF
--- a/.claude/skills/scaffold-provider/SKILL.md
+++ b/.claude/skills/scaffold-provider/SKILL.md
@@ -59,6 +59,7 @@ Mirror an existing connector's structure exactly. Required fields:
 - `[project.entry-points."genblaze.providers"]` — `{name} = "genblaze_{name}:{Name}Provider"` (one line per exported provider class)
 - `[tool.hatch.build.targets.wheel]` — `packages = ["genblaze_{name}"]`
 - `[tool.pytest.ini_options]` — `testpaths = ["tests"]`
+- `[tool.deptry]` — `optional_dependencies_dev_groups = ["dev"]` (required, else the new package fails `make deptry`). The `make deptry` connector glob picks the package up automatically; no Makefile edit needed.
 
 ### `genblaze_{name}/__init__.py`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   lint:
+    # Runs ruff directly rather than `make lint` (which also runs `make
+    # deptry`): deptry needs the full workspace installed, so it gets its own
+    # `deptry` job below. Local `make lint` therefore covers more than this
+    # job — that's intentional, the two are split by install cost.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -96,6 +100,33 @@ jobs:
             echo "::error::Typecheck failed for:$failed"
             exit 1
           fi
+
+  deptry:
+    # Dependency hygiene gate. `pip check` proves the installed set has no
+    # conflicting/missing transitive deps; `make deptry` proves every package
+    # declares what it imports — the replicate/httpx clean-install crash class
+    # (#37/#106). Both run against the editable workspace install (deptry maps
+    # imports to packages via installed metadata). NOTE: `pip install -e`
+    # ignores version constraints, so `pip check` here does NOT exercise
+    # published-pin resolution or floor conflicts — that's the constraint-
+    # respecting wheel install in `make release-smoke` at tag time, and the
+    # per-PR resolve-check is a documented follow-up.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: Install workspace (editable, all dev extras; deptry ships in core[dev])
+        run: make install-dev
+      - name: Dependency consistency (pip check)
+        run: pip check
+      - name: Dependency hygiene (deptry)
+        run: make deptry
 
   build:
     # Smoke-build every published package on every PR so packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `httpx>=0.24` already used by the nvidia, gmicloud, and stability-audio
   connectors. Version bumped so a corrected wheel can publish past the
   `skip-existing` pin-parity gate (#37).
+- **`genblaze-core`** (0.3.2 → **0.3.3**): declare `urllib3>=1.26,<3` as a
+  direct dependency. `storage/transfer.py` imports `urllib3` unguarded at module load
+  (the shared `PoolManager` behind `AssetTransfer`) and `storage/__init__`
+  imports it eagerly, so `import genblaze_core.storage` hard-required urllib3 on
+  a clean install while core declared only `pydantic` + `pillow`. It previously
+  arrived only transitively via a connector's boto3 stack — the same
+  clean-install crash class as the replicate/httpx fix above.
+- **`genblaze-s3`** (0.3.2 → **0.3.3**): declare `botocore>=1.31` (imported
+  directly in `backend.py`) and `aiobotocore>=2.7` in the `async` extra
+  (imported directly in `async_backend.py`). Both always shipped transitively
+  via boto3/aioboto3, which pin their exact versions — so these declarations add
+  honesty for the dependency gate without changing what resolves.
+
+### Added
+
+- `genblaze-core`: `http` (`httpx`), `otel` (`opentelemetry-api`), and
+  `testing` (`pytest`) extras. These advertise previously-undeclared
+  guarded/soft imports. In particular `genblaze_core.testing` (the public
+  `MockProvider` / `ProviderComplianceTests` harness) imports `pytest` at module
+  load and ships in the wheel, so it now installs via
+  `pip install "genblaze-core[testing]"`.
+
+### Changed
+
+- **Repo tooling**: new `make deptry` dependency-hygiene gate
+  (backed by per-package `[tool.deptry]` config) fails on undeclared imports
+  (DEP001), shipped imports of dev-only deps (DEP004), and misclassified
+  transitive deps — the clean-install crash class above. Wired into `make lint`,
+  `make pre-release`, and a new `deptry` CI job that also runs `pip check`
+  against the editable workspace. `libs/meta` is excluded (umbrella metapackage:
+  its deps are install-time bundles, not imports).
 
 ## [0.3.3] - 2026-05-26
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev test lint fmt typecheck coverage clean ts-types ts-types-check pypi-metadata-check pypi-pin-parity release-smoke pre-release post-release
+.PHONY: install install-dev test lint deptry fmt typecheck coverage clean ts-types ts-types-check pypi-metadata-check pypi-pin-parity release-smoke pre-release post-release
 
 install:
 	pip install -e libs/core
@@ -57,6 +57,24 @@ test:
 lint:
 	ruff check libs/ cli/ examples/
 	ruff format --check libs/ cli/ examples/
+	$(MAKE) deptry
+
+# Dependency hygiene gate. Per-package because each carries its own
+# [project.dependencies] + [tool.deptry] config. Fails on undeclared imports
+# (DEP001) — the replicate/httpx clean-install crash class (#37/#106) — plus
+# misclassified transitive deps (DEP003) and unused declared deps (DEP002).
+# Requires the workspace installed (run after `make install-dev`); deptry maps
+# imports to packages via installed metadata. The connector glob auto-includes
+# newly scaffolded packages (matching the CI `build` job) so the gate can't
+# silently skip one. libs/meta is intentionally excluded: it's an umbrella
+# metapackage whose deps are install-time bundles, not imports, so deptry's
+# import-vs-declaration model does not apply.
+deptry:
+	@for pkg in libs/core cli libs/connectors/*/; do \
+		pkg="$${pkg%/}"; \
+		echo "=== deptry: $$pkg ==="; \
+		(cd "$$pkg" && deptry .) || exit 1; \
+	done
 
 fmt:
 	ruff format libs/ cli/ examples/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,9 +59,12 @@ make pre-release
 ```
 
 This runs `lint`, `typecheck`, `ts-types-check`, `pypi-metadata-check`,
-`test`, and `release-smoke` in quick-fail order. A clean run on `main`
-is a strong signal that `validate-version`, `changelog-gate`, and
-`release-smoke` in the workflow will all be green once you tag.
+`pypi-pin-parity`, `test`, and `release-smoke` in quick-fail order. `lint`
+now also runs the `deptry` dependency-hygiene gate (`make deptry`), which
+fails if any package imports a dependency it doesn't declare — the
+clean-install crash class behind #37/#106. A clean run on `main` is a strong
+signal that `validate-version`, `changelog-gate`, and `release-smoke` in the
+workflow will all be green once you tag.
 
 ## The publish pipeline
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -48,3 +48,8 @@ packages = ["genblaze_cli"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/docs/exec-plans/active/dependency-hygiene-deptry.md
+++ b/docs/exec-plans/active/dependency-hygiene-deptry.md
@@ -1,0 +1,193 @@
+<!-- created: 2026-06-18 -->
+# Dependency Hygiene — deptry gate + declared imports
+
+Single PR closing the class of bug found in #37/#106 (`genblaze-replicate` imported
+`httpx` on its default path without declaring it, crashing a clean install). A repo-wide
+`deptry` scan found the remaining offenders. Two are the *same severity* as replicate —
+unguarded imports of undeclared deps reachable on a clean install:
+
+- `genblaze-core` imports `urllib3` unguarded at module load in `storage/transfer.py`
+  (the `PoolManager` behind `AssetTransfer`), and `storage/__init__` imports it eagerly,
+  so `import genblaze_core.storage` crashed a `pydantic`+`pillow`-only install.
+- `genblaze-core/testing.py` (the public `MockProvider` / `ProviderComplianceTests`
+  harness, shipped in the wheel and documented in connector READMEs) imports `pytest` at
+  module load, which was declared dev-only — so `import genblaze_core.testing` crashed too.
+
+The rest are guarded soft deps (advertised as extras) or genuine cross-package classifiers
+(ignored). So this is a correctness + tooling pass that also fixes two latent clean-install
+crashes.
+
+Goal: declare what we import, advertise soft integrations as extras, and add a CI gate so
+the next undeclared import fails locally instead of reaching a user.
+
+`deptry` only closes the *undeclared-import* direction (we import `httpx` without declaring
+it). The complementary direction — *declared-but-broken version constraints* (a `>=` floor
+that's never installed against, or two packages' pins that can't co-resolve) — is out of
+deptry's reach and is covered in the [Follow-up section](#follow-up--version-resolution-gates-separate-pr).
+That direction is not academic here: this PR *adds* new `>=` floors (`httpx>=0.24`,
+`opentelemetry-api>=1.20`, `botocore>=1.31`, `aiobotocore>=2.7`), and CI today installs with
+`pip install -e`, which ignores version constraints entirely — so nothing proves those floors
+actually resolve until release-time `make release-smoke`.
+
+## Goals & success criteria
+
+- **No undeclared default-path imports** anywhere in the workspace.
+- **`make deptry` passes** for every package and is wired into `make lint` and `make pre-release`.
+- **No behavior change, no new public API** — packaging metadata + config only, so this
+  ships as a patch wave.
+- **`make pypi-pin-parity` stays green** — every package whose metadata changes gets a
+  version bump in the same PR.
+
+## Findings (deptry 0.25.1, run per-package 2026-06-18 — verified during implementation)
+
+| Package | Import | Rule | Reality | Action |
+|---|---|---|---|---|
+| `genblaze-core` | `urllib3` (storage/transfer.py) | DEP003 | **Unguarded module-load import, eager via `storage/__init__`**; not transitively guaranteed (core deps = pydantic+pillow) | **Declare** `urllib3>=1.26,<3` in deps |
+| `genblaze-core` | `pytest` (testing.py) | DEP004 | Shipped public test harness imports pytest at module load; was dev-only | **Add `testing` extra** (`pytest>=7.0`) |
+| `genblaze-core` | `httpx` (providers/retry.py) | DEP003 | Guarded soft dep | Add `http` extra (declared → resolves) |
+| `genblaze-core` | `opentelemetry` (observability, storage) | DEP003 | Guarded soft dep | Add `otel` extra + `package_module_name_map` (`opentelemetry-api` → `opentelemetry`) |
+| `genblaze-core` | `botocore` (storage/errors.py) | DEP003 | Cross-package classifier; reached only when a connector already loaded botocore | `per_rule_ignores` DEP001+DEP003 (do **not** add to core deps) |
+| `genblaze-core` | `google` (providers/pattern_safety.py) | DEP003 | Optional `google-re2` accelerator, guarded | `per_rule_ignores` DEP001+DEP003 |
+| `genblaze-s3` | `botocore` (backend.py) | DEP003 | Unguarded; always ships with declared `boto3` | Declare `botocore>=1.31` in deps |
+| `genblaze-s3` | `aiobotocore` (async_backend.py) | DEP001 | Guarded; always ships with declared `aioboto3` (`async` extra) | Declare `aiobotocore>=2.7` in `async` extra |
+| **all 16 packages** | dev tools (`pytest`, `ruff`, `mypy`, …) | DEP002 | Test/dev tooling, not imported in shipped code | `[tool.deptry] optional_dependencies_dev_groups = ["dev"]` per package |
+| `libs/meta` | all 14 `genblaze-*` deps | DEP002 | Umbrella metapackage — deps are install-time bundles, not imports | **Exclude meta** from the gate |
+
+Notes that corrected the original table: the `google` DEP003 is in **core** (`google-re2`), not a
+false-positive in the google connector (which is clean apart from dev-tool noise); `urllib3` is a
+hard dep, not an ignorable transitive; DEP002 dev-tool noise and the `testing.py` DEP004 were not
+anticipated. `cli`'s `pillow` flag is resolved by the dev-group config (it lives in `cli[dev]`).
+
+## Scope — one PR, one branch (`chore/dependency-hygiene-deptry`)
+
+### 1. Add the deptry gate (prevents recurrence — the point of the PR) — done
+- Added `deptry>=0.23` to `core[dev]` (the canonical dev-tool location, alongside ruff/mypy);
+  `make install-dev` propagates it. Floor is `0.23` because the gate uses the modern
+  `optional_dependencies_dev_groups` config key (the older `pep621_dev_dependency_groups` is
+  deprecated in 0.25).
+- Added a `deptry` target to the `Makefile` (per-package loop, **excludes `libs/meta`**),
+  folded into `make lint` (so `make pre-release` inherits it via `lint`).
+- Documented it in `RELEASING.md` alongside the existing gates.
+- Added a dedicated **`deptry` CI job** that runs `make install-dev`, then `pip check`
+  (installed-set conflict/missing-dep gate — the cheap counterpart to deptry), then
+  `make deptry`. A standalone job mirrors the repo's one-job-per-concern convention; the
+  editable install means deptry can map imports to packages. The stronger constraint-
+  respecting wheel install is the follow-up below.
+- Per-package `[tool.deptry] optional_dependencies_dev_groups = ["dev"]` added to all 14
+  checked packages (core, s3, the 12 other connectors, cli) so dev tooling isn't flagged
+  DEP002. `libs/meta` is excluded from the gate entirely.
+
+### 2. `genblaze-s3` — declare direct imports (bump 0.3.2 → 0.3.3) — done
+- `dependencies`: added `botocore>=1.31` (tracks the `boto3>=1.28` floor; boto3 pins the
+  exact version, so no resolver conflict).
+- `async` extra: added `aiobotocore>=2.7` (`aioboto3` pins the exact version).
+- CHANGELOG entry added.
+
+### 3. `genblaze-core` — declare urllib3, advertise soft deps as extras (bump 0.3.2 → 0.3.3) — done
+- **Declared `urllib3>=1.26,<3` as a hard runtime dependency** (unguarded module-load import —
+  see findings). This is the substantive fix, not an ignore.
+- Added extras: `http = ["httpx>=0.24"]`, `otel = ["opentelemetry-api>=1.20"]`,
+  `testing = ["pytest>=7.0"]` (the shipped `genblaze_core.testing` harness). Added `httpx`
+  and `opentelemetry-api` to `dev` so the guarded paths run under test.
+- `[tool.deptry]`: `optional_dependencies_dev_groups = ["dev"]`;
+  `per_rule_ignores` DEP001+DEP003 = `["botocore", "google"]` (cross-package classifier +
+  optional `google-re2`); `package_module_name_map` mapping `opentelemetry-api` →
+  `opentelemetry` so the `otel` extra is recognized without the package installed.
+- CHANGELOG entry added.
+
+### 4. Other connectors + cli — deptry config only (no version bump) — done
+- Added `[tool.deptry] optional_dependencies_dev_groups = ["dev"]` to all 12 remaining
+  connectors and `cli`. The google connector needed **no** module map — deptry 0.25 resolves
+  `google.genai` to the declared `google-genai` correctly; only the dev-tool DEP002 applied.
+- No `Requires-Dist` change → no version bump (tool tables aren't distribution metadata),
+  so `make pypi-pin-parity` stays green for these.
+
+## Decisions
+
+- **`urllib3`: declared (not ignored).** The original table marked it an ignorable transitive;
+  verification showed it's an unguarded module-load import reachable on a clean install — the
+  same class as #37/#106. Declaring it is the honest, minimal fix (boto3 already needs urllib3,
+  so no resolver conflict). Guarding the import + making it an extra was rejected: `AssetTransfer`
+  is core's byte-transfer path, not optional, and that would be a behavior change.
+- **`testing.py` pytest: `testing` extra (not a code change).** The harness is a documented
+  public surface; advertising the extra fixes the clean-install crash without touching code.
+- **s3 botocore/aiobotocore: declared** (the original plan's lean). boto3/aioboto3 pin the exact
+  versions, so the declarations add honesty for the gate with zero resolver effect.
+- **`libs/meta` excluded from the gate.** An umbrella metapackage's deps are install-time bundles,
+  not imports; deptry's import-vs-declaration model doesn't apply, and a blanket DEP002 ignore
+  would need editing on every new connector.
+- **Version wave.** Bundles `genblaze-core 0.3.3` + `genblaze-s3 0.3.3` (independent of the wave
+  tag, which follows the CHANGELOG header). Other packages unchanged.
+
+## Test plan
+
+- [x] `make deptry` passes for all 16 checked packages (meta excluded) — verified
+- [x] `make pypi-pin-parity` green (core + s3 at new unpublished 0.3.3 → skipped; 0 drift)
+- [x] `pip check` reports no genblaze-* conflicts after a consistent `make install-dev`
+- [x] `make test` passes (core 1577, s3 246, meta 8; connectors unaffected — metadata-only)
+- [x] `make lint` passes (now includes deptry)
+- [x] CHANGELOG updated for core + s3 + tooling
+- [x] Smoke: `import genblaze_core.storage` and `import genblaze_core.testing` succeed
+
+## Code review follow-through (4-dimension EM review)
+
+A parallel EM review (architecture, security/reliability, B2, test coverage) ran against the
+diff. Outcomes:
+
+- **False positive (security, "Critical"):** claimed `urllib3>=1.26` conflicts with botocore's
+  `urllib3<1.27` cap at minimum floors. Verified empirically — pip backtracks to `urllib3
+  1.26.20` (satisfies both); the realistic set resolves to `urllib3 2.0.7`. No conflict.
+- **Applied — floor accuracy:** `aiobotocore>=2.5` → `>=2.7` (aioboto3 12.0.0 pins
+  `aiobotocore==2.7.0`, the true minimum); `urllib3>=1.26` → `>=1.26,<3` (repo bounded-major
+  convention, cf. `pydantic<3`).
+- **Applied — test coverage gap (the strongest real finding):** `release_smoke.sh`,
+  `install-verify`, and `post-release` only `import genblaze_core`, whose lazy `__getattr__`
+  never executes `storage/transfer.py` — so they would NOT catch a urllib3-removal regression.
+  Added `genblaze_core.storage` to the `release_smoke.sh` import list (urllib3 is now a hard
+  dep, present in any core install). Deliberately did NOT add `genblaze_core.testing` there —
+  `genblaze[all]` does not pull `genblaze-core[testing]`, so pytest is absent in that venv;
+  bare-venv validation of the `testing` extra is routed to the entry-point follow-up below.
+- **Applied — maintainability:** `make deptry` now globs `libs/connectors/*/` (auto-includes
+  new connectors, can't silently skip one); CI `lint` and `deptry` jobs gained comments
+  explaining the ruff-vs-`make lint` split and the editable-install limitation of `pip check`.
+- **Applied (after maintainer authorization):** `.claude/skills/scaffold-provider/SKILL.md`
+  now lists `[tool.deptry] optional_dependencies_dev_groups = ["dev"]` as a required
+  `pyproject.toml` field, so a newly scaffolded connector won't fail `make deptry`. The
+  Makefile glob means no Makefile edit is needed for new connectors — only the per-package
+  config.
+
+## Follow-up — version-resolution gates (separate PR)
+
+Out of scope for the deptry PR (new CI infra, not packaging metadata), but the natural next
+step and motivated by the `>=` floors this PR introduces. Sourced from deep-research on how
+LangChain and the broader Python ecosystem catch cross-package dependency conflicts; see the
+research report in the conversation thread for citations. Sequenced by payoff:
+
+1. **Constraint-respecting install + `pip check` on every PR (highest payoff).** CI's
+   `pip install -e` bypasses version constraints, so a bad pin only surfaces at release time
+   via `make release-smoke`. Add a `resolve-check` job that installs the *built wheels*
+   (`genblaze[all]` from the wheelhouse, non-editable) and runs `pip check`. This is
+   `release_smoke.sh` running per-PR instead of pre-tag — the hard part is already written, so
+   the job can largely call `make release-smoke`.
+
+2. **Minimum-version job — validates the `>=` floors this PR adds.** LangChain's central
+   technique: install with `uv pip install --resolution lowest-direct` and run `make test`
+   against the declared floors. Without it, `httpx>=0.24` / `botocore>=1.31` / `aiobotocore>=2.7`
+   / `opentelemetry-api>=1.20` are untested assertions. Watch the lockfile trap: if a uv
+   lockfile is ever committed, `lowest-direct` resolves against it and masks too-low bounds
+   (FastMCP #2290) — bypass the lockfile for this job, or use `tox-uv`'s `uv_resolution`.
+
+3. **Entry-point validation.** `release_smoke.sh` already asserts each connector *imports*;
+   strengthen it to load providers via `importlib.metadata.entry_points()` so the registration
+   mechanism (not just the module) is exercised.
+
+4. **Tooling hygiene (no migration).** Keep `check_pin_parity.py` as-is — it guards the
+   release `skip-existing` silent-skip trap the above gates don't cover. If grouped dependency
+   bumps are wanted, configure Renovate; do *not* switch off Dependabot on the belief it can't
+   group monorepo bumps — it can via `groups` config (the research's one refuted claim).
+
+Caveat on a future uv migration: a single uv workspace shares one lockfile, which assumes all
+members agree on versions. Providers that need divergent transitive pins (the `httpx`
+situation is the canary) must be isolated via path dependencies rather than forced into one
+workspace lockfile — which is exactly where per-package `pip check` and min-version jobs earn
+their keep.

--- a/libs/connectors/decart/pyproject.toml
+++ b/libs/connectors/decart/pyproject.toml
@@ -48,3 +48,8 @@ packages = ["genblaze_decart"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/elevenlabs/pyproject.toml
+++ b/libs/connectors/elevenlabs/pyproject.toml
@@ -47,3 +47,8 @@ packages = ["genblaze_elevenlabs"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/gmicloud/pyproject.toml
+++ b/libs/connectors/gmicloud/pyproject.toml
@@ -48,3 +48,8 @@ packages = ["genblaze_gmicloud"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/google/pyproject.toml
+++ b/libs/connectors/google/pyproject.toml
@@ -47,3 +47,8 @@ packages = ["genblaze_google"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/langsmith/pyproject.toml
+++ b/libs/connectors/langsmith/pyproject.toml
@@ -43,3 +43,8 @@ packages = ["genblaze_langsmith"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/lmnt/pyproject.toml
+++ b/libs/connectors/lmnt/pyproject.toml
@@ -46,3 +46,8 @@ packages = ["genblaze_lmnt"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/luma/pyproject.toml
+++ b/libs/connectors/luma/pyproject.toml
@@ -46,3 +46,8 @@ packages = ["genblaze_luma"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/nvidia/pyproject.toml
+++ b/libs/connectors/nvidia/pyproject.toml
@@ -53,3 +53,8 @@ packages = ["genblaze_nvidia"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/openai/pyproject.toml
+++ b/libs/connectors/openai/pyproject.toml
@@ -48,3 +48,8 @@ packages = ["genblaze_openai"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/replicate/pyproject.toml
+++ b/libs/connectors/replicate/pyproject.toml
@@ -47,3 +47,8 @@ packages = ["genblaze_replicate"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/runway/pyproject.toml
+++ b/libs/connectors/runway/pyproject.toml
@@ -46,3 +46,8 @@ packages = ["genblaze_runway"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/s3/pyproject.toml
+++ b/libs/connectors/s3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-s3"
-version = "0.3.2"
+version = "0.3.3"
 description = "S3-compatible storage backend for genblaze (B2, R2, MinIO, AWS)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"
@@ -25,6 +25,12 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 dependencies = [
     "genblaze-core>=0.3.2,<0.4",
     "boto3>=1.28",
+    # backend.py imports botocore.exceptions directly (unguarded, module load).
+    # boto3 always ships it, but declaring the direct import is honest and lets
+    # deptry verify it. Floor tracks boto3>=1.28's botocore baseline; safe
+    # because pip propagates boto3's exact botocore pin (a `--no-deps` install
+    # could still skew it, but that bypasses all our gates anyway).
+    "botocore>=1.31",
 ]
 
 [project.urls]
@@ -40,6 +46,11 @@ async = [
     # an aioboto3 major bump doesn't silently land breaking changes for
     # users with floating extras pins.
     "aioboto3>=12,<13",
+    # async_backend.py imports aiobotocore.config.AioConfig directly. aioboto3
+    # always pulls it, but the direct import is declared so deptry can verify
+    # it; aioboto3 pins the exact aiobotocore (==2.7.0 at our 12.0 floor), so no
+    # resolver conflict — the floor just matches that true minimum.
+    "aiobotocore>=2.7",
 ]
 dev = [
     "pytest>=7.0",
@@ -50,3 +61,8 @@ packages = ["genblaze_s3"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry doesn't flag pytest as
+# an unused declared dep (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/stability-audio/pyproject.toml
+++ b/libs/connectors/stability-audio/pyproject.toml
@@ -46,3 +46,8 @@ packages = ["genblaze_stability_audio"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-core"
-version = "0.3.2"
+version = "0.3.3"
 description = "Core SDK for genblaze media generation orchestration"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"
@@ -26,6 +26,17 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 dependencies = [
     "pydantic>=2.0,<3",
     "pillow>=10.0",
+    # urllib3 is imported unguarded at module load in storage/transfer.py
+    # (the shared PoolManager backing AssetTransfer's presigned-URL streaming),
+    # and storage/__init__ imports transfer eagerly — so `import
+    # genblaze_core.storage` hard-requires it on a clean install. It used to
+    # arrive only transitively via a connector's boto3 stack; declaring it
+    # closes the same crash class as the replicate/httpx fix (#37/#106).
+    # >=1.26 for the Retry(allowed_methods=...) API; <3 matches the repo's
+    # bounded-major convention (cf. pydantic<3) and resolves cleanly against
+    # boto3/botocore's urllib3 cap (botocore<=1.31 wants <1.27 → 1.26.x; newer
+    # botocore allows 2.x — both inside <3).
+    "urllib3>=1.26,<3",
 ]
 
 [project.urls]
@@ -38,16 +49,30 @@ Issues = "https://github.com/backblaze-labs/genblaze/issues"
 [project.optional-dependencies]
 parquet = ["pyarrow>=14.0"]
 audio = ["mutagen>=1.47"]
+# Soft integrations: imported behind guards (try/except ImportError or
+# function-local), so core stays installable without them. Advertised as
+# extras so callers can opt in explicitly. http floor matches the connectors
+# already on httpx>=0.24 (nvidia, gmicloud, stability-audio, replicate).
+http = ["httpx>=0.24"]
+otel = ["opentelemetry-api>=1.20"]
+# genblaze_core.testing ships in the wheel and is a public, documented surface
+# (MockProvider/ProviderComplianceTests — see connector test suites and the
+# langsmith README). It imports pytest at module load, so it's only usable with
+# this extra installed: `pip install "genblaze-core[testing]"`.
+testing = ["pytest>=7.0"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "ruff>=0.4",
     "mypy>=1.8",
+    "deptry>=0.23",
     "pyarrow>=14.0",
     "mutagen>=1.47",
     "jsonschema>=4.0",
     "hypothesis>=6.0",
+    "httpx>=0.24",
+    "opentelemetry-api>=1.20",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -72,3 +97,24 @@ omit = ["*/tests/*"]
 show_missing = true
 skip_empty = true
 fail_under = 70
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry doesn't flag pytest,
+# ruff, mypy, etc. as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]
+
+[tool.deptry.per_rule_ignores]
+# botocore: core touches botocore exception types only inside
+# classify_botocore_error, reached exclusively from connector code
+# (genblaze-s3) that has already imported botocore. Declaring it in core would
+# wrongly pull boto3's stack into a storage-only install.
+# google: optional google-re2 accelerator for pattern safety; guarded at the
+# import site and absent by default.
+DEP001 = ["botocore", "google"]
+DEP003 = ["botocore", "google"]
+
+[tool.deptry.package_module_name_map]
+# opentelemetry-api (the `otel` extra) ships the top-level `opentelemetry`
+# module; map it so the guarded observability imports resolve to the
+# declaration without requiring the extra to be installed.
+opentelemetry-api = ["opentelemetry"]

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -91,6 +91,13 @@ import sys
 
 connectors = [
     "genblaze_core",
+    # Submodule with a hard import-at-load dependency (urllib3, via the
+    # AssetTransfer PoolManager). `import genblaze_core` uses lazy __getattr__
+    # dispatch and never executes this, so it must be imported explicitly to
+    # prove the clean-install contract — the regression class behind #37/#106.
+    # (genblaze_core.testing is NOT checked here: it needs pytest, which
+    # genblaze[all] does not install — that extra is gated in the follow-up.)
+    "genblaze_core.storage",
     "genblaze_s3",
     "genblaze_openai",
     "genblaze_google",


### PR DESCRIPTION
Add a deptry dependency-hygiene gate across the monorepo to close the undeclared-import crash class
  behind #37/#106 (a package imports a dependency it doesn't declare, crashing a clean install). The gate
  surfaced — and this PR fixes — two latent clean-install crashes of the same severity, plus declares
  several imports honestly. Metadata + tooling only; no application code changed.
  
  Changes

  New gate
  - Makefile: new deptry target (globs libs/connectors/*/ so new connectors are auto-included; excludes
  libs/meta), folded into make lint.
  - .github/workflows/ci.yml: dedicated deptry CI job running make install-dev → pip check → make deptry.
  - [tool.deptry] optional_dependencies_dev_groups = ["dev"] added to all 15 checked packages (core, s3,
  12 other connectors, cli). libs/meta excluded (umbrella metapackage: deps are install-time bundles, not
  imports).

  Fixes the gate surfaced
  - libs/core (0.3.2 → 0.3.3): declare urllib3>=1.26,<3 — it was imported unguarded at module load in
  storage/transfer.py (eager via storage/__init__) while core declared only pydantic+pillow, so import 
  genblaze_core.storage crashed a clean install. Add a testing extra (pytest>=7.0) because the shipped,
  documented genblaze_core.testing harness imports pytest at module load. Advertise guarded soft deps as
  http (httpx) and otel (opentelemetry-api) extras.
  - libs/connectors/s3 (0.3.2 → 0.3.3): declare botocore>=1.31 and aiobotocore>=2.7 (async extra) — direct
  imports that only arrived transitively via boto3/aioboto3, which pin their exact versions (no resolver
  effect).

  Regression guard + docs
  - tools/release_smoke.sh: now imports genblaze_core.storage in the clean-venv check, so a future urllib3
  removal fails the gate (plain import genblaze_core uses lazy dispatch and never executed it).
  - CHANGELOG.md, RELEASING.md, .claude/skills/scaffold-provider/SKILL.md (new connectors get the required
  [tool.deptry] field), and the execution plan updated.
  
  Test plan

  - [x] make test passes (core 1577, s3 246, meta 8; connectors unaffected — metadata-only)
  - [x] make lint passes (now includes make deptry; 15 packages clean)
  - [x] Docs updated (CHANGELOG, RELEASING, exec plan, scaffold skill)
  - [x] make deptry passes for all checked packages
  - [x] make pypi-pin-parity green (core/s3 fresh at 0.3.3, 0 drift)
  - [x] make release-smoke green — clean wheel venv imports genblaze_core.storage
  - [x] pip check reports no genblaze-* conflicts

  Related

  - Closes the import-declaration class behind #37, #106
  - Execution plan: docs/exec-plans/active/dependency-hygiene-deptry.md
  - Follow-up (separate PR, documented in the plan): constraint-respecting wheel pip check per-PR + uv 
  --resolution lowest-direct min-version CI to validate the >= floors this PR adds