### PR TITLE
feat(connectors): add genblaze-assemblyai speech-to-text provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           pip install -e "libs/connectors/gmicloud[dev]"
           pip install -e "libs/connectors/langsmith[dev]"
           pip install -e "libs/connectors/nvidia[dev]"
+          pip install -e "libs/connectors/assemblyai[dev]"
           pip install -e "cli[dev]"
           pip install mypy
       - name: Typecheck core
@@ -91,7 +92,7 @@ jobs:
       - name: Typecheck connectors
         run: |
           failed=""
-          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia; do
+          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia assemblyai; do
             echo "=== Typechecking $conn ==="
             if ! mypy libs/connectors/$conn/genblaze_*/ --ignore-missing-imports; then
               failed="$failed $conn"
@@ -198,6 +199,7 @@ jobs:
           pip install -e "libs/connectors/gmicloud[dev]"
           pip install -e "libs/connectors/langsmith[dev]"
           pip install -e "libs/connectors/nvidia[dev]"
+          pip install -e "libs/connectors/assemblyai[dev]"
           pip install -e "cli[dev]"
           pip install pytest-cov
       - name: Run core tests with coverage
@@ -205,7 +207,7 @@ jobs:
           cd libs/core && pytest tests/ -v --cov=genblaze_core --cov-report=xml --cov-report=term-missing
       - name: Run connector tests
         run: |
-          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia; do
+          for conn in replicate s3 openai google runway luma decart elevenlabs stability-audio lmnt hume gmicloud langsmith nvidia assemblyai; do
             echo "=== Testing $conn ==="
             (cd libs/connectors/$conn && pytest -v)
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
           - gmicloud
           - langsmith
           - nvidia
+          - assemblyai
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## Repo Purpose
 
-Orchestration framework for generative media pipelines with manifest-based provenance tracking. Produces 15 pip-installable packages: `genblaze-core`, 12 provider adapter packages (`genblaze-openai`, `genblaze-google`, `genblaze-runway`, `genblaze-luma`, `genblaze-decart`, `genblaze-replicate`, `genblaze-elevenlabs`, `genblaze-stability-audio`, `genblaze-lmnt`, `genblaze-hume`, `genblaze-gmicloud`, `genblaze-nvidia`), `genblaze-s3`, and `genblaze-cli`.
+Orchestration framework for generative media pipelines with manifest-based provenance tracking. Produces 16 pip-installable packages: `genblaze-core`, 13 provider adapter packages (`genblaze-openai`, `genblaze-google`, `genblaze-runway`, `genblaze-luma`, `genblaze-decart`, `genblaze-replicate`, `genblaze-elevenlabs`, `genblaze-stability-audio`, `genblaze-lmnt`, `genblaze-hume`, `genblaze-gmicloud`, `genblaze-nvidia`, `genblaze-assemblyai`), `genblaze-s3`, and `genblaze-cli`.
 
 ## Architecture Boundaries
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,7 @@
   - `genblaze-hume` — Hume AI (Octave TTS)
   - `genblaze-gmicloud` — GMICloud (video, image, audio via request queue)
   - `genblaze-nvidia` — NVIDIA NIM / build.nvidia.com (video, image, audio, chat)
+  - `genblaze-assemblyai` — AssemblyAI (speech-to-text / transcription → TEXT output)
 - **genblaze-s3** (`libs/connectors/s3/`) — S3-compatible storage backend
 - **genblaze-langsmith** (`libs/connectors/langsmith/`) — LangSmith observability tracer
 - **genblaze-cli** (`cli/`) — Click-based CLI: extract, verify, replay, index
@@ -68,6 +69,7 @@
 - **LMNT API** — Fast TTS (`genblaze-lmnt`)
 - **Hume AI API** — Octave TTS (`genblaze-hume`)
 - **GMICloud API** — Video, image, audio via request queue (`genblaze-gmicloud`)
+- **AssemblyAI API** — Speech-to-text / transcription → TEXT transcript (`genblaze-assemblyai`)
 - All accessed via lazy SDK imports — no runtime dependency unless the connector is used
 
 ## Trust Boundaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pricing (register per-character rates via the recipe in
   `docs/reference/pricing-recipes.md`). Available as `pip install genblaze-hume`
   or the `genblaze[hume]` / `genblaze[audio]` extras.
+- `genblaze-assemblyai`: new provider adapter for **AssemblyAI** speech-to-text
+  / transcription — the first connector that *consumes* audio and *produces*
+  text. Async `BaseProvider` (submit / poll / fetch_output) that resolves an
+  audio URL (`step.inputs[0]` → `params["audio_url"]` → `prompt`, SSRF-validated
+  via `validate_chain_input_url`) and emits a hash-verified **TEXT asset**
+  (`text:{sha256}`, `media_type="text/plain"`, transcript in `metadata["text"]`)
+  with word-level timings on `AudioMetadata.word_timings` (converted ms → s).
+  `step.model` is sent on the SDK's plural `speech_models` field (the live API
+  has deprecated the singular `speech_model` field and the legacy best/nano
+  aliases). Ships a pattern-keyed `assemblyai-speech` family (`universal-3-pro`
+  / `universal-2`) with a permissive TEXT fallback,
+  `DiscoverySupport.NONE`, and no hardcoded pricing (register
+  per-minute-of-input-audio rates via the recipe in
+  `docs/reference/pricing-recipes.md`). Available as
+  `pip install genblaze-assemblyai` or the `genblaze[assemblyai]` extra.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install:
 	pip install -e libs/connectors/gmicloud
 	pip install -e libs/connectors/langsmith
 	pip install -e libs/connectors/nvidia
+	pip install -e libs/connectors/assemblyai
 	pip install -e cli
 	pip install -e libs/meta
 
@@ -35,6 +36,7 @@ install-dev:
 	pip install -e "libs/connectors/gmicloud[dev]"
 	pip install -e "libs/connectors/langsmith[dev]"
 	pip install -e "libs/connectors/nvidia[dev]"
+	pip install -e "libs/connectors/assemblyai[dev]"
 	pip install -e "cli[dev]"
 	pip install -e "libs/meta[dev]"
 
@@ -54,6 +56,7 @@ test:
 	cd libs/connectors/gmicloud && pytest -v
 	cd libs/connectors/langsmith && pytest -v
 	cd libs/connectors/nvidia && pytest -v
+	cd libs/connectors/assemblyai && pytest -v
 	cd cli && pytest tests/ -v
 	cd libs/meta && pytest tests/ -v
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ pip install genblaze-elevenlabs      # ElevenLabs TTS + sound effects
 pip install genblaze-stability-audio # Stability AI Stable Audio (music)
 pip install genblaze-lmnt            # LMNT fast TTS
 pip install genblaze-hume            # Hume AI Octave TTS
+pip install genblaze-assemblyai      # AssemblyAI speech-to-text / transcription
 ```
 
 Install names use hyphens, Python imports use underscores: `pip install genblaze-<name>` → `import genblaze_<name>`.
@@ -160,6 +161,8 @@ Genblaze ships adapters for major generative AI platforms. The matrix below is t
 | **LMNT** | — | — | TTS | — |
 | **Hume** | — | — | Octave TTS | — |
 
+> **Speech-to-Text / Transcription:** [`genblaze-assemblyai`](libs/connectors/assemblyai/README.md) is the inverse of the matrix above — it *consumes* an audio URL and *produces* a hash-verified **TEXT transcript** asset (with word-level timings), composable into pipelines like any other step.
+
 ## Configure API keys
 
 Every provider reads its credentials from an environment variable. You don't need all of them — just the ones whose providers you use.
@@ -179,6 +182,7 @@ Every provider reads its credentials from an environment variable. You don't nee
 | Stability AI (music) | `STABILITY_API_KEY` | [platform.stability.ai](https://platform.stability.ai/account/keys) |
 | LMNT (fast TTS) | `LMNT_API_KEY` | [app.lmnt.com](https://app.lmnt.com/account) |
 | Hume (Octave TTS) | `HUME_API_KEY` | [platform.hume.ai](https://platform.hume.ai/) |
+| AssemblyAI (speech-to-text) | `ASSEMBLYAI_API_KEY` | [assemblyai.com/app/api-keys](https://www.assemblyai.com/app/api-keys) |
 
 **Example — one provider + B2 storage:**
 

--- a/docs/exec-plans/active/assemblyai-provider.md
+++ b/docs/exec-plans/active/assemblyai-provider.md
@@ -1,0 +1,186 @@
+# Add AssemblyAI as a genblaze provider (speech-to-text)
+
+> Status: active · Owner: Eduardo Pavez · Created 2026-06-23
+
+## Context
+
+AssemblyAI is a **speech-to-text / audio-intelligence** API — it *consumes* an audio
+URL and *produces* a text transcript (+ word-level timing, speaker labels, optional
+audio-intelligence). This is the inverse of every existing genblaze connector, which
+generates media. We add it anyway because:
+
+- It fits genblaze's primitives with **zero core changes**: `Modality.TEXT` already
+  exists, `AudioMetadata.word_timings` (`WordTiming{word,start,end,confidence}`) is
+  purpose-built for transcript timing, and `NvidiaChatProvider`
+  (`libs/connectors/nvidia/genblaze_nvidia/chat_provider.py`) is a working precedent
+  for a Pipeline provider that emits a **TEXT `Asset`** (`url="text:{sha256}"`,
+  `media_type="text/plain"`, payload in `metadata["text"]`, sha256 over text bytes).
+- It makes a transcribe step composable into pipelines (e.g. generate audio → transcribe,
+  or caption a generated video) with full provenance: the transcript gets a
+  manifest + canonical hash and lands in B2 like any other asset.
+
+**Outcome:** a new `genblaze-assemblyai` connector package, installable as
+`pip install genblaze-assemblyai`, discoverable via the `genblaze.providers` entry point,
+that transcribes an audio URL into a hash-verified TEXT asset with word timings.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Base class | **`BaseProvider`** (submit/poll/fetch_output) | AssemblyAI's REST API is genuinely async (POST `/v2/transcript` → poll GET status). Gets adaptive polling, progress events, `resume()` crash-recovery, and poll caching for free — the right fit for long jobs. |
+| v1 scope | **Transcription + word timings** | Core STT: audio URL → transcript TEXT asset, speaker labels, `word_timings`. Audio-intelligence flags pass through to the API and land in `metadata`, not first-class. |
+| Output | TEXT `Asset` per the NvidiaChatProvider precedent | No new asset shape needed. |
+| Input source | Resolve audio URL from (priority) `step.inputs[0].url` → `step.params["audio_url"]` → `step.prompt`; `validate_chain_input_url()` the chosen URL | Supports both standalone and chained pipeline use; satisfies the SSRF invariant. |
+| Discovery | `DiscoverySupport.NONE` + one `ModelFamily` for known `speech_model` slugs + permissive `TEXT` fallback | AssemblyAI exposes no live `/models` catalog; the slug set is small/stable. |
+| Pricing | User-registered, **per minute of *input* audio** via a custom strategy reading `audio_duration` from the response; ship **no** hardcoded price | Per-0.3.0 invariant: connectors ship zero prices. AssemblyAI bills per input-audio duration (new recipe shape — no existing helper). |
+| Env var | `ASSEMBLYAI_API_KEY` | AssemblyAI convention. |
+| SDK | `assemblyai` (PyPI; current 0.64.x) | Use `Transcriber().submit()` (non-blocking) + `aai.Transcript.get_by_id(id)` for polling. |
+
+## Out of scope for v1 (follow-ups)
+
+- **Real-time/streaming** transcription (websocket) — doesn't fit the Pipeline step lifecycle.
+- **LeMUR** (LLM-over-transcript) — would mirror the standalone `chat()` shape, separate effort.
+- **SRT/VTT subtitle outputs** and **first-class audio-intelligence** surfacing — both were
+  offered and deferred; clean follow-ups once the core connector lands.
+
+## Files to create — `libs/connectors/assemblyai/`
+
+```
+libs/connectors/assemblyai/
+├── genblaze_assemblyai/
+│   ├── __init__.py          # from .provider import AssemblyAIProvider; __all__
+│   ├── provider.py          # AssemblyAIProvider(BaseProvider)
+│   ├── _errors.py           # map_assemblyai_error(exc) -> ProviderErrorCode
+│   └── py.typed             # empty PEP 561 marker
+├── tests/
+│   ├── __init__.py
+│   └── test_assemblyai.py   # TestAssemblyAICompliance + provider-specific tests
+├── pyproject.toml
+└── README.md
+```
+
+### `provider.py` — shape (mirror `replicate/provider.py` for lifecycle, `nvidia/chat_provider.py` for the TEXT asset)
+
+```python
+class AssemblyAIProvider(BaseProvider):
+    name = "assemblyai"
+    discovery_support = DiscoverySupport.NONE
+
+    @classmethod
+    def create_registry(cls) -> ModelRegistry: ...   # ModelFamily(pattern for best|nano|universal*|slam-*) + TEXT fallback
+
+    def __init__(self, api_key=None, *, poll_interval=3.0, models=None,
+                 retry_policy=None, probe_cache_ttl=None, probe_cache_max_entries=None):
+        super().__init__(models=models, retry_policy=retry_policy,
+                         probe_cache_ttl=probe_cache_ttl, probe_cache_max_entries=probe_cache_max_entries)
+        self._api_key = api_key; self._client = None
+
+    def _get_client(self): ...        # lazy `import assemblyai`; ImportError -> ProviderError with pip hint
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supported_modalities=[Modality.TEXT], supported_inputs=["audio"],
+            accepts_chain_input=True, models=self._models.known(), output_formats=["text/plain"])
+
+    def normalize_params(self, params, modality=None): ...   # language -> language_code (idempotent guards); pass-through rest
+
+    def submit(self, step, config=None):     # resolve+validate audio_url; build aai.TranscriptionConfig(speech_model=step.model, **params)
+        return self._get_client()... .submit(audio_url, config=cfg).id   # non-blocking; return transcript id
+
+    def poll(self, prediction_id, config=None):   # t = aai.Transcript.get_by_id(id)
+        if t.status in (completed, error):
+            self._cache_poll_result(prediction_id, t); return True
+        return False
+
+    def fetch_output(self, prediction_id, step):
+        t = self._get_cached_poll_result(prediction_id) or aai.Transcript.get_by_id(prediction_id)
+        if t.status == error: raise ProviderError(t.error, error_code=map_assemblyai_error(t.error))
+        text = t.text or ""; digest = sha256(text)
+        asset = Asset(url=f"text:{digest}", media_type="text/plain", sha256=digest,
+                      size_bytes=len(text.encode()),
+                      audio=AudioMetadata(word_timings=[...]) if t.words else None,
+                      metadata={"text": text, "language": ..., "confidence": ..., "utterances": ...})
+        step.assets = [asset]
+        step.provider_payload["audio_duration"] = t.audio_duration   # seconds; pricing reads this
+        self._apply_registry_pricing(step)
+        return step
+```
+
+### Key implementation gotchas (easy to get wrong)
+
+1. **Milliseconds → seconds.** AssemblyAI returns word `start`/`end` in **ms**;
+   `WordTiming` expects **seconds**. Divide by 1000.
+2. **Verify SDK surface at the chosen floor.** Confirm `Transcriber().submit()` (non-blocking)
+   and `aai.Transcript.get_by_id(id)` exist in the pinned `assemblyai` version. If not,
+   fall back to raw REST via `httpx` (POST `/v2/transcript`, GET `/v2/transcript/{id}`,
+   `Authorization: <API_KEY>` header, no `Bearer`).
+3. **`step.model` is the `speech_model`** ("best" | "nano" | "universal" | "slam-1" | …).
+   Map string → `aai.SpeechModel` enum where the SDK requires it; pass through otherwise.
+4. **`expects_cost = False`** in the compliance subclass — we ship no pricing, so
+   `step.cost_usd` is `None` unless the user registers a strategy (same as Hume).
+5. **No core / spec change.** We add no fields to core Pydantic models, so **no
+   `make ts-types` regen and no `test_spec_conformance` impact**. Keep it that way.
+
+### `_errors.py` — `map_assemblyai_error(exc)` (status-code-first, like `hume/_errors.py`)
+
+```python
+def map_assemblyai_error(exc):
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status == 429: return RATE_LIMIT
+        if status in (401, 403): return AUTH_FAILURE
+        if status in (400, 422): return INVALID_INPUT
+        if status >= 500: return SERVER_ERROR
+    return classify_api_error(exc)   # shared string fallback; also used for transcript.error strings
+```
+
+### `pyproject.toml` (copy `libs/connectors/hume/pyproject.toml`, which is current 0.3.0)
+
+- `name = "genblaze-assemblyai"`, `version = "0.3.0"` (match current release wave — confirm vs a sibling)
+- `dependencies = ["genblaze-core>=0.3.0,<0.4", "assemblyai>=0.40,<1"]`
+- `[project.entry-points."genblaze.providers"]` → `assemblyai = "genblaze_assemblyai:AssemblyAIProvider"`
+- classifiers, `[tool.hatch.build.targets.wheel] packages = ["genblaze_assemblyai"]`,
+  `[tool.pytest.ini_options] testpaths = ["tests"]`, `[tool.deptry]` block — all per the hume template.
+
+### `tests/test_assemblyai.py`
+
+- `class TestAssemblyAICompliance(ProviderComplianceTests)` with `expects_cost = False`;
+  `_patch_sdk` fixture patching `sys.modules["assemblyai"]` (Hume pattern); `make_provider()`
+  injects a fake whose `Transcriber.submit()` → fake id and `Transcript.get_by_id()` → a
+  **completed** fake transcript with `.text`, `.words`, `.audio_duration`, `.status`.
+- Provider-specific tests: `map_assemblyai_error` by status code; ms→s word-timing conversion;
+  audio-URL resolution precedence (`inputs` > `params["audio_url"]` > `prompt`);
+  `status == "error"` raises `ProviderError`; `normalize_params` idempotency.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `Makefile` | Add 3 lines: `pip install -e libs/connectors/assemblyai` (`install`), `pip install -e "libs/connectors/assemblyai[dev]"` (`install-dev`), `cd libs/connectors/assemblyai && pytest -v` (`test`). **Without the `test` line, CI never runs the tests.** |
+| `libs/meta/pyproject.toml` | Add an `assemblyai = ["genblaze-assemblyai"]` optional extra and include it in the `all` extra (confirm the meta package's extras layout first). |
+| `README.md` | Add to the Install list and the "Configure API keys" table (`ASSEMBLYAI_API_KEY` → platform.assemblyai.com). The provider matrix is generation-only (Video/Image/Audio/Chat) — AssemblyAI fits none; add a short **Speech-to-Text / Transcription** note or a matrix row with a "transcription, TEXT output" footnote (keep minimal). |
+| `ARCHITECTURE.md` | Add `genblaze-assemblyai` to the provider-adapters list and the External Services list. |
+| `AGENTS.md` | Update the package count (15 → 16) and the connector enumeration in "Repo Purpose". |
+| `docs/reference/pricing-recipes.md` | Add an AssemblyAI section: per-minute-of-input-audio strategy reading `step.provider_payload["audio_duration"]`, plus the upstream pricing URL. (New recipe shape — no existing helper.) |
+| `CHANGELOG` | Add an entry under the current wave (per RELEASING/CONTRIBUTING). |
+
+## Verification
+
+1. `cd libs/connectors/assemblyai && pytest -v` — compliance harness (16 checks) + provider-specific tests pass.
+2. From repo root: **`make test`**, **`make lint`**, **`make typecheck`** all green (AGENTS.md invariant).
+3. Entry-point discovery: `python -c "from genblaze_core.providers import discover_providers; assert 'assemblyai' in {p.name for p in discover_providers()}"`.
+4. **Live smoke (optional, needs `ASSEMBLYAI_API_KEY`):** a tiny Pipeline step transcribing a
+   public audio URL; assert `result.run.steps[0].assets[0].metadata["text"]` non-empty,
+   `word_timings` populated, and `result.manifest.verify()` is `True`. Consider adding it as
+   `examples/transcribe.py`.
+
+## Execution order
+
+1. Create the package files under `libs/connectors/assemblyai/`.
+2. Update `Makefile` / `libs/meta` / docs (`README.md`, `ARCHITECTURE.md`, `AGENTS.md`,
+   `docs/reference/pricing-recipes.md`, `CHANGELOG`) in the same PR as the code (AGENTS.md invariant).
+3. Run the verification gates above (`make test`, `make lint`, `make typecheck`).
+4. Open the PR; move this plan to `docs/exec-plans/completed/` once merged.
+
+> Working in a background session: implementation happens in a git worktree, then merges
+> back to `main` with the worktree removed, so the end state matches an in-place edit.

--- a/docs/features/provider-system.md
+++ b/docs/features/provider-system.md
@@ -110,7 +110,7 @@ Connectors as of 0.3.0:
 
 - `NATIVE`: OpenAI (TTS / DALL-E / Sora), ElevenLabs TTS, Replicate, NVIDIA chat
 - `PARTIAL`: NVIDIA generative endpoints (audio / video / image), GMICloud, Google (Veo / Imagen)
-- `NONE`: Decart, Runway, Luma, Stability-Audio, ElevenLabs SFX, LMNT, Hume
+- `NONE`: Decart, Runway, Luma, Stability-Audio, ElevenLabs SFX, LMNT, Hume, AssemblyAI
 
 ## Error Deduplication
 Each connector family shares a single error mapper module:

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -724,6 +724,64 @@ extend the rate dictionary and re-register as new models ship.
 
 ---
 
+## AssemblyAI
+
+**Source:** user-registered (the SDK ships no prices for AssemblyAI).
+**Snapshot date:** TODO — fill in when you read the rate.
+**Verify at:** [assemblyai.com/pricing](https://www.assemblyai.com/pricing).
+
+AssemblyAI bills per minute of **input** audio, with the rate depending on
+the speech model (e.g. `universal-3-pro` vs `universal-2`). This is a new
+recipe shape — there is no packaged helper. `AssemblyAIProvider` captures the
+transcribed file's duration in seconds in
+`step.provider_payload["audio_duration"]` during `fetch_output()`, so a
+`per_response_metric` strategy can read it directly. Replace each `RATE` below
+with the current per-minute USD rate for that model from AssemblyAI's pricing
+page (left undefined on purpose, so the example fails fast instead of shipping a
+fabricated cost).
+
+```python
+from genblaze_core.providers import per_response_metric
+from genblaze_assemblyai import AssemblyAIProvider
+
+# USD per minute of input audio, per speech model. Verify with AssemblyAI.
+ASSEMBLYAI_RATE_PER_MINUTE: dict[str, float] = {
+    "universal-3-pro": RATE,   # TODO: confirm at assemblyai.com/pricing
+    "universal-2": RATE,       # TODO: confirm
+}
+
+
+def per_minute_of_input_audio(rate: float):
+    """Per-minute pricing on the *input* audio duration (seconds → minutes)."""
+
+    def _strategy(ctx):
+        payload = ctx.provider_payload or {}
+        seconds = payload.get("audio_duration")
+        if seconds is None:
+            return None
+        try:
+            return (float(seconds) / 60.0) * rate
+        except (TypeError, ValueError):
+            return None
+
+    return _strategy
+
+
+provider = AssemblyAIProvider(api_key="...")
+
+# Speech-model slugs match the connector's family, so register against the
+# concrete slug(s) you use — register_pricing layers pricing onto the
+# family-resolved spec.
+for slug, rate in ASSEMBLYAI_RATE_PER_MINUTE.items():
+    provider.models.register_pricing(slug, per_response_metric(per_minute_of_input_audio(rate)))
+```
+
+Future `universal-*` slugs match the connector's `assemblyai-speech` family
+automatically but won't have rates here — extend `ASSEMBLYAI_RATE_PER_MINUTE`
+and re-register as you adopt them.
+
+---
+
 <!--
   Subsequent connectors append their sections here as they migrate:
     - nvidia (chat / generative)

--- a/examples/transcribe.py
+++ b/examples/transcribe.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Example: AssemblyAI speech-to-text transcription pipeline.
+
+AssemblyAI is the inverse of every other genblaze connector: it *consumes* an
+audio URL and *produces* a hash-verified TEXT transcript (plus word-level
+timings). This example transcribes AssemblyAI's own public quickstart sample
+(the "Canadian wildfires" clip) with the ``universal-3-pro`` speech model and
+verifies the manifest end-to-end.
+
+This is a live smoke test against the real API — it makes a real transcription
+call and bills your account per minute of input audio.
+
+Models (sent on the SDK's plural ``speech_models`` field — the legacy
+singular ``speech_model`` field and the ``best`` / ``nano`` aliases were
+retired by the live API and now error):
+    - universal-3-pro: Highest accuracy (default here).
+    - universal-2:     Prior-generation universal model.
+
+Usage:
+    export ASSEMBLYAI_API_KEY=...
+    python examples/transcribe.py
+"""
+
+from __future__ import annotations
+
+from genblaze_core import Modality, Pipeline
+
+# AssemblyAI's public quickstart sample (302-redirects to a ~3-min mp3 hosted
+# on the AssemblyAI-Community GitHub). https-only, so it passes the provider's
+# SSRF validator. Swap in any public https:// audio URL to transcribe your own.
+AUDIO_URL = "https://assembly.ai/wildfires.mp3"
+
+
+def main() -> None:
+    from genblaze_assemblyai import AssemblyAIProvider
+
+    # api_key falls back to ASSEMBLYAI_API_KEY in the environment.
+    provider = AssemblyAIProvider()
+
+    run, manifest = (
+        Pipeline("assemblyai-transcribe-demo", project_id="examples")
+        .step(
+            provider,
+            model="universal-3-pro",
+            prompt=AUDIO_URL,  # resolved as the audio URL to transcribe
+            modality=Modality.TEXT,
+        )
+        # Transcription of a ~3-min clip completes well inside this; give it
+        # generous headroom since it's a real network job.
+        .run(timeout=300, max_retries=1, raise_on_failure=True)
+    )
+
+    step = run.steps[0]
+
+    print(f"Run ID:    {run.run_id}")
+    print(f"Status:    {step.status}")
+    print(f"Hash:      {manifest.canonical_hash}")
+    print(f"Verified:  {manifest.verify()}")
+
+    asset = step.assets[0]
+    text = asset.metadata["text"]
+    word_timings = asset.audio.word_timings if asset.audio else []
+    audio_duration = step.provider_payload.get("audio_duration")
+
+    # --- assertions (the actual smoke test) ---
+    assert text, "transcript text is empty"
+    assert word_timings, "word_timings is empty"
+    assert audio_duration is not None, "audio_duration missing from provider_payload"
+    assert manifest.verify() is True, "manifest failed verification"
+    # NOTE: deliberately no cost_usd assertion — this provider ships no pricing
+    # (per-minute-of-input-audio is user-registered; see pricing-recipes.md).
+
+    print()
+    print(f"Asset:           {asset.url}")
+    print(f"Audio duration:  {audio_duration}s")
+    print(f"Word count:      {len(word_timings)}")
+    print()
+    print("Transcript:")
+    print(f"  {text}")
+    print()
+    print("First word timings (word: start–end s, confidence):")
+    for w in word_timings[:8]:
+        conf = f"{w.confidence:.2f}" if w.confidence is not None else "n/a"
+        print(f"  {w.word!r}: {w.start:.2f}–{w.end:.2f}s  conf={conf}")
+
+    print()
+    print("✅ Smoke test passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/connectors/assemblyai/README.md
+++ b/libs/connectors/assemblyai/README.md
@@ -1,0 +1,91 @@
+<!-- last_verified: 2026-06-23 -->
+# genblaze-assemblyai
+
+[AssemblyAI](https://www.assemblyai.com/) **speech-to-text / transcription**
+provider adapter for [genblaze](https://github.com/backblaze-labs/genblaze).
+
+This connector is the inverse of every other genblaze adapter: instead of
+*generating* media it *consumes* an audio URL and *produces* a text
+transcript with word-level timings. The transcript lands as a hash-verified
+**TEXT asset** with a provenance manifest, so it composes into pipelines
+(generate audio → transcribe, caption a generated video) and persists to
+Backblaze B2 / S3 like any other genblaze step.
+
+## Install
+
+```bash
+pip install genblaze-assemblyai      # or: pip install "genblaze[assemblyai]"
+export ASSEMBLYAI_API_KEY="..."      # from https://www.assemblyai.com/app/api-keys
+```
+
+## Usage
+
+```python
+from genblaze_core import Modality, Pipeline
+from genblaze_assemblyai import AssemblyAIProvider
+
+run, manifest = (
+    Pipeline("transcribe")
+    .step(
+        AssemblyAIProvider(),
+        model="universal-3-pro",                       # speech_models: universal-3-pro | universal-2
+        prompt="https://example.com/podcast-episode.mp3",  # or params={"audio_url": ...}, or a chained audio input
+        modality=Modality.TEXT,
+        speaker_labels=True,                           # any TranscriptionConfig flag passes through
+    )
+    .run()
+)
+
+asset = run.steps[0].assets[0]
+print(asset.metadata["text"])          # the transcript
+print(asset.audio.word_timings[:3])    # [WordTiming(word=..., start=..., end=...), ...] (seconds)
+print(manifest.canonical_hash)
+```
+
+The audio URL is resolved from (in priority order) `step.inputs[0].url` →
+`step.params["audio_url"]` → `step.prompt`, then SSRF-validated (https:// or
+file:// only) before submission. `step.model` selects the AssemblyAI speech
+model (sent on the SDK's plural `speech_models` field — the live API retired
+the singular `speech_model` field and the `best` / `nano` aliases; current
+values are `universal-3-pro` / `universal-2`); every other
+`TranscriptionConfig` flag (`speaker_labels`, `language_code`,
+audio-intelligence options, …) passes through `step.params`.
+
+## Pricing
+
+The SDK ships no hardcoded prices. AssemblyAI bills per minute of *input*
+audio; the connector captures the input duration in
+`step.provider_payload["audio_duration"]` (seconds) during `fetch_output`.
+Register a recipe at runtime — see
+[`docs/reference/pricing-recipes.md`](https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md)
+("AssemblyAI" section):
+
+```python
+from genblaze_core.providers import per_response_metric
+
+RATE_PER_MINUTE = RATE  # replace RATE with the per-minute USD rate from assemblyai.com/pricing
+
+
+def per_minute(ctx):
+    seconds = ctx.provider_payload.get("audio_duration")
+    return (seconds / 60.0) * RATE_PER_MINUTE if seconds is not None else None
+
+
+provider = AssemblyAIProvider(api_key="...")
+# Speech-model slugs match the connector's family, so register against the
+# concrete slug(s) you use (register_pricing layers onto the family spec).
+for slug in ("universal-3-pro", "universal-2"):
+    provider.models.register_pricing(slug, per_response_metric(per_minute))
+```
+
+## Notes
+
+- **Out of scope for v1:** real-time/streaming transcription, LeMUR
+  (LLM-over-transcript), and first-class SRT/VTT subtitle outputs. Audio-
+  intelligence flags pass through to the API and land in `metadata`.
+
+## Docs
+
+- [AssemblyAI docs](https://www.assemblyai.com/docs)
+- [Transcript API reference](https://www.assemblyai.com/docs/api-reference/transcripts/get)
+- genblaze [new-provider guide](https://github.com/backblaze-labs/genblaze/blob/main/docs/guides/new-provider.md)

--- a/libs/connectors/assemblyai/genblaze_assemblyai/__init__.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/__init__.py
@@ -1,0 +1,7 @@
+"""AssemblyAI (speech-to-text / transcription) provider adapter for genblaze."""
+
+from genblaze_assemblyai.provider import AssemblyAIProvider
+
+from ._version import __version__  # noqa: F401 — re-exported
+
+__all__ = ["AssemblyAIProvider"]

--- a/libs/connectors/assemblyai/genblaze_assemblyai/_errors.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/_errors.py
@@ -1,0 +1,29 @@
+"""Shared AssemblyAI error mapping — used by provider.py.
+
+The AssemblyAI Python SDK raises exceptions that may carry an HTTP
+``status_code`` attribute (e.g. ``aai.types.TranscriptError`` and the
+underlying transport errors). We classify off the status code when present,
+then fall back to the shared string-based classifier. The same function also
+classifies the plain ``transcript.error`` string returned when a transcript
+finishes with ``status == "error"``.
+"""
+
+from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_core.providers.base import classify_api_error
+
+
+def map_assemblyai_error(exc: Exception | str) -> ProviderErrorCode:
+    """Map an AssemblyAI API exception (or error string) to a ProviderErrorCode."""
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status == 429:
+            return ProviderErrorCode.RATE_LIMIT
+        if status in (401, 403):
+            return ProviderErrorCode.AUTH_FAILURE
+        if status in (400, 422):
+            return ProviderErrorCode.INVALID_INPUT
+        if status >= 500:
+            return ProviderErrorCode.SERVER_ERROR
+    # Fall back to shared string-based classifier (also handles the plain
+    # ``transcript.error`` string from a failed transcript).
+    return classify_api_error(exc)

--- a/libs/connectors/assemblyai/genblaze_assemblyai/_version.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/_version.py
@@ -1,0 +1,14 @@
+"""``genblaze-assemblyai`` package version — single source of truth via importlib.metadata.
+
+Reading from ``importlib.metadata`` keeps the constant equal to whatever
+wheel is installed; no manual edits per release.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__: str = version("genblaze-assemblyai")
+except PackageNotFoundError:  # pragma: no cover — editable dev installs
+    __version__ = "0.0.0+unknown"

--- a/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
@@ -1,0 +1,384 @@
+"""AssemblyAIProvider — adapter for the AssemblyAI speech-to-text API.
+
+AssemblyAI is the inverse of every other genblaze connector: it *consumes* an
+audio URL and *produces* a text transcript (plus word-level timing, speaker
+labels, and optional audio-intelligence). It fits genblaze's primitives with
+zero core changes — the transcript lands as a **TEXT ``Asset``** following the
+``NvidiaChatProvider`` precedent (``url="text:{sha256}"``,
+``media_type="text/plain"``, payload in ``metadata["text"]``, sha256 over the
+text bytes), and word timings populate ``AudioMetadata.word_timings``.
+
+**API style:** genuinely async — the SDK's ``Transcriber().submit()`` is
+non-blocking (returns a queued ``Transcript`` immediately) and
+``aai.Transcript.get_by_id(id)`` polls/fetches by id. So this is a
+``BaseProvider`` (submit / poll / fetch_output), which gets adaptive polling,
+progress events, ``resume()`` crash-recovery, and poll caching for free.
+
+**Catalog architecture (genblaze-core 0.3.0):** AssemblyAI exposes no live
+``GET /models`` catalog; the model set is small and stable. This connector
+therefore declares ``DiscoverySupport.NONE`` and ships a single pattern-keyed
+``ModelFamily`` for the current ``universal-*`` speech models
+(``universal-3-pro`` / ``universal-2``) plus a permissive TEXT fallback so any
+slug passes through. ``step.model`` is the AssemblyAI speech model and is sent
+on the SDK's plural ``speech_models`` field — the live API has deprecated the
+singular ``speech_model`` field (and the legacy ``best`` / ``nano`` aliases).
+
+**Pricing:** AssemblyAI bills per minute of *input* audio. The SDK ships zero
+hardcoded prices — register a recipe at runtime that reads
+``step.provider_payload["audio_duration"]`` (seconds, captured during
+``fetch_output``); see ``docs/reference/pricing-recipes.md`` ("AssemblyAI").
+
+Docs: https://www.assemblyai.com/docs
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from typing import Any
+
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.asset import Asset, AudioMetadata, WordTiming
+from genblaze_core.models.enums import Modality, ProviderErrorCode
+from genblaze_core.models.step import Step
+from genblaze_core.providers import (
+    BaseProvider,
+    DiscoverySupport,
+    ModelFamily,
+    ModelRegistry,
+    ModelSpec,
+    ProviderCapabilities,
+    RetryPolicy,
+    validate_chain_input_url,
+)
+from genblaze_core.providers.retry import retry_after_from_response
+from genblaze_core.runnable.config import RunnableConfig
+
+from ._errors import map_assemblyai_error
+
+logger = logging.getLogger("genblaze.assemblyai")
+
+# Terminal transcript statuses. AssemblyAI's lifecycle is
+# queued → processing → completed | error.
+_TERMINAL_STATUSES = frozenset({"completed", "error"})
+
+# The AssemblyAI speech-model family covers the current ``universal-*`` line
+# (``universal-3-pro``, ``universal-2``) — the only values the live API accepts
+# on the ``speech_models`` field as of 2026-06. The legacy ``speech_model``
+# tier aliases (``best`` / ``nano``) and the bare ``universal`` slug are now
+# rejected server-side; they fall through to the permissive fallback (which
+# still lets the request through — failures surface at submit, per NONE
+# discovery). Output is always a TEXT transcript, so the spec modality is TEXT.
+# spec_template.pricing MUST be None (pricing is user-registered).
+_ASSEMBLYAI_SPEECH_FAMILY = ModelFamily(
+    name="assemblyai-speech",
+    pattern=re.compile(r"^universal"),
+    spec_template=ModelSpec(model_id="*", modality=Modality.TEXT),
+    description="AssemblyAI speech models — universal-3-pro / universal-2.",
+    example_slugs=("universal-3-pro", "universal-2"),
+)
+
+_ASSEMBLYAI_FALLBACK = ModelSpec(model_id="*", modality=Modality.TEXT)
+
+
+def _ms_to_s(value: Any) -> float | None:
+    """Convert an AssemblyAI millisecond timestamp to seconds, or None."""
+    if value is None:
+        return None
+    try:
+        return float(value) / 1000.0
+    except (TypeError, ValueError):
+        return None
+
+
+def _status_str(transcript: Any) -> str:
+    """Return the transcript status as a lowercase string.
+
+    ``transcript.status`` is an ``aai.TranscriptStatus`` (a ``str`` enum) on
+    the real SDK; tests may use a plain string. Normalize both to the bare
+    value (``"completed"`` / ``"error"`` / …).
+    """
+    status = getattr(transcript, "status", None)
+    value = getattr(status, "value", None)
+    return str(value if value is not None else status).lower()
+
+
+def _serialize_utterances(utterances: Any) -> list[dict[str, Any]]:
+    """Flatten SDK utterance objects to canonical-JSON-safe dicts.
+
+    Times are converted ms → seconds to match ``word_timings``. Kept minimal
+    (speaker / text / start / end / confidence) — utterances are pass-through
+    context in ``metadata``, not a first-class shape in v1.
+    """
+    out: list[dict[str, Any]] = []
+    for u in utterances or []:
+        out.append(
+            {
+                "speaker": getattr(u, "speaker", None),
+                "text": getattr(u, "text", None),
+                "start": _ms_to_s(getattr(u, "start", None)),
+                "end": _ms_to_s(getattr(u, "end", None)),
+                "confidence": getattr(u, "confidence", None),
+            }
+        )
+    return out
+
+
+class AssemblyAIProvider(BaseProvider):
+    """Provider adapter for AssemblyAI speech-to-text transcription.
+
+    Transcribes an audio URL into a hash-verified TEXT asset with word-level
+    timings. The audio URL is resolved from (in priority order)
+    ``step.inputs[0].url`` → ``step.params["audio_url"]`` → ``step.prompt`` and
+    SSRF-validated via ``validate_chain_input_url`` before submission, so the
+    same provider works both standalone and chained into a pipeline (e.g.
+    generate audio → transcribe).
+
+    ``step.model`` is the AssemblyAI speech model (``universal-3-pro`` /
+    ``universal-2``) and is sent on the SDK's plural ``speech_models`` field;
+    any other ``TranscriptionConfig`` kwarg (``speaker_labels``,
+    ``language_code``, audio-intelligence flags, …) passes through
+    ``step.params``.
+
+    Args:
+        api_key: AssemblyAI API key. Falls back to ``ASSEMBLYAI_API_KEY``.
+        poll_interval: Base seconds between polls (the base class applies
+            adaptive backoff on top).
+        models: Optional custom ``ModelRegistry`` — overrides the class default.
+        retry_policy: Optional retry policy override.
+        probe_cache_ttl: Per-instance probe-cache TTL (no-op for NONE discovery
+            but accepted for API uniformity with other providers).
+        probe_cache_max_entries: Per-instance probe-cache size cap.
+    """
+
+    name = "assemblyai"
+    discovery_support = DiscoverySupport.NONE
+    """AssemblyAI exposes no ``GET /models`` catalog — the model set is small
+    and stable. Family-matched ``universal-*`` slugs (``universal-3-pro`` /
+    ``universal-2``) preflight as ``OK_PROVISIONAL``; everything else resolves
+    through the permissive fallback as ``UNKNOWN_PERMISSIVE``."""
+
+    @classmethod
+    def create_registry(cls) -> ModelRegistry:
+        return ModelRegistry(
+            provider_families=(_ASSEMBLYAI_SPEECH_FAMILY,),
+            fallback=_ASSEMBLYAI_FALLBACK,
+        )
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        """AssemblyAI: audio in, TEXT transcript out."""
+        return ProviderCapabilities(
+            supported_modalities=[Modality.TEXT],
+            supported_inputs=["audio"],
+            accepts_chain_input=True,
+            models=self._models.known(),
+            output_formats=["text/plain"],
+        )
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        poll_interval: float = 3.0,
+        models: ModelRegistry | None = None,
+        retry_policy: RetryPolicy | None = None,
+        probe_cache_ttl: float | None = None,
+        probe_cache_max_entries: int | None = None,
+    ):
+        super().__init__(
+            models=models,
+            retry_policy=retry_policy,
+            probe_cache_ttl=probe_cache_ttl,
+            probe_cache_max_entries=probe_cache_max_entries,
+        )
+        self.poll_interval = poll_interval
+        self._api_key = api_key
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        """Return the ``assemblyai`` module, configured with the API key.
+
+        AssemblyAI's SDK is module-scoped: transcription goes through
+        ``aai.Transcriber()`` / ``aai.Transcript.get_by_id()`` with the key set
+        on ``aai.settings.api_key``. So the "client" is the module itself. The
+        key is resolved here (the SDK does not auto-read ``ASSEMBLYAI_API_KEY``)
+        and a missing key fails fast with ``AUTH_FAILURE`` rather than a
+        deferred opaque 401.
+        """
+        if self._client is None:
+            key = self._api_key or os.getenv("ASSEMBLYAI_API_KEY")
+            if not key:
+                raise ProviderError(
+                    "No AssemblyAI API key found. Pass api_key=... or set ASSEMBLYAI_API_KEY.",
+                    error_code=ProviderErrorCode.AUTH_FAILURE,
+                )
+            try:
+                import assemblyai as aai
+            except ImportError as exc:
+                raise ProviderError(
+                    "assemblyai package not installed. Run: pip install assemblyai"
+                ) from exc
+            aai.settings.api_key = key
+            self._client = aai
+        return self._client
+
+    def normalize_params(
+        self, params: dict[str, Any], modality: Modality | None = None
+    ) -> dict[str, Any]:
+        """Map standard names to AssemblyAI's native ``TranscriptionConfig`` keys.
+
+        ``language`` → ``language_code`` (AssemblyAI native). Everything else
+        passes through untouched. Idempotent via the ``if x in p and native
+        not in p`` guard.
+        """
+        p = dict(params)
+        if "language" in p and "language_code" not in p:
+            p["language_code"] = p.pop("language")
+        return p
+
+    def _resolve_audio_url(self, step: Step) -> str:
+        """Resolve + SSRF-validate the audio URL to transcribe.
+
+        Priority: ``step.inputs[0].url`` (chained pipeline output) →
+        ``step.params["audio_url"]`` → ``step.prompt`` (standalone use). The
+        chosen URL is validated with ``validate_chain_input_url`` (https:// or
+        file:// only) before it leaves the process.
+        """
+        if step.inputs and step.inputs[0].url:
+            url = step.inputs[0].url
+        elif step.params.get("audio_url"):
+            url = str(step.params["audio_url"])
+        elif step.prompt:
+            url = step.prompt
+        else:
+            raise ProviderError(
+                "AssemblyAI requires an audio URL via step.inputs[0], "
+                "step.params['audio_url'], or step.prompt.",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        validate_chain_input_url(url)
+        return url
+
+    def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+        """Submit a transcription job (non-blocking) and return its id."""
+        aai = self._get_client()
+        audio_url = self._resolve_audio_url(step)
+        try:
+            cfg_kwargs = self.normalize_params(dict(step.params), step.modality)
+            # audio_url is the submit() argument, not a TranscriptionConfig field.
+            cfg_kwargs.pop("audio_url", None)
+            # step.model is the speech model. The live API has deprecated the
+            # singular ``speech_model`` field (and the legacy best/nano tier
+            # aliases); the slug is sent on the plural ``speech_models`` list,
+            # which currently accepts ``universal-3-pro`` / ``universal-2``.
+            if step.model:
+                cfg_kwargs["speech_models"] = [step.model]
+            transcription_config = aai.TranscriptionConfig(**cfg_kwargs)
+            transcriber = aai.Transcriber()
+            transcript = transcriber.submit(audio_url, config=transcription_config)
+            return transcript.id
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"AssemblyAI submit failed: {exc}",
+                error_code=map_assemblyai_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc
+
+    def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
+        """Return True once the transcript reaches a terminal status."""
+        aai = self._get_client()
+        try:
+            transcript = aai.Transcript.get_by_id(prediction_id)
+            if _status_str(transcript) in _TERMINAL_STATUSES:
+                self._cache_poll_result(prediction_id, transcript)
+                return True
+            return False
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"AssemblyAI poll failed: {exc}",
+                error_code=map_assemblyai_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc
+
+    def fetch_output(self, prediction_id: Any, step: Step) -> Step:
+        """Build the TEXT transcript asset from the completed transcript."""
+        aai = self._get_client()
+        try:
+            transcript = self._get_cached_poll_result(prediction_id)
+            if transcript is None:
+                transcript = aai.Transcript.get_by_id(prediction_id)
+
+            status = _status_str(transcript)
+            if status == "error":
+                err = getattr(transcript, "error", None) or "AssemblyAI transcription failed"
+                raise ProviderError(str(err), error_code=map_assemblyai_error(err))
+            if status != "completed":
+                # fetch_output is only reached after poll() confirms a terminal
+                # status, so this guards the off-happy-path / resume case rather
+                # than silently emitting an empty transcript for a running job.
+                raise ProviderError(
+                    f"AssemblyAI transcript {prediction_id} is not complete (status={status!r}).",
+                    error_code=ProviderErrorCode.SERVER_ERROR,
+                )
+
+            text = getattr(transcript, "text", None) or ""
+            text_bytes = text.encode("utf-8")
+            digest = hashlib.sha256(text_bytes).hexdigest()
+
+            asset = Asset(
+                url=f"text:{digest}",  # synthetic TEXT asset (NvidiaChatProvider precedent)
+                media_type="text/plain",
+                sha256=digest,
+                size_bytes=len(text_bytes),
+            )
+
+            words = getattr(transcript, "words", None)
+            if words:
+                # AssemblyAI word start/end are in MILLISECONDS; WordTiming
+                # expects seconds — divide by 1000.
+                timings = [
+                    WordTiming(
+                        word=getattr(w, "text", "") or "",
+                        start=_ms_to_s(getattr(w, "start", None)) or 0.0,
+                        end=_ms_to_s(getattr(w, "end", None)) or 0.0,
+                        confidence=getattr(w, "confidence", None),
+                    )
+                    for w in words
+                ]
+                asset.audio = AudioMetadata(word_timings=timings)
+
+            asset.metadata["text"] = text
+            language = getattr(transcript, "language_code", None)
+            if language is not None:
+                asset.metadata["language"] = language
+            confidence = getattr(transcript, "confidence", None)
+            if confidence is not None:
+                asset.metadata["confidence"] = confidence
+            utterances = getattr(transcript, "utterances", None)
+            if utterances:
+                asset.metadata["utterances"] = _serialize_utterances(utterances)
+
+            step.assets = [asset]
+
+            # Seconds of input audio; the pricing recipe reads this.
+            audio_duration = getattr(transcript, "audio_duration", None)
+            if audio_duration is not None:
+                step.provider_payload["audio_duration"] = audio_duration
+                asset.metadata["audio_duration"] = audio_duration
+
+            self._apply_registry_pricing(step)
+            return step
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"AssemblyAI fetch_output failed: {exc}",
+                error_code=map_assemblyai_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc

--- a/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
@@ -38,6 +38,8 @@ import logging
 import os
 import re
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, WordTiming
@@ -103,6 +105,26 @@ def _status_str(transcript: Any) -> str:
     status = getattr(transcript, "status", None)
     value = getattr(status, "value", None)
     return str(value if value is not None else status).lower()
+
+
+def _audio_ref_for_sdk(audio_url: str) -> str:
+    """Shape a resolved audio URL into the form ``Transcriber.submit()`` wants.
+
+    The AssemblyAI SDK treats any non-HTTP string as a *local file path* and
+    opens it with ``open(ref, "rb")``. A ``file://`` URI — the form chained
+    SyncProvider outputs take, percent-encoded via ``quote()`` — would be
+    opened literally as the filename ``file:///tmp/a.wav`` and fail. Convert
+    validated ``file://`` URIs to a real filesystem path (``url2pathname``
+    handles percent-decoding and platform path conversion); pass ``https://``
+    URLs through untouched so the SDK fetches them remotely.
+
+    Assumes the URL already passed ``validate_chain_input_url`` (so the scheme
+    is ``https`` or ``file`` and any ``file://`` netloc is empty/``localhost``).
+    """
+    parsed = urlparse(audio_url)
+    if parsed.scheme == "file":
+        return url2pathname(parsed.path)
+    return audio_url
 
 
 def _serialize_utterances(utterances: Any) -> list[dict[str, Any]]:
@@ -264,7 +286,10 @@ class AssemblyAIProvider(BaseProvider):
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
         """Submit a transcription job (non-blocking) and return its id."""
         aai = self._get_client()
-        audio_url = self._resolve_audio_url(step)
+        # Resolve + SSRF-validate, then shape for the SDK: a validated file://
+        # chain input must reach Transcriber.submit() as a local filesystem
+        # path, since the SDK open()s any non-HTTP string literally.
+        audio_ref = _audio_ref_for_sdk(self._resolve_audio_url(step))
         try:
             cfg_kwargs = self.normalize_params(dict(step.params), step.modality)
             # audio_url is the submit() argument, not a TranscriptionConfig field.
@@ -277,7 +302,7 @@ class AssemblyAIProvider(BaseProvider):
                 cfg_kwargs["speech_models"] = [step.model]
             transcription_config = aai.TranscriptionConfig(**cfg_kwargs)
             transcriber = aai.Transcriber()
-            transcript = transcriber.submit(audio_url, config=transcription_config)
+            transcript = transcriber.submit(audio_ref, config=transcription_config)
             return transcript.id
         except ProviderError:
             raise

--- a/libs/connectors/assemblyai/pyproject.toml
+++ b/libs/connectors/assemblyai/pyproject.toml
@@ -26,9 +26,13 @@ dependencies = [
     "genblaze-core>=0.3.0,<0.4",
     # The provider uses Transcriber().submit() (non-blocking) and
     # aai.Transcript.get_by_id(id) for polling; both have been stable across
-    # the 0.x line. Floored at 0.40 and bounded below 1.0 so a future major
+    # the 0.x line. The floor is 0.45, not 0.40: submit() always sends the
+    # speech model on TranscriptionConfig's plural ``speech_models`` field,
+    # which the SDK only added in 0.45.0 — 0.40.0–0.44.3 raise
+    # ``TypeError: ... unexpected keyword argument 'speech_models'`` before the
+    # request ever leaves the process. Bounded below 1.0 so a future major
     # can't silently reshape these call sites.
-    "assemblyai>=0.40,<1",
+    "assemblyai>=0.45,<1",
 ]
 
 [project.urls]

--- a/libs/connectors/assemblyai/pyproject.toml
+++ b/libs/connectors/assemblyai/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "genblaze-assemblyai"
+version = "0.3.0"
+description = "AssemblyAI (speech-to-text / transcription) provider adapter for genblaze"
+authors = [{name = "Eduardo Pavez", email = "epavez@backblaze.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia",
+    "Topic :: Software Development :: Libraries",
+]
+keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "assemblyai", "speech-to-text", "transcription", "audio"]
+
+dependencies = [
+    "genblaze-core>=0.3.0,<0.4",
+    # The provider uses Transcriber().submit() (non-blocking) and
+    # aai.Transcript.get_by_id(id) for polling; both have been stable across
+    # the 0.x line. Floored at 0.40 and bounded below 1.0 so a future major
+    # can't silently reshape these call sites.
+    "assemblyai>=0.40,<1",
+]
+
+[project.urls]
+Homepage = "https://github.com/backblaze-labs/genblaze"
+Documentation = "https://github.com/backblaze-labs/genblaze"
+Repository = "https://github.com/backblaze-labs/genblaze"
+Issues = "https://github.com/backblaze-labs/genblaze/issues"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.entry-points."genblaze.providers"]
+assemblyai = "genblaze_assemblyai:AssemblyAIProvider"
+
+[tool.hatch.build.targets.wheel]
+packages = ["genblaze_assemblyai"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.deptry]
+# Treat the `dev` extra as dev-only tooling so deptry does not flag pytest
+# (and other test-only deps) as unused declared deps (DEP002).
+optional_dependencies_dev_groups = ["dev"]

--- a/libs/connectors/assemblyai/tests/test_assemblyai.py
+++ b/libs/connectors/assemblyai/tests/test_assemblyai.py
@@ -149,6 +149,44 @@ def test_submit_strips_audio_url_from_config():
     assert cfg.speaker_labels is True
 
 
+def test_submit_converts_file_uri_to_local_path():
+    # A validated file:// chain input (e.g. a generate-audio step's output)
+    # must reach the SDK as a local filesystem PATH — the SDK open()s any
+    # non-HTTP string literally, so forwarding "file:///tmp/clip.wav" would try
+    # to open that exact filename and fail.
+    provider = _make_provider()
+    step = _make_step(prompt="file:///srv/audio/clip.wav")
+    provider.submit(step)
+    assert _FakeTranscriber.last_submit["audio_url"] == "/srv/audio/clip.wav"
+
+
+def test_submit_decodes_percent_encoded_file_uri():
+    # Sibling connectors emit file:// URLs via quote(), so a path with spaces
+    # arrives percent-encoded; it must be decoded back to the real path.
+    provider = _make_provider()
+    step = _make_step(prompt="file:///srv/audio/my%20clip.wav")
+    provider.submit(step)
+    assert _FakeTranscriber.last_submit["audio_url"] == "/srv/audio/my clip.wav"
+
+
+def test_submit_file_uri_localhost_netloc_to_local_path():
+    # RFC 8089 'file://localhost/...' (allowed by validate_chain_input_url)
+    # drops the localhost host and resolves to the bare path.
+    provider = _make_provider()
+    step = _make_step(prompt="file://localhost/srv/audio/clip.wav")
+    provider.submit(step)
+    assert _FakeTranscriber.last_submit["audio_url"] == "/srv/audio/clip.wav"
+
+
+def test_submit_https_url_passes_through_unchanged():
+    # https:// inputs are uploaded/fetched remotely by the SDK — not opened
+    # locally — so they must reach submit() byte-for-byte unchanged.
+    provider = _make_provider()
+    step = _make_step(prompt=AUDIO_URL)
+    provider.submit(step)
+    assert _FakeTranscriber.last_submit["audio_url"] == AUDIO_URL
+
+
 # --- full lifecycle -------------------------------------------------------
 
 

--- a/libs/connectors/assemblyai/tests/test_assemblyai.py
+++ b/libs/connectors/assemblyai/tests/test_assemblyai.py
@@ -1,0 +1,489 @@
+"""Tests for AssemblyAIProvider (mocked — no real API calls).
+
+The provider's "client" is the ``assemblyai`` module itself (transcription
+goes through ``aai.Transcriber()`` / ``aai.Transcript.get_by_id()`` with the
+key on ``aai.settings.api_key``). Tests inject a fake module via
+``provider._client`` — the lazy ``import assemblyai`` in ``_get_client`` is
+never reached on the happy path, so the real SDK is not required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.asset import Asset
+from genblaze_core.models.enums import Modality, ProviderErrorCode, StepStatus
+from genblaze_core.models.step import Step
+from genblaze_core.testing import ProviderComplianceTests
+
+AUDIO_URL = "https://example.com/audio.mp3"
+
+
+# --- fakes ----------------------------------------------------------------
+
+
+class _FakeWord:
+    def __init__(self, text: str, start: int, end: int, confidence: float = 0.99):
+        self.text = text
+        self.start = start  # milliseconds (AssemblyAI native)
+        self.end = end  # milliseconds
+        self.confidence = confidence
+
+
+def _fake_transcript(
+    *,
+    status: str = "completed",
+    text: str = "hello world",
+    with_words: bool = True,
+    audio_duration: float | None = 12.5,
+    error: str | None = None,
+    language_code: str | None = "en_us",
+    confidence: float | None = 0.97,
+    utterances=None,
+):
+    words = (
+        [_FakeWord("hello", 0, 500, 0.99), _FakeWord("world", 500, 1000, 0.98)]
+        if with_words
+        else None
+    )
+    return SimpleNamespace(
+        id="transcript-abc123",
+        status=status,
+        text=text,
+        words=words,
+        audio_duration=audio_duration,
+        language_code=language_code,
+        confidence=confidence,
+        utterances=utterances,
+        error=error,
+    )
+
+
+class _FakeTranscriber:
+    """Records the submitted (audio_url, config) and returns a queued id."""
+
+    last_submit: dict = {}
+
+    def submit(self, audio_url, config=None):
+        _FakeTranscriber.last_submit = {"audio_url": audio_url, "config": config}
+        return SimpleNamespace(id="transcript-abc123", status="queued")
+
+
+def _make_fake_aai(transcript=None):
+    """Build a fake ``assemblyai`` module exposing the surface the provider uses."""
+    transcript = transcript if transcript is not None else _fake_transcript()
+    fake = SimpleNamespace()
+    fake.settings = SimpleNamespace(api_key=None)
+    fake.Transcriber = _FakeTranscriber
+    fake.Transcript = SimpleNamespace(get_by_id=lambda tid: transcript)
+    fake.TranscriptionConfig = lambda **kwargs: SimpleNamespace(**kwargs)
+    return fake
+
+
+def _make_provider(transcript=None):
+    from genblaze_assemblyai import AssemblyAIProvider
+
+    provider = AssemblyAIProvider(api_key="test-key", poll_interval=0.0)
+    provider._client = _make_fake_aai(transcript)
+    return provider
+
+
+def _make_step(**kwargs) -> Step:
+    kwargs.setdefault("provider", "assemblyai")
+    kwargs.setdefault("model", "universal-3-pro")
+    kwargs.setdefault("modality", Modality.TEXT)
+    kwargs.setdefault("prompt", AUDIO_URL)
+    return Step(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Isolate the class-level model registry between tests.
+
+    ``BaseProvider`` caches one ``ModelRegistry`` per provider class
+    (``models_default()``), shared across instances. A test that calls
+    ``register_pricing`` would otherwise leak the user-registered spec — and
+    flip a family-matched slug's validation outcome to AUTHORITATIVE — into
+    later tests. Resetting the cache gives each test a fresh registry built
+    from the (unmutated) module-level family/fallback specs.
+    """
+    from genblaze_assemblyai import AssemblyAIProvider
+
+    AssemblyAIProvider._models_cache = None
+    yield
+    AssemblyAIProvider._models_cache = None
+
+
+# --- submit ---------------------------------------------------------------
+
+
+def test_submit_returns_id_and_forwards_audio_url():
+    provider = _make_provider()
+    step = _make_step()
+    pred_id = provider.submit(step)
+    assert pred_id == "transcript-abc123"
+    assert _FakeTranscriber.last_submit["audio_url"] == AUDIO_URL
+
+
+def test_submit_passes_speech_model_to_config():
+    provider = _make_provider()
+    step = _make_step(model="universal-3-pro")
+    provider.submit(step)
+    cfg = _FakeTranscriber.last_submit["config"]
+    # step.model is sent on the plural ``speech_models`` field — the live API
+    # deprecated the singular ``speech_model`` field and the best/nano aliases.
+    assert cfg.speech_models == ["universal-3-pro"]
+
+
+def test_submit_strips_audio_url_from_config():
+    provider = _make_provider()
+    step = _make_step(prompt=None, params={"audio_url": AUDIO_URL, "speaker_labels": True})
+    provider.submit(step)
+    cfg = _FakeTranscriber.last_submit["config"]
+    assert not hasattr(cfg, "audio_url")
+    assert cfg.speaker_labels is True
+
+
+# --- full lifecycle -------------------------------------------------------
+
+
+def test_full_lifecycle_via_invoke():
+    provider = _make_provider()
+    step = _make_step()
+    result = provider.invoke(step)
+    assert result.status == StepStatus.SUCCEEDED
+    assert len(result.assets) == 1
+    asset = result.assets[0]
+    assert asset.media_type == "text/plain"
+    assert asset.url.startswith("text:")
+    assert asset.metadata["text"] == "hello world"
+
+
+def test_text_asset_hash_matches_content():
+    provider = _make_provider()
+    step = _make_step()
+    pred_id = provider.submit(step)
+    result = provider.fetch_output(pred_id, step)
+    asset = result.assets[0]
+    expected = hashlib.sha256(b"hello world").hexdigest()
+    assert asset.sha256 == expected
+    assert asset.url == f"text:{expected}"
+    assert asset.size_bytes == len(b"hello world")
+
+
+# --- word timings (ms -> seconds) ----------------------------------------
+
+
+def test_word_timings_converted_ms_to_seconds():
+    provider = _make_provider()
+    step = _make_step()
+    pred_id = provider.submit(step)
+    result = provider.fetch_output(pred_id, step)
+    timings = result.assets[0].audio.word_timings
+    assert [t.word for t in timings] == ["hello", "world"]
+    # 0 ms -> 0.0 s, 500 ms -> 0.5 s, 1000 ms -> 1.0 s
+    assert timings[0].start == 0.0
+    assert timings[0].end == 0.5
+    assert timings[1].start == 0.5
+    assert timings[1].end == 1.0
+    assert timings[1].confidence == 0.98
+
+
+def test_no_words_leaves_audio_metadata_unset():
+    provider = _make_provider(_fake_transcript(with_words=False))
+    step = _make_step()
+    pred_id = provider.submit(step)
+    result = provider.fetch_output(pred_id, step)
+    assert result.assets[0].audio is None
+
+
+# --- audio_duration / pricing payload ------------------------------------
+
+
+def test_audio_duration_captured_in_provider_payload():
+    provider = _make_provider(_fake_transcript(audio_duration=42.0))
+    step = _make_step()
+    pred_id = provider.submit(step)
+    result = provider.fetch_output(pred_id, step)
+    assert result.provider_payload["audio_duration"] == 42.0
+    assert result.assets[0].metadata["audio_duration"] == 42.0
+
+
+def test_user_registered_per_minute_pricing():
+    from genblaze_core.providers import per_response_metric
+
+    provider = _make_provider(_fake_transcript(audio_duration=120.0))  # 2 minutes
+
+    def per_minute(ctx):
+        dur = ctx.provider_payload.get("audio_duration")
+        return (dur / 60.0) * 0.12 if dur is not None else None
+
+    # "universal-3-pro" matches the speech family, so register against the
+    # concrete slug (register_pricing falls through to the family spec and
+    # layers pricing).
+    provider.models.register_pricing("universal-3-pro", per_response_metric(per_minute))
+    step = _make_step(model="universal-3-pro")
+    result = provider.invoke(step)
+    assert result.cost_usd == pytest.approx(2 * 0.12)
+
+
+# --- audio-url resolution precedence -------------------------------------
+
+
+def test_audio_url_precedence_inputs_first():
+    provider = _make_provider()
+    step = _make_step(
+        prompt="https://prompt.example/p.mp3",
+        params={"audio_url": "https://params.example/p.mp3"},
+        inputs=[Asset(url="https://inputs.example/in.mp3", media_type="audio/mpeg")],
+    )
+    assert provider._resolve_audio_url(step) == "https://inputs.example/in.mp3"
+
+
+def test_audio_url_precedence_params_over_prompt():
+    provider = _make_provider()
+    step = _make_step(
+        prompt="https://prompt.example/p.mp3",
+        params={"audio_url": "https://params.example/p.mp3"},
+    )
+    assert provider._resolve_audio_url(step) == "https://params.example/p.mp3"
+
+
+def test_audio_url_falls_back_to_prompt():
+    provider = _make_provider()
+    step = _make_step(prompt="https://prompt.example/p.mp3")
+    assert provider._resolve_audio_url(step) == "https://prompt.example/p.mp3"
+
+
+def test_empty_input_url_falls_through_to_params():
+    # An input asset with an empty url must not short-circuit the precedence
+    # chain — it degrades to params["audio_url"] rather than failing the SSRF
+    # validator on "".
+    provider = _make_provider()
+    step = _make_step(
+        prompt=None,
+        params={"audio_url": "https://params.example/p.mp3"},
+        inputs=[Asset(url="", media_type="audio/mpeg")],
+    )
+    assert provider._resolve_audio_url(step) == "https://params.example/p.mp3"
+
+
+def test_missing_audio_url_raises_invalid_input():
+    provider = _make_provider()
+    step = _make_step(prompt=None)
+    with pytest.raises(ProviderError) as ei:
+        provider.submit(step)
+    assert ei.value.error_code == ProviderErrorCode.INVALID_INPUT
+
+
+def test_unsafe_audio_url_rejected():
+    provider = _make_provider()
+    step = _make_step(prompt="http://insecure.example/a.mp3")
+    with pytest.raises(ProviderError):
+        provider.submit(step)
+
+
+# --- error status ---------------------------------------------------------
+
+
+def test_error_status_raises_provider_error():
+    provider = _make_provider(_fake_transcript(status="error", error="bad audio file"))
+    step = _make_step()
+    pred_id = provider.submit(step)
+    with pytest.raises(ProviderError, match="bad audio file"):
+        provider.fetch_output(pred_id, step)
+
+
+def test_poll_false_until_terminal():
+    provider = _make_provider(_fake_transcript(status="processing"))
+    step = _make_step()
+    pred_id = provider.submit(step)
+    assert provider.poll(pred_id) is False
+
+
+def test_fetch_output_non_terminal_raises():
+    # Defensive guard: fetch_output on a still-running transcript must raise
+    # rather than emit a silently-empty (text:"") asset and report SUCCEEDED.
+    provider = _make_provider(_fake_transcript(status="processing", text=None))
+    step = _make_step()
+    pred_id = provider.submit(step)
+    with pytest.raises(ProviderError, match="not complete") as ei:
+        provider.fetch_output(pred_id, step)
+    assert ei.value.error_code == ProviderErrorCode.SERVER_ERROR
+
+
+def test_submit_api_error_wrapped_with_code():
+    from genblaze_assemblyai import AssemblyAIProvider
+
+    class _RaisingTranscriber:
+        def submit(self, audio_url, config=None):
+            err = RuntimeError("boom")
+            err.status_code = 429  # type: ignore[attr-defined]
+            raise err
+
+    fake = _make_fake_aai()
+    fake.Transcriber = _RaisingTranscriber
+    provider = AssemblyAIProvider(api_key="test-key", poll_interval=0.0)
+    provider._client = fake
+    step = _make_step()
+    with pytest.raises(ProviderError, match="AssemblyAI submit failed") as ei:
+        provider.submit(step)
+    assert ei.value.error_code == ProviderErrorCode.RATE_LIMIT
+
+
+# --- normalize_params -----------------------------------------------------
+
+
+def test_normalize_params_language_alias():
+    provider = _make_provider()
+    out = provider.normalize_params({"language": "es", "speaker_labels": True})
+    assert out["language_code"] == "es"
+    assert "language" not in out
+    assert out["speaker_labels"] is True
+
+
+def test_normalize_params_idempotent():
+    provider = _make_provider()
+    params = {"language": "es", "speaker_labels": True}
+    once = provider.normalize_params(params)
+    twice = provider.normalize_params(once)
+    assert once == twice
+
+
+def test_normalize_params_respects_existing_language_code():
+    provider = _make_provider()
+    out = provider.normalize_params({"language": "es", "language_code": "en_us"})
+    # Existing native key wins; the alias is left intact (idempotency guard).
+    assert out["language_code"] == "en_us"
+
+
+# --- credentials ----------------------------------------------------------
+
+
+def test_missing_api_key_raises_auth_failure(monkeypatch):
+    monkeypatch.delenv("ASSEMBLYAI_API_KEY", raising=False)
+    from genblaze_assemblyai import AssemblyAIProvider
+
+    provider = AssemblyAIProvider(api_key=None)  # no injected client
+    step = _make_step()
+    with pytest.raises(ProviderError, match="No AssemblyAI API key") as ei:
+        provider.submit(step)
+    assert ei.value.error_code == ProviderErrorCode.AUTH_FAILURE
+
+
+# --- error mapping --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (429, ProviderErrorCode.RATE_LIMIT),
+        (401, ProviderErrorCode.AUTH_FAILURE),
+        (403, ProviderErrorCode.AUTH_FAILURE),
+        (400, ProviderErrorCode.INVALID_INPUT),
+        (422, ProviderErrorCode.INVALID_INPUT),
+        (500, ProviderErrorCode.SERVER_ERROR),
+        (503, ProviderErrorCode.SERVER_ERROR),
+    ],
+)
+def test_map_assemblyai_error_status_codes(status, expected):
+    from genblaze_assemblyai._errors import map_assemblyai_error
+
+    exc = RuntimeError("err")
+    exc.status_code = status  # type: ignore[attr-defined]
+    assert map_assemblyai_error(exc) == expected
+
+
+def test_map_assemblyai_error_no_status_falls_back():
+    from genblaze_assemblyai._errors import map_assemblyai_error
+
+    assert map_assemblyai_error(RuntimeError("totally opaque")) == ProviderErrorCode.UNKNOWN
+
+
+def test_map_assemblyai_error_accepts_error_string():
+    from genblaze_assemblyai._errors import map_assemblyai_error
+
+    # transcript.error is a plain string; the classifier handles it.
+    assert map_assemblyai_error("rate limit exceeded") == ProviderErrorCode.RATE_LIMIT
+
+
+# --- catalog decoupling ---------------------------------------------------
+
+
+def test_declares_discovery_support_none():
+    from genblaze_assemblyai import AssemblyAIProvider
+    from genblaze_core.providers import DiscoverySupport
+
+    assert AssemblyAIProvider.discovery_support is DiscoverySupport.NONE
+
+
+@pytest.mark.parametrize("slug", ["universal", "universal-2", "universal-3-pro"])
+def test_speech_slug_matches_family(slug):
+    from genblaze_core.providers import ValidationOutcome
+
+    provider = _make_provider()
+    assert provider.validate_model(slug).outcome is ValidationOutcome.OK_PROVISIONAL
+
+
+def test_non_speech_slug_unknown_permissive():
+    from genblaze_core.providers import ValidationOutcome
+
+    provider = _make_provider()
+    assert provider.validate_model("some-other-model").outcome is (
+        ValidationOutcome.UNKNOWN_PERMISSIVE
+    )
+
+
+def test_family_and_fallback_carry_no_pricing():
+    provider = _make_provider()
+    assert provider._models.get("universal-3-pro").pricing is None  # family-matched
+    assert provider._models.get("anything-else").pricing is None  # permissive fallback
+
+
+def test_capabilities_text_only():
+    provider = _make_provider()
+    caps = provider.get_capabilities()
+    assert caps.supported_modalities == [Modality.TEXT]
+    assert caps.accepts_chain_input is True
+    assert caps.output_formats == ["text/plain"]
+
+
+# --- compliance harness ---------------------------------------------------
+
+
+class TestAssemblyAICompliance(ProviderComplianceTests):
+    """Verify AssemblyAIProvider satisfies the genblaze provider contract."""
+
+    # AssemblyAI ships zero hardcoded prices (per-minute-of-input-audio is
+    # user-registered; see docs/reference/pricing-recipes.md). cost_usd stays
+    # None unless the user registers a strategy — same posture as Hume.
+    expects_cost = False
+
+    @pytest.fixture(autouse=True)
+    def _patch_sdk(self):
+        # Safety net so the lazy ``import assemblyai`` resolves to the fake if
+        # ever reached; make_provider also injects ``_client`` directly.
+        with patch.dict(sys.modules, {"assemblyai": _make_fake_aai()}):
+            yield
+
+    def make_provider(self):
+        return _make_provider()
+
+    def make_step(self):
+        return _make_step()
+
+    def test_assets_have_valid_urls(self) -> None:
+        """Transcripts emit a synthetic ``text:{sha256}`` asset (the
+        NvidiaChatProvider TEXT-asset precedent), not an https:// / file://
+        URL — so we assert that scheme instead of the harness default."""
+        provider = self.make_provider()
+        step = self.make_step()
+        result = provider.invoke(step)
+        assert result.assets
+        for asset in result.assets:
+            assert asset.url.startswith("text:"), f"Expected text: asset URL, got {asset.url}"

--- a/libs/core/tests/unit/test_version_coherence.py
+++ b/libs/core/tests/unit/test_version_coherence.py
@@ -67,7 +67,7 @@ class TestVersionCoherence:
 class TestConnectorVersionCoherence:
     """Each genblaze-* connector's ``__version__`` must read from
     ``importlib.metadata`` rather than a hardcoded string. Plan 5
-    Phase 1B closed the version-drift class of bug across all 14
+    Phase 1B closed the version-drift class of bug across all 15
     connector packages."""
 
     @staticmethod
@@ -127,3 +127,6 @@ class TestConnectorVersionCoherence:
 
     def test_genblaze_langsmith(self):
         self._check("genblaze_langsmith", "genblaze-langsmith")
+
+    def test_genblaze_assemblyai(self):
+        self._check("genblaze_assemblyai", "genblaze-assemblyai")

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -47,6 +47,7 @@ elevenlabs = ["genblaze-elevenlabs>=0.3.0,<0.4"]
 stability-audio = ["genblaze-stability-audio>=0.3.0,<0.4"]
 lmnt = ["genblaze-lmnt>=0.3.0,<0.4"]
 hume = ["genblaze-hume>=0.3.0,<0.4"]
+assemblyai = ["genblaze-assemblyai>=0.3.0,<0.4"]
 langsmith = ["genblaze-langsmith>=0.2.1,<0.4"]
 nvidia = ["genblaze-nvidia>=0.3.0,<0.4"]
 
@@ -85,6 +86,7 @@ all = [
     "genblaze-stability-audio>=0.3.0,<0.4",
     "genblaze-lmnt>=0.3.0,<0.4",
     "genblaze-hume>=0.3.0,<0.4",
+    "genblaze-assemblyai>=0.3.0,<0.4",
     "genblaze-langsmith>=0.2.1,<0.4",
     "genblaze-nvidia>=0.3.0,<0.4",
 ]

--- a/tools/check_pin_parity.py
+++ b/tools/check_pin_parity.py
@@ -103,6 +103,7 @@ PACKAGES: list[str] = [
     "libs/connectors/gmicloud",
     "libs/connectors/langsmith",
     "libs/connectors/nvidia",
+    "libs/connectors/assemblyai",
     "cli",
     "libs/meta",
 ]

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -54,6 +54,7 @@ PACKAGES=(
     "libs/connectors/gmicloud"
     "libs/connectors/langsmith"
     "libs/connectors/nvidia"
+    "libs/connectors/assemblyai"
     "cli"
     "libs/meta"
 )
@@ -113,6 +114,7 @@ connectors = [
     "genblaze_gmicloud",
     "genblaze_langsmith",
     "genblaze_nvidia",
+    "genblaze_assemblyai",
     "genblaze",
 ]
 failures = []


### PR DESCRIPTION
## Summary

Adds `genblaze-assemblyai`, a provider adapter for **AssemblyAI** speech-to-text /
transcription. It's the **first connector that consumes audio and produces text** —
the inverse of every existing (media-generating) connector — and it fits genblaze's
primitives with **zero core or spec changes**.

An async `BaseProvider` (submit / poll / fetch_output) resolves an audio URL
(`step.inputs[0]` → `params["audio_url"]` → `prompt`, SSRF-validated via
`validate_chain_input_url`) and emits a hash-verified **TEXT asset**
(`text:{sha256}`, `media_type="text/plain"`, transcript in `metadata["text"]`) with
word-level timings on `AudioMetadata.word_timings` (converted ms → s). This makes a
transcribe step composable into pipelines (generate audio → transcribe, caption a
generated video) with full manifest provenance, landing in B2 like any other asset.

`step.model` is the AssemblyAI speech model, sent on the SDK's plural
`speech_models` field — the live API has **retired** the singular `speech_model`
field and the legacy `best` / `nano` aliases, so the family is keyed to the current
`universal-*` line (`universal-3-pro` / `universal-2`) with a permissive TEXT
fallback and `DiscoverySupport.NONE`. Per the 0.3.0 zero-hardcoded-pricing invariant
it ships **no** prices — users register a per-minute-of-input-audio strategy (reads
`step.provider_payload["audio_duration"]`) via the recipe in
`docs/reference/pricing-recipes.md`. Installable as `pip install genblaze-assemblyai`
or the `genblaze[assemblyai]` extra.

Out of scope for v1 (clean follow-ups): real-time/streaming transcription, LeMUR,
and SRT/VTT subtitle outputs.

> Validated against the **live** AssemblyAI API, not just mocks — `examples/transcribe.py`
> is a reproducible live smoke test against the real `speech_models` request surface.

## Changes

**New package — `libs/connectors/assemblyai/`**
- `genblaze_assemblyai/provider.py` — `AssemblyAIProvider(BaseProvider)`; `submit()` sends `speech_models=[step.model]`; `assemblyai-speech` family pattern `^universal`
- `genblaze_assemblyai/_errors.py` — `map_assemblyai_error` (status-code-first, like hume)
- `__init__.py`, `_version.py`, `py.typed`, `README.md`
- `pyproject.toml` — `genblaze.providers` entry point, `assemblyai>=0.40,<1` dep, deptry block
- `tests/test_assemblyai.py` — `TestAssemblyAICompliance` (`expects_cost = False`) + provider-specific tests (error mapping, ms→s conversion, audio-URL resolution precedence, error-status raising, `normalize_params` idempotency, `speech_models` forwarding, family matching)

**Example**
- `examples/transcribe.py` — live smoke test: transcribes AssemblyAI's public sample with `universal-3-pro`, asserts non-empty text, populated `word_timings`, `audio_duration` present, and `manifest.verify()` True

**Wiring & docs (same PR, per AGENTS.md invariant)**
- `Makefile` — install / install-dev / test targets for the new package
- `libs/meta/pyproject.toml` — `assemblyai` optional extra, included in `all`
- `README.md` — install list + `ASSEMBLYAI_API_KEY` in the API-key table
- `ARCHITECTURE.md` — provider-adapters list + External Services list
- `AGENTS.md` — package count 15 → 16, connector enumeration
- `docs/reference/pricing-recipes.md` — per-minute-of-input-audio recipe (`universal-3-pro` / `universal-2`) + upstream pricing URL
- `docs/features/provider-system.md` — provider note
- `libs/core/tests/unit/test_version_coherence.py` — include the new package
- `docs/exec-plans/active/assemblyai-provider.md` — execution plan

## Test plan

- [x] `make test` passes — exit 0, all packages green (core 165 passed, assemblyai 52 passed / 3 skipped)
- [x] `make lint` passes — exit 0 (ruff + deptry, no dependency issues)
- [x] `make typecheck` passes — exit 0 (mypy, no issues)
- [x] Entry-point discovery — `assemblyai` resolves via `discover_providers()`
- [x] Live API smoke (`examples/transcribe.py`, manual, needs `ASSEMBLYAI_API_KEY`) — validated against the real `speech_models` surface
- [x] Docs updated in the same PR as code changes

## Related

- Execution plan: `docs/exec-plans/active/assemblyai-provider.md` (in this PR)
- No existing issue — searched upstream issues for "assemblyai" / "transcription" / "speech-to-text", none found.
