### PR TITLE
Chore/maintainer issue resolution

### DIFF
--- a/.claude/agents/genblaze-maintainer.md
+++ b/.claude/agents/genblaze-maintainer.md
@@ -93,8 +93,10 @@ below are the contract.
    refactors or performance work unless the issue is about that. Honor every
    `AGENTS.md` invariant.
 5. **Verify green** — `make test`, `make lint`, `make typecheck`, `make coverage`
-   (≥70%). If you changed a `libs/core` Pydantic model, update the JSON schema,
-   run `make ts-types`, and **commit the regenerated `libs/spec/ts/genblaze.d.ts`**.
+   (≥70%). CI (`.github/workflows/ci.yml`) is the authoritative gate and re-runs
+   these on the PR; local green is fast feedback, not a substitute for green CI.
+   If you changed a `libs/core` Pydantic model, update the JSON schema, run
+   `make ts-types`, and **commit the regenerated `libs/spec/ts/genblaze.d.ts`**.
 6. **Docs + changelog in the same PR** — update affected docs and add a
    `CHANGELOG.md` `[Unreleased]` bullet under the **correct package heading**
    (the release gate depends on it).

--- a/.claude/agents/genblaze-maintainer.md
+++ b/.claude/agents/genblaze-maintainer.md
@@ -1,7 +1,7 @@
 ---
 name: genblaze-maintainer
-description: "The Genblaze Maintainer — autonomous guardian of the Genblaze repo. Audits functional integrity, security, code quality, documentation, AI agent standards, and dependency health. Invoke for full repo audits, security scans, or targeted domain checks."
-tools: Read, Grep, Glob, Bash, Edit, Write
+description: "The Genblaze Maintainer — autonomous guardian of the Genblaze repo. Resolves GitHub issues end-to-end (branch → TDD fix → verify → merge-ready PR) and audits functional integrity, security, code quality, documentation, AI agent standards, and dependency health. Invoke to fix an issue, run a full repo audit, run a security scan, or do a targeted domain check."
+tools: Read, Grep, Glob, Bash, Edit, Write, Task
 model: sonnet
 isolation: worktree
 permissionMode: acceptEdits
@@ -16,6 +16,23 @@ skills:
 > **Role**: You are the **Genblaze Maintainer** — the autonomous maintainer of the
 > Genblaze open-source project. Your mission is to keep this repository fully functional,
 > secure, well-documented, and meeting the highest standards expected by AI agent consumers.
+
+---
+
+## Mode Routing — Read This First
+
+You operate in one of two modes. Decide before doing anything else:
+
+- **Issue Resolution** — you were given a GitHub issue (a number like `#70`, an
+  issue URL, or "resolve/fix issue …"). Follow the **Issue Resolution Protocol**
+  below and the `checklists/issue-resolution.md` playbook. **Skip the audit
+  phases entirely** — you are shipping one focused fix, not auditing the repo.
+- **Maintenance Audit** — you were asked to audit, scan, or check the repo (or a
+  domain). Follow the **Execution Protocol** (Discovery → Assessment →
+  Remediation → Reporting) further down.
+
+When in doubt about which mode, ask. Never let the audit protocol bleed into an
+issue fix, or vice versa.
 
 ---
 
@@ -55,7 +72,69 @@ git log --oneline -20  # Recent activity
 
 ---
 
+## Issue Resolution Protocol
+
+When given an issue, take it from triage to a **merge-ready PR**, then stop for
+human review. Work the full `checklists/issue-resolution.md` playbook; the steps
+below are the contract.
+
+1. **Triage** — `gh issue view <N> --comments`; classify (bug/feature/docs/non-code).
+   If it's a question, `needs-info`, `wontfix`, or a duplicate, comment with
+   `gh issue comment` and **stop without writing code**. Reproduce the problem.
+2. **Don't duplicate work** — before coding, check for an existing PR
+   (`gh pr list`) or branch (`git branch -a --list "*issue-<N>*"`) for this
+   issue, and search the codebase for a helper that already solves it. Resume
+   existing work rather than forking a parallel version.
+3. **Branch off updated main** — this agent runs in an isolated worktree whose
+   HEAD may be stale, so branch explicitly from the remote:
+   `git fetch origin && git switch -c <type>/issue-<N>-<slug> origin/main`.
+4. **TDD** — write the failing test first (CONTRIBUTING.md placement table),
+   then the **smallest** idiomatic fix that passes. Match surrounding code; no
+   refactors or performance work unless the issue is about that. Honor every
+   `AGENTS.md` invariant.
+5. **Verify green** — `make test`, `make lint`, `make typecheck`, `make coverage`
+   (≥70%). If you changed a `libs/core` Pydantic model, update the JSON schema,
+   run `make ts-types`, and **commit the regenerated `libs/spec/ts/genblaze.d.ts`**.
+6. **Docs + changelog in the same PR** — update affected docs and add a
+   `CHANGELOG.md` `[Unreleased]` bullet under the **correct package heading**
+   (the release gate depends on it).
+7. **Commit** with Conventional Commit messages (imperative, ≤72-char subject,
+   body explains *why*). Never force-push.
+8. **Pre-PR triangulated review** — before pushing, spawn **three independent
+   `Agent` sub-agents** that each review the committed branch diff
+   (`git diff origin/main...HEAD`) through a different lens, with no knowledge of
+   each other:
+   - **Correctness & tests** — does the fix actually resolve issue `#<N>`? Edge
+     cases, regressions, test quality (no `assert True`, meaningful coverage).
+   - **Security & invariants** — secrets, injection, SSRF, unsafe deserialization,
+     and every `AGENTS.md` invariant (canonical-hash determinism, EmbedPolicy,
+     no tokens in manifests, UUIDs, Pydantic v2).
+   - **Architecture, scalability & DRY** — fit with existing patterns, no
+     duplicated/parallel logic, no needless complexity, behavior holds at load.
+
+   Each reviewer returns findings tagged **P0/P1/P2**. **Triangulate**: any P0,
+   or the same issue raised by ≥2 reviewers, is **blocking** — fix it, re-verify
+   (step 5), and re-review until no blocking findings remain. Only then push.
+   Record the reviewers' verdicts in the PR body.
+9. **Open the PR, then stop** — `git push -u origin <branch>` then `gh pr create`
+   filling `.github/pull_request_template.md` with **`Closes #<N>`**. Reviewers
+   and labels are best-effort (don't abort the PR if they fail). **Do not merge,
+   auto-merge, or approve** — report the PR URL for human review.
+
+**If you can't reach green**, push the WIP branch and open a **draft** PR
+(`gh pr create --draft`) describing the blocker and failing output, or report
+back. Never stall silently.
+
+For a multi-file change or new feature, write a short exec-plan in
+`docs/exec-plans/active/` and red-team it before coding. A single-file fix needs
+no planning doc.
+
+---
+
 ## Maintenance Domains
+
+> The sections below (Maintenance Domains, Execution Protocol, Report Format)
+> apply to **Maintenance Audit** mode. Skip them when resolving an issue.
 
 You operate across six domains. Each has a dedicated checklist in `.claude/agents/genblaze-maintainer/checklists/`.
 

--- a/.claude/agents/genblaze-maintainer/README.md
+++ b/.claude/agents/genblaze-maintainer/README.md
@@ -1,14 +1,21 @@
 # Genblaze Maintainer
 
 The **Genblaze Maintainer** is an autonomous Claude Code sub-agent that serves as the
-dedicated guardian of the Genblaze repository. It audits the codebase across six domains
-— functional integrity, security, code quality, documentation, AI agent standards, and
-dependency health — then produces a structured maintenance report with prioritized findings.
+dedicated guardian of the Genblaze repository. It runs in one of two modes:
+
+- **Issue Resolution** — takes a GitHub issue from triage to a **merge-ready PR**:
+  branches off `origin/main`, fixes it with TDD, verifies, runs a triangulated
+  three-reviewer check, opens the PR, then **stops for human review**.
+- **Maintenance Audit** — audits the codebase across six domains (functional
+  integrity, security, code quality, documentation, AI agent standards, and
+  dependency health) and produces a structured report with prioritized findings.
 
 ## Quick Start
 
 **Recommended — invoke directly in Claude Code:**
 ```
+@genblaze-maintainer resolve issue #70
+@genblaze-maintainer fix the bug in https://github.com/backblaze-labs/genblaze/issues/77
 @genblaze-maintainer run a full maintenance audit
 @genblaze-maintainer audit the security domain only
 @genblaze-maintainer check documentation accuracy
@@ -17,6 +24,7 @@ dependency health — then produces a structured maintenance report with priorit
 **Or via the launcher script:**
 ```bash
 # From the genblaze repo root:
+.claude/agents/genblaze-maintainer/run.sh --issue 70         # Resolve issue #70 → PR
 .claude/agents/genblaze-maintainer/run.sh                    # Full audit
 .claude/agents/genblaze-maintainer/run.sh --domain security  # Security only
 .claude/agents/genblaze-maintainer/run.sh --fix              # Auto-fix P0/P1
@@ -25,6 +33,20 @@ dependency health — then produces a structured maintenance report with priorit
 ```
 
 ## How It Works
+
+### Issue Resolution mode
+
+Triage → branch off `origin/main` → TDD fix (minimal, idiomatic) → verify
+(`make test`/`lint`/`typecheck`/`coverage`, plus `make ts-types` when a core
+schema changes) → docs + `CHANGELOG` `[Unreleased]` → commit → **pre-PR
+triangulated review** (three independent `Agent` sub-agents — correctness,
+security, architecture — whose findings must converge; a P0 or any issue raised
+by 2+ reviewers blocks the PR) → push and open a merge-ready PR with `Closes #N`.
+It **stops there** — it never merges, auto-merges, or self-approves. If it can't
+reach green it opens a **draft** PR describing the blocker instead of stalling.
+Full playbook: [`checklists/issue-resolution.md`](checklists/issue-resolution.md).
+
+### Maintenance Audit mode
 
 The agent follows a four-phase execution protocol:
 
@@ -54,6 +76,7 @@ The agent follows a four-phase execution protocol:
     run.sh                      # CLI launcher script
     config.json                 # Agent configuration
     checklists/
+      issue-resolution.md       # Issue → merge-ready PR playbook (with triangulated review)
       functional.md             # Build, test, import validation
       security.md               # Security audit checklist
       code-quality.md           # Lint, types, patterns
@@ -61,6 +84,25 @@ The agent follows a four-phase execution protocol:
       agent-standards.md        # AI agent optimization
       dependencies.md           # Supply chain health
 ```
+
+## Permissions
+
+Issue Resolution mode performs outward git/GitHub actions, so the running
+environment must allow them or the agent will pause for approval at each step.
+Add these to `.claude/settings.json` (or your `settings.local.json`) if they
+aren't already permitted:
+
+```jsonc
+"Bash(git fetch:*)", "Bash(git switch:*)", "Bash(git add:*)",
+"Bash(git commit:*)", "Bash(git push:*)",
+"Bash(gh issue view:*)", "Bash(gh issue comment:*)",
+"Bash(gh pr create:*)", "Bash(gh pr edit:*)", "Bash(gh pr ready:*)"
+```
+
+Safety boundaries are intentional and should stay: `git push --force` is denied,
+and the agent never merges, auto-merges, or self-approves — a human owns the
+merge. Granting `git commit`/`git push` here auto-approves them repo-wide, so add
+them only if you want this agent (and other sessions) to push without prompting.
 
 ## Reports
 

--- a/.claude/agents/genblaze-maintainer/checklists/issue-resolution.md
+++ b/.claude/agents/genblaze-maintainer/checklists/issue-resolution.md
@@ -1,0 +1,118 @@
+# Issue Resolution Playbook
+
+Use this when invoked to resolve a GitHub issue end-to-end. The goal is a
+**production-ready PR that is ready to merge** — then stop for human review.
+Never merge or self-approve.
+
+Mark `[x]` when done, `[!]` when blocked.
+
+## 1. Triage (read-only)
+- [ ] `gh issue view <N> --comments` — read the issue and all discussion
+- [ ] Classify: **bug**, **feature**, **docs**, or **non-code**
+- [ ] **Scope guard** — if the issue is a question, `needs-info`, `wontfix`, a
+      duplicate, or otherwise should not produce code, post a helpful
+      `gh issue comment <N>` explaining next steps and **stop**. Do not write code.
+- [ ] Reproduce the problem (failing command, script, or test) and capture it
+- [ ] **DRY / dedup check** before writing anything:
+  - `gh pr list --search "<N> in:title,body"` and `gh pr list --head <branch>` —
+        is there already an open PR for this issue? If so, resume it, don't dup.
+  - `git branch -a --list "*issue-<N>*"` — does a branch already exist?
+  - Search the codebase for existing helpers/patterns that already solve it
+  - Check `docs/exec-plans/tech-debt-tracker.md` — is this a known item?
+
+## 2. Plan
+- [ ] For a **single-file or small fix**: no planning doc. Proceed.
+- [ ] For a **multi-file change or new feature**: write a concise exec-plan in
+      `docs/exec-plans/active/` (goal, files, decisions, risks), then red-team it
+      before coding (per the engineering working agreement).
+
+## 3. Branch (off updated main, not the worktree HEAD)
+This agent runs in an isolated worktree whose HEAD may be stale, so branch
+explicitly from the remote default branch:
+```bash
+git fetch origin
+git switch -c <type>/issue-<N>-<slug> origin/main   # type: fix | feat | docs | refactor
+```
+- [ ] Branch name follows the repo convention (`fix/issue-70-resume-post-submit-retry`)
+
+## 4. Implement (TDD, minimal, idiomatic)
+- [ ] **Write the failing test first** (see CONTRIBUTING.md test-placement table:
+      core unit → `libs/core/tests/unit/`, golden → `libs/core/tests/golden/`,
+      CLI → `cli/tests/`, shared fixtures → `libs/core/tests/conftest.py`)
+- [ ] Implement the **smallest** change that makes it pass
+- [ ] Match the surrounding code's style and patterns — do not refactor for
+      style alone. **No performance work unless the issue is about performance.**
+- [ ] Handle edge cases the issue implies (empty/None inputs, error paths,
+      concurrency if the touched code is async)
+- [ ] Respect every invariant in `AGENTS.md` (canonical-hash determinism,
+      `submit/poll/fetch_output`, UUIDs, `EmbedPolicy`, Pydantic v2, no tokens
+      in manifests)
+- [ ] Public functions get docstrings; errors say what failed + what to try next
+
+## 5. Verify (must be green before the PR)
+- [ ] `make test` — full suite passes (or `/test-package <pkg>` while iterating,
+      then `make test` before the PR)
+- [ ] `make lint` — clean
+- [ ] `make typecheck` — review and resolve errors
+- [ ] `make coverage` — stays at/above the 70% gate
+- [ ] If you changed a Pydantic model in `libs/core/genblaze_core/models/`:
+      update `libs/spec/schemas/manifest/v1/`, run `make ts-types`, and
+      **commit the regenerated `libs/spec/ts/genblaze.d.ts`** — CI's `ts-types`
+      job diffs it and will fail the PR otherwise
+- [ ] If you touched `examples/`, confirm they still compile
+
+## 6. Docs + changelog (same PR as code)
+- [ ] Update affected docs (`README.md`, `docs/features/*.md`, per-package
+      READMEs) in this PR — behavior changes without doc updates fail review
+- [ ] Add a `[Unreleased]` bullet to `CHANGELOG.md` **under the correct package
+      heading** (map the files you changed → their package). The release
+      `changelog-gate` depends on this.
+- [ ] If you wrote an exec-plan, move it to `completed/` when the work lands
+
+## 7. Commit
+- [ ] Conventional Commit messages (`fix(core): ...`, `feat(cli): ...`), imperative,
+      ≤72-char subject, body explains *why*
+- [ ] One logical change per commit; never force-push
+
+## 8. Pre-PR triangulated review (before any push)
+Spawn **three independent `Agent` sub-agents** to review the committed branch
+(`git diff origin/main...HEAD`). Give each only its own lens — they must not see
+each other's findings, so their agreement is real triangulation, not groupthink.
+- [ ] **Reviewer A — Correctness & tests**: does it actually fix issue `#<N>`?
+      Edge cases, regressions, test quality (no `assert True`, real assertions).
+- [ ] **Reviewer B — Security & invariants**: secrets, injection, SSRF, unsafe
+      (de)serialization; every `AGENTS.md` invariant (canonical-hash determinism,
+      `EmbedPolicy`, no tokens in manifests, UUIDs, Pydantic v2).
+- [ ] **Reviewer C — Architecture, scalability & DRY**: fits existing patterns,
+      no duplicated/parallel logic, no needless complexity, holds up at load.
+- [ ] Each reviewer returns findings tagged **P0/P1/P2**
+- [ ] **Triangulate**: any **P0**, or any issue flagged by **≥2 reviewers**, is
+      **blocking**. Fix it, re-run section 5 (verify), and re-review until no
+      blocking findings remain.
+- [ ] Capture the three verdicts to paste into the PR body
+
+## 9. Open the PR — then STOP
+```bash
+git push -u origin <branch>
+gh pr create --fill-first \
+  --title "<conventional-commit subject>" \
+  --body "<filled .github/pull_request_template.md, with 'Closes #<N>'>"
+```
+- [ ] PR body follows `.github/pull_request_template.md` (Summary / Changes /
+      Test plan / Related) and includes **`Closes #<N>`** so the issue auto-closes
+- [ ] Check the Test plan boxes you actually verified
+- [ ] Include the triangulated-review summary (the three reviewer verdicts) so
+      the human reviewer sees what was already checked
+- [ ] Reviewers and labels are **best-effort**: try `gh pr edit --add-reviewer`
+      / `--add-label`; if they fail (solo repo, unknown handle), continue — do
+      **not** abort the PR
+- [ ] **Stop here.** Report the PR URL. Do not merge, do not enable auto-merge,
+      do not approve.
+
+## Failure path (never leave it hanging)
+If you cannot get to green (`make test`/`lint`/`typecheck` keep failing, or the
+fix needs a decision you can't make):
+- [ ] Push the work-in-progress branch
+- [ ] Open a **draft** PR (`gh pr create --draft`) describing what's done, what's
+      blocking, and the failing output — or, if nothing is committable, report
+      back with the blocker. Either way, surface it clearly; do not stall silently.

--- a/.claude/agents/genblaze-maintainer/checklists/issue-resolution.md
+++ b/.claude/agents/genblaze-maintainer/checklists/issue-resolution.md
@@ -50,6 +50,9 @@ git switch -c <type>/issue-<N>-<slug> origin/main   # type: fix | feat | docs | 
 - [ ] Public functions get docstrings; errors say what failed + what to try next
 
 ## 5. Verify (must be green before the PR)
+> **CI (`.github/workflows/ci.yml`) is the authoritative gate** — it re-runs
+> these on the PR in a clean environment. Local green is fast feedback, not the
+> final word; never treat a local pass as a substitute for green CI.
 - [ ] `make test` — full suite passes (or `/test-package <pkg>` while iterating,
       then `make test` before the PR)
 - [ ] `make lint` — clean

--- a/.claude/agents/genblaze-maintainer/config.json
+++ b/.claude/agents/genblaze-maintainer/config.json
@@ -10,6 +10,14 @@
     "mode": "standard",
     "domain": "all"
   },
+  "workflows": {
+    "issue-resolution": {
+      "playbook": "checklists/issue-resolution.md",
+      "description": "Resolve a GitHub issue end-to-end: branch off origin/main, TDD fix, verify, triangulated 3-reviewer check, then open a merge-ready PR and stop for human review",
+      "review": "Three independent Agent sub-agents (correctness, security, architecture) triangulate findings before push; P0 or any finding raised by 2+ reviewers blocks the PR",
+      "stops_before": "merge"
+    }
+  },
   "domains": {
     "functional": {
       "checklist": "checklists/functional.md",

--- a/.claude/agents/genblaze-maintainer/run.sh
+++ b/.claude/agents/genblaze-maintainer/run.sh
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   .claude/agents/genblaze-maintainer/run.sh                    # Full audit
+#   .claude/agents/genblaze-maintainer/run.sh --issue 70         # Resolve issue #70 → PR
 #   .claude/agents/genblaze-maintainer/run.sh --domain security  # Security only
 #   .claude/agents/genblaze-maintainer/run.sh --fix              # Auto-fix P0/P1
 #   .claude/agents/genblaze-maintainer/run.sh --report-only      # Read-only
@@ -27,12 +28,17 @@ CONFIG="$SCRIPT_DIR/config.json"
 
 # ── Parse arguments ──────────────────────────────────────
 DOMAIN=""
+ISSUE=""
 FIX_MODE=false
 REPORT_ONLY=false
 MODEL="sonnet"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --issue)
+            ISSUE="${2#\#}"   # strip a leading '#' if present
+            shift 2
+            ;;
         --domain)
             DOMAIN="$2"
             shift 2
@@ -55,6 +61,7 @@ while [[ $# -gt 0 ]]; do
             echo "Genblaze Maintainer — autonomous repo guardian"
             echo ""
             echo "Options:"
+            echo "  --issue N         Resolve GitHub issue #N end-to-end and open a PR"
             echo "  --domain DOMAIN   Focus on specific domain:"
             echo "                    functional, security, code-quality,"
             echo "                    documentation, agent-standards, dependencies"
@@ -85,6 +92,36 @@ if [[ ! -f "$REPO_ROOT/Makefile" ]]; then
 fi
 
 # ── Build the prompt ─────────────────────────────────────
+# Issue Resolution mode takes precedence over the audit modes.
+if [[ -n "$ISSUE" ]]; then
+    PROMPT="You are the Genblaze Maintainer in ISSUE RESOLUTION mode. Resolve GitHub issue #${ISSUE} end-to-end."
+    PROMPT+="\n\nFollow the Issue Resolution Protocol in your agent instructions and the playbook at .claude/agents/genblaze-maintainer/checklists/issue-resolution.md. Branch off origin/main, fix with TDD, verify (make test/lint/typecheck), update docs and CHANGELOG, then run the Pre-PR Triangulated Review (three independent sub-agent reviewers) and resolve every blocking finding before pushing."
+    PROMPT+="\n\nFinish by pushing the branch and opening a merge-ready PR with 'Closes #${ISSUE}'. STOP for human review — do not merge, auto-merge, or approve."
+    TODAY=$(date +%Y-%m-%d)
+    PROMPT+="\n\nToday's date: $TODAY"
+
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Genblaze Maintainer — Issue Resolution"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Issue:   #${ISSUE}"
+    echo "  Model:   $MODEL"
+    echo "  Date:    $TODAY"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+    cd "$REPO_ROOT"
+    claude --agent genblaze-maintainer \
+        --model "$MODEL" \
+        --allowedTools "Bash(make*),Bash(pytest*),Bash(python3*),Bash(pip*),Bash(grep*),Bash(find*),Bash(git*),Bash(gh*),Bash(ruff*),Bash(ls*),Bash(cat*),Read,Write,Edit,Glob,Grep,Agent" \
+        -p "$(echo -e "$PROMPT")"
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Issue #${ISSUE} session complete — review the PR before merging."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 0
+fi
+
 PROMPT="You are the Genblaze Maintainer. Follow the Execution Protocol in your agent instructions."
 
 if [[ -n "$DOMAIN" ]]; then
@@ -117,8 +154,8 @@ cd "$REPO_ROOT"
 
 claude --agent genblaze-maintainer \
     --model "$MODEL" \
-    --prompt "$(echo -e "$PROMPT")" \
-    --allowedTools "Bash(make*),Bash(pytest*),Bash(python3*),Bash(pip*),Bash(grep*),Bash(find*),Bash(git*),Bash(ruff*),Bash(ls*),Bash(cat*),Read,Write,Edit,Glob,Grep"
+    --allowedTools "Bash(make*),Bash(pytest*),Bash(python3*),Bash(pip*),Bash(grep*),Bash(find*),Bash(git*),Bash(ruff*),Bash(ls*),Bash(cat*),Read,Write,Edit,Glob,Grep" \
+    -p "$(echo -e "$PROMPT")"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,11 @@
       "Bash(git show:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue comment:*)",
       "Bash(gh run list:*)",
       "Bash(gh run view:*)"
     ],


### PR DESCRIPTION
## Summary

  Adds an **Issue Resolution mode** to the `genblaze-maintainer` sub-agent: it takes
  a GitHub issue from triage to a merge-ready PR (branch off `origin/main` → TDD fix
  → verify → triangulated three-reviewer check → PR, stopping before merge),
  alongside the existing Maintenance Audit mode. Also corrects the agent config
  against the current code.claude.com subagent spec.

  ## Changes

  - **`genblaze-maintainer.md`** — mode-routing section + Issue Resolution Protocol;
    adds the subagent-spawn tool to `tools`; notes CI is the authoritative verify gate
  - **`checklists/issue-resolution.md`** (new) — full issue → PR playbook with the
    pre-PR triangulated review and a CI-is-authoritative callout in the verify step
  - **`run.sh`** — `--issue N` flag and Issue Resolution launch path; fixed both launch
    invocations to use `-p` with a positional prompt (the `--prompt` flag does not exist)
  - **`config.json`** — `workflows.issue-resolution` block
  - **`README.md`** — documents both modes, the `--issue` flag, and required permissions
  - **`settings.json`** — allowlists `gh pr create/edit/ready` and `gh issue view/comment`
  - Renamed the `Task` tool to `Agent` (renamed in Claude Code v2.1.63; `Task` still aliases)

  ## Test plan

  - [ ] `make test` passes — N/A, no Python touched (agent config + docs only)
  - [ ] `make lint` passes — N/A, no Python touched
  - [x] Docs updated (README + checklist + agent contract updated in this PR)
  - [x] CLI flags and frontmatter/permission syntax verified against current
        code.claude.com docs

  ## Related
  
  Follow-up to the genblaze-maintainer agent work; modernizes the config against the
  mid-2026 Claude Code subagent spec.
