### PR TITLE
fix(core): offload arun() preflight to thread to unblock event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `genblaze-core`: `Pipeline.arun()` no longer blocks the event loop during
+  model preflight. The network-bound phase (`_validate_models`, which uses a
+  `ThreadPoolExecutor` for provider discovery fetches) is now offloaded via
+  `asyncio.to_thread`, allowing concurrent coroutines to keep running during
+  the preflight window. Cheap capability checks (modality, chain-input) still
+  run synchronously. `Pipeline.run()` behavior is unchanged (#56).
 - `genblaze-core`: post-submit step-level retries now resume the existing
   upstream prediction instead of submitting a new one, including transient
   checkpoint failures after `submit()` returns by replaying idempotent

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -73,6 +73,15 @@ from real provider calls.
 - If `sink` provided, writes run data
 - Returns `PipelineResult`
 
+## Model preflight and async safety
+When `preflight=True` (default), both `run()` and `arun()` validate each step's
+model slug against provider catalogs before execution. In `arun()`, the
+network-bound validation phase runs via `asyncio.to_thread` so the event loop
+stays free during provider discovery fetches. Cheap capability checks (modality,
+chain-input compatibility) run inline. `run()` behavior is unchanged (sync
+`ThreadPoolExecutor` path). Disable preflight with `Pipeline(preflight=False)` or
+`.preflight(False)` for hot paths where the overhead matters.
+
 ## Edge Cases
 - Provider failure mid-pipeline → step gets `error_code`; with `fail_fast=True` pipeline stops, with `fail_fast=False` it continues
 - Empty pipeline (no steps) → raises `GenblazeError`

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -346,6 +346,27 @@ class Pipeline(Runnable[None, PipelineResult]):
             self._tracer = NoOpTracer()
         self._event_emitter: QueueEmitter | None = None
 
+    def __deepcopy__(self, memo: dict) -> Pipeline:
+        """Deep-copy support: ``threading.Lock`` is not copyable, so rebuild it.
+
+        ``copy.copy`` (shallow — used by ``batch_run``/``abatch_run``)
+        intentionally shares the lock and dedup set across clones so a batch
+        dedups WARNs as a unit. ``deepcopy`` semantics instead yield a fully
+        independent Pipeline: the clone gets its own fresh lock and a deep copy
+        of every other attribute. Without this, the lock added for #56 would
+        make ``copy.deepcopy(Pipeline(...))`` raise ``TypeError``.
+        """
+        import copy
+
+        clone = self.__class__.__new__(self.__class__)
+        memo[id(self)] = clone
+        for key, value in self.__dict__.items():
+            if key == "_warned_preflight_lock":
+                clone.__dict__[key] = threading.Lock()
+            else:
+                clone.__dict__[key] = copy.deepcopy(value, memo)
+        return clone
+
     @staticmethod
     def _reject_config_tenant(cfg: RunnableConfig | None) -> None:
         """Reject a per-call ``tenant_id`` in ``RunnableConfig``.
@@ -383,8 +404,8 @@ class Pipeline(Runnable[None, PipelineResult]):
         When enabled (the default), ``run()`` calls ``validate_model()`` on
         each step's provider before issuing any generation calls. ``NOT_FOUND``
         raises ``ProviderError(MODEL_ERROR)``; ``OK_PROVISIONAL`` and
-        ``UNKNOWN_PERMISSIVE`` emit a one-per-process WARN; ``OK_AUTHORITATIVE``
-        is silent.
+        ``UNKNOWN_PERMISSIVE`` emit a WARN once per (provider, slug) per
+        Pipeline instance; ``OK_AUTHORITATIVE`` is silent.
 
         Disable for hot paths where preflight overhead matters and the
         caller has already validated models out-of-band, or when running

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -346,26 +346,31 @@ class Pipeline(Runnable[None, PipelineResult]):
             self._tracer = NoOpTracer()
         self._event_emitter: QueueEmitter | None = None
 
-    def __deepcopy__(self, memo: dict) -> Pipeline:
-        """Deep-copy support: ``threading.Lock`` is not copyable, so rebuild it.
+    # --- Copy / serialization protocols ---------------------------------
+    # The WARN-dedup ``threading.Lock`` added for #56 is neither copyable nor
+    # picklable, so each protocol is handled explicitly:
+    #   * copy.copy  -> __copy__: shallow, SHARES the lock + dedup set so a
+    #     batch_run/abatch_run batch dedups each preflight WARN once as a unit.
+    #   * copy.deepcopy / pickle -> __getstate__/__setstate__: a fully
+    #     independent clone with a freshly built lock.
+    # Defining __copy__ is required: without it, __getstate__/__setstate__
+    # would also drive copy.copy and silently break the shared-lock contract.
 
-        ``copy.copy`` (shallow — used by ``batch_run``/``abatch_run``)
-        intentionally shares the lock and dedup set across clones so a batch
-        dedups WARNs as a unit. ``deepcopy`` semantics instead yield a fully
-        independent Pipeline: the clone gets its own fresh lock and a deep copy
-        of every other attribute. Without this, the lock added for #56 would
-        make ``copy.deepcopy(Pipeline(...))`` raise ``TypeError``.
-        """
-        import copy
-
+    def __copy__(self) -> Pipeline:
+        """Shallow copy that shares the WARN-dedup lock and set across clones."""
         clone = self.__class__.__new__(self.__class__)
-        memo[id(self)] = clone
-        for key, value in self.__dict__.items():
-            if key == "_warned_preflight_lock":
-                clone.__dict__[key] = threading.Lock()
-            else:
-                clone.__dict__[key] = copy.deepcopy(value, memo)
+        clone.__dict__.update(self.__dict__)
         return clone
+
+    def __getstate__(self) -> dict:
+        """Omit the unpicklable lock for pickle/deepcopy; rebuilt in setstate."""
+        state = self.__dict__.copy()
+        state.pop("_warned_preflight_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._warned_preflight_lock = threading.Lock()
 
     @staticmethod
     def _reject_config_tenant(cfg: RunnableConfig | None) -> None:

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
 from collections.abc import Awaitable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -318,7 +319,8 @@ class Pipeline(Runnable[None, PipelineResult]):
         self._max_concurrency = max_concurrency
         self._moderation = moderation
         # Model preflight (default ON, soft-launch posture):
-        # _validate_steps() calls validate_model() on each step's provider.
+        # preflight (_check_step_capabilities + _validate_models) calls
+        # validate_model() on each step's provider.
         # NOT_FOUND raises before any wire calls; OK_PROVISIONAL and
         # UNKNOWN_PERMISSIVE emit a single WARN per (provider, slug) per
         # Pipeline instance (the dedup set below resets on each Pipeline
@@ -328,7 +330,12 @@ class Pipeline(Runnable[None, PipelineResult]):
         # Tracks (provider_name, slug) tuples already warned about so the
         # WARN log is one-per-pipeline-lifetime, mirroring the
         # _warned_deprecated dedup pattern in ModelRegistry.
+        # The lock makes the check-then-add atomic across threads: arun()
+        # offloads _validate_models via asyncio.to_thread, and abatch_run
+        # clones share this set (shallow copy.copy), so several clones can
+        # mutate it concurrently from different worker threads.
         self._warned_preflight: set[tuple[str, str]] = set()
+        self._warned_preflight_lock = threading.Lock()
         # Tracer resolution: explicit arg wins; legacy structured_log=True maps
         # to LoggingTracer so existing callers keep their JSON event stream.
         if tracer is not None:
@@ -554,14 +561,19 @@ class Pipeline(Runnable[None, PipelineResult]):
         )
         return self
 
-    def _validate_steps(self) -> None:
-        """Validate step capabilities before execution. Fails loud on mismatches."""
+    def _check_step_capabilities(self) -> None:
+        """Validate modality support and chain-input compatibility for every step.
+
+        CPU-only checks (no network I/O). Separated from ``_validate_models`` so
+        the fast, cheap assertions can run inline on the event loop while the
+        slow model-preflight can be offloaded to a thread in async contexts.
+        """
         for i, ps in enumerate(self._steps):
             caps = ps.provider.get_capabilities()
             if caps is None:
                 continue
 
-            # Check modality support
+            # Modality support
             if caps.supported_modalities and ps.modality not in caps.supported_modalities:
                 supported = ", ".join(str(m) for m in caps.supported_modalities)
                 msg = (
@@ -585,11 +597,41 @@ class Pipeline(Runnable[None, PipelineResult]):
                 )
                 raise GenblazeError(msg)
 
+    def _validate_steps(self) -> None:
+        """Validate step capabilities and run model preflight. Fails loud on mismatches."""
+        self._check_step_capabilities()
+
         # Model preflight runs after capability validation so a misconfigured
         # step (wrong modality, missing chain support) surfaces a clear error
         # before the slug-validity question even comes up.
         if self._preflight:
             self._validate_models()
+
+    async def _validate_steps_async(self) -> None:
+        """Async variant of ``_validate_steps`` that keeps the event loop free.
+
+        Cheap capability checks run synchronously (CPU-only, negligible). The
+        network-bound ``_validate_models`` phase (ThreadPoolExecutor + provider
+        discovery fetches) is offloaded via ``asyncio.to_thread`` so concurrent
+        coroutines keep running during the preflight window.
+
+        The single-flight discovery/probe cache inside each provider makes
+        off-thread dispatch safe -- concurrent fetches deduplicate at the
+        provider level.
+
+        Cancellation note: cancelling the awaiting task raises CancelledError
+        here, but the offloaded worker runs to completion (Python can't
+        interrupt the blocking fetch). The only residue is benign -- cache
+        fill and a possible WARN may land after the caller has gone.
+        """
+        # Capabilities before model preflight (see _validate_steps): a
+        # misconfigured step must surface before the slug-validity question.
+        # Cheap modality/chain-input checks run inline, no I/O.
+        self._check_step_capabilities()
+
+        # Network-bound model preflight: offload so the event loop stays free.
+        if self._preflight:
+            await asyncio.to_thread(self._validate_models)
 
     def _validate_models(self) -> None:
         """Preflight: validate every step's model in parallel.
@@ -604,8 +646,8 @@ class Pipeline(Runnable[None, PipelineResult]):
 
         Behavior on outcome:
         - ``NOT_FOUND``: raise ``ProviderError(MODEL_ERROR)`` immediately.
-        - ``OK_PROVISIONAL``: log WARN once per (provider, slug) per process.
-        - ``UNKNOWN_PERMISSIVE``: log WARN once per (provider, slug) per process.
+        - ``OK_PROVISIONAL``: WARN once per (provider, slug) per Pipeline instance.
+        - ``UNKNOWN_PERMISSIVE``: WARN once per (provider, slug) per Pipeline instance.
         - ``OK_AUTHORITATIVE``: silent.
         """
         if not self._steps:
@@ -672,8 +714,7 @@ class Pipeline(Runnable[None, PipelineResult]):
 
         key = (ps.provider.name, ps.model)
         if result.outcome is ValidationOutcome.OK_PROVISIONAL:
-            if key not in self._warned_preflight:
-                self._warned_preflight.add(key)
+            if self._warn_once(key):
                 logger.warning(
                     "preflight.provisional step=%d provider=%s model=%s "
                     "family=%s detail=%s — liveness unverifiable; "
@@ -685,8 +726,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                     result.detail,
                 )
         elif result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE:
-            if key not in self._warned_preflight:
-                self._warned_preflight.add(key)
+            if self._warn_once(key):
                 logger.warning(
                     "preflight.unknown step=%d provider=%s model=%s — "
                     "no family matched; permissive fallback applies",
@@ -695,6 +735,22 @@ class Pipeline(Runnable[None, PipelineResult]):
                     ps.model,
                 )
         # OK_AUTHORITATIVE: silent.
+
+    def _warn_once(self, key: tuple[str, str]) -> bool:
+        """Atomically claim ``key`` for a one-time WARN; return True the first
+        time it is seen, False thereafter.
+
+        The check-then-add runs under a lock so concurrent _validate_models
+        runs (abatch_run clones share this set via shallow copy.copy, each
+        dispatched to its own asyncio.to_thread worker) can't both emit the
+        same WARN. Logging is left to the caller so the loop's I/O happens
+        outside the lock.
+        """
+        with self._warned_preflight_lock:
+            if key in self._warned_preflight:
+                return False
+            self._warned_preflight.add(key)
+            return True
 
     def _resolve_inputs(
         self,
@@ -1760,7 +1816,9 @@ class Pipeline(Runnable[None, PipelineResult]):
         # do network work), so a bad ainvoke(config={"tenant_id": ...}) fails fast.
         self._reject_config_tenant(config)
 
-        self._validate_steps()
+        # Offload blocking preflight (ThreadPoolExecutor + provider discovery)
+        # to a thread so the event loop stays free during the preflight window.
+        await self._validate_steps_async()
 
         run_id = new_id()
         # input_from requires sequential execution (needs prior step results)

--- a/libs/core/tests/unit/test_pipeline_preflight.py
+++ b/libs/core/tests/unit/test_pipeline_preflight.py
@@ -8,12 +8,16 @@ Coverage:
 - Suggestions surface in NOT_FOUND error messages.
 - ``ThreadPoolExecutor`` parallelism — preflight runs validate_model
   on every step, sync codebase, no asyncio.run_until_complete (RT-2).
+- Issue #56: ``arun()`` must not block the event loop during preflight.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
+import threading
+import time
 
 import pytest
 from genblaze_core import Pipeline
@@ -276,3 +280,122 @@ class TestValidatorExceptionHandling:
         # The broken validator surfaces as UNKNOWN_PERMISSIVE → preflight.unknown.
         unknown_warns = [r for r in caplog.records if "preflight.unknown" in r.getMessage()]
         assert len(unknown_warns) == 1
+
+
+class TestArunDoesNotBlockEventLoop:
+    """Issue #56: ``arun()`` preflight must not stall the event loop.
+
+    Strategy: a provider whose ``validate_model`` does blocking I/O
+    (simulated with ``time.sleep``). A concurrent heartbeat coroutine
+    increments a counter every 10 ms. If preflight blocks the event
+    loop the counter never ticks during the preflight window.
+    After the fix (offloading via ``asyncio.to_thread``), the counter
+    accumulates multiple ticks while preflight runs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_event_loop_not_blocked_during_preflight(self) -> None:
+        PREFLIGHT_SLEEP = 0.15  # simulated blocking network call
+
+        class _SlowProvider(BaseProvider):
+            name = "slow-preflight"
+            discovery_support = DiscoverySupport.NONE
+
+            def validate_model(self, model_id: str, *, refresh: bool = False):  # type: ignore[no-untyped-def,override]
+                # Simulate a blocking discovery fetch (the root cause of #56).
+                time.sleep(PREFLIGHT_SLEEP)
+                from genblaze_core.providers.validation import (
+                    ValidationResult,
+                    ValidationSource,
+                )
+
+                return ValidationResult.ok_authoritative(ValidationSource.DISCOVERY)
+
+            def get_capabilities(self) -> ProviderCapabilities:
+                return ProviderCapabilities(supported_modalities=[Modality.IMAGE], models=[])
+
+            def submit(self, step, config=None):  # type: ignore[no-untyped-def]
+                return "pid"
+
+            def poll(self, prediction_id, config=None):  # type: ignore[no-untyped-def]
+                return True
+
+            def fetch_output(self, prediction_id, step):  # type: ignore[no-untyped-def]
+                return step
+
+        # Heartbeat that ticks every 10 ms while the event loop is free.
+        tick_count = 0
+        running = True
+
+        async def heartbeat() -> None:
+            nonlocal tick_count
+            while running:
+                await asyncio.sleep(0.01)
+                tick_count += 1
+
+        p = _SlowProvider()
+        pipe = Pipeline("t", preflight=True).step(
+            p, model="any", modality=Modality.IMAGE, prompt="hi"
+        )
+
+        hb_task = asyncio.create_task(heartbeat())
+        try:
+            # Call arun() — the actual public call site — to verify the event loop
+            # is not blocked at the preflight call site, not just on the helper.
+            await pipe.arun(raise_on_failure=False)
+        finally:
+            running = False
+            hb_task.cancel()
+            try:
+                await hb_task
+            except asyncio.CancelledError:
+                pass
+
+        # With a 150 ms preflight sleep and 10 ms heartbeat interval we expect
+        # ~14 ticks; assert >= 3 for generous CI-jitter margin. A blocked loop
+        # yields 0-1 (the heartbeat's first sleep may fire before preflight
+        # begins blocking).
+        assert tick_count >= 3, (
+            f"Event loop was blocked during preflight: heartbeat ticked only "
+            f"{tick_count} time(s) during a {PREFLIGHT_SLEEP * 1000:.0f} ms "
+            f"preflight window (expected >= 3)."
+        )
+
+
+class TestWarnOnceConcurrency:
+    """Issue #56: ``_warn_once`` must dedup atomically across threads.
+
+    Preflight now runs off the event loop via ``asyncio.to_thread`` and
+    ``abatch_run`` clones share the ``_warned_preflight`` set (shallow
+    ``copy.copy``), so multiple worker threads can call ``_warn_once`` on the
+    same key concurrently. Exactly one caller must win the claim, else a
+    duplicate WARN leaks. This locks in the contract so the guarding lock
+    cannot be silently dropped in a future refactor.
+    """
+
+    def test_warn_once_claims_key_exactly_once_under_contention(self) -> None:
+        pipe = Pipeline("warn-once")
+        key = ("prov", "model-x")
+        n_threads = 32
+        # Barrier maximizes the check-then-add overlap window across threads.
+        barrier = threading.Barrier(n_threads)
+        results: list[bool] = []
+        results_lock = threading.Lock()
+
+        def claim() -> None:
+            barrier.wait()
+            won = pipe._warn_once(key)
+            with results_lock:
+                results.append(won)
+
+        threads = [threading.Thread(target=claim) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sum(results) == 1, (
+            f"_warn_once must grant the claim to exactly one thread, "
+            f"got {sum(results)} winners out of {n_threads}."
+        )
+        assert key in pipe._warned_preflight

--- a/libs/core/tests/unit/test_pipeline_preflight.py
+++ b/libs/core/tests/unit/test_pipeline_preflight.py
@@ -14,6 +14,7 @@ Coverage:
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import re
 import threading
@@ -399,3 +400,35 @@ class TestWarnOnceConcurrency:
             f"got {sum(results)} winners out of {n_threads}."
         )
         assert key in pipe._warned_preflight
+
+
+class TestPipelineCopySemantics:
+    """Issue #56: the preflight lock must not break copy.deepcopy.
+
+    The threading.Lock added for the WARN-dedup is not copyable, so a custom
+    __deepcopy__ rebuilds it. Two clone paths must stay correct: shallow
+    copy.copy (used by batch_run/abatch_run) shares the lock+set so a batch
+    dedups as a unit, while deepcopy yields a fully independent pipeline.
+    """
+
+    def test_deepcopy_succeeds_and_isolates_lock(self) -> None:
+        p = Pipeline("orig")
+        p._warned_preflight.add(("seed", "model"))
+
+        clone = copy.deepcopy(p)
+
+        # deepcopy => independent lock and dedup set (no shared mutation).
+        assert clone._warned_preflight_lock is not p._warned_preflight_lock
+        assert clone._warned_preflight is not p._warned_preflight
+        p._warned_preflight.add(("prov", "model"))
+        assert ("prov", "model") not in clone._warned_preflight
+
+    def test_shallow_copy_shares_lock_for_batch_clones(self) -> None:
+        p = Pipeline("orig")
+
+        clone = copy.copy(p)
+
+        # abatch_run relies on clones sharing the lock+set so _warn_once dedups
+        # across the whole batch — this must NOT change.
+        assert clone._warned_preflight_lock is p._warned_preflight_lock
+        assert clone._warned_preflight is p._warned_preflight

--- a/libs/core/tests/unit/test_pipeline_preflight.py
+++ b/libs/core/tests/unit/test_pipeline_preflight.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
+import pickle
 import re
 import threading
 import time
@@ -403,12 +404,13 @@ class TestWarnOnceConcurrency:
 
 
 class TestPipelineCopySemantics:
-    """Issue #56: the preflight lock must not break copy.deepcopy.
+    """Issue #56: the preflight lock must not break copy/pickle.
 
-    The threading.Lock added for the WARN-dedup is not copyable, so a custom
-    __deepcopy__ rebuilds it. Two clone paths must stay correct: shallow
-    copy.copy (used by batch_run/abatch_run) shares the lock+set so a batch
-    dedups as a unit, while deepcopy yields a fully independent pipeline.
+    The threading.Lock added for the WARN-dedup is neither copyable nor
+    picklable. Three protocols must stay correct: shallow copy.copy (used by
+    batch_run/abatch_run) shares the lock+set so a batch dedups as a unit,
+    while deepcopy and pickle each yield a fully independent pipeline with a
+    freshly built lock.
     """
 
     def test_deepcopy_succeeds_and_isolates_lock(self) -> None:
@@ -422,6 +424,19 @@ class TestPipelineCopySemantics:
         assert clone._warned_preflight is not p._warned_preflight
         p._warned_preflight.add(("prov", "model"))
         assert ("prov", "model") not in clone._warned_preflight
+
+    def test_pickle_roundtrip_succeeds_and_rebuilds_lock(self) -> None:
+        p = Pipeline("orig")
+        p._warned_preflight.add(("seed", "model"))
+
+        clone = pickle.loads(pickle.dumps(p))  # noqa: S301 — round-tripping our own pipeline in a test
+
+        # pickle => independent pipeline with a usable, freshly built lock.
+        assert isinstance(clone, Pipeline)
+        assert clone._warned_preflight == {("seed", "model")}
+        assert clone._warned_preflight is not p._warned_preflight
+        # The rebuilt lock must be a real, acquirable lock.
+        assert clone._warn_once(("new", "model")) is True
 
     def test_shallow_copy_shares_lock_for_batch_clones(self) -> None:
         p = Pipeline("orig")

--- a/libs/core/tests/unit/test_prompt_template.py
+++ b/libs/core/tests/unit/test_prompt_template.py
@@ -160,8 +160,10 @@ class TestPromptTemplatePipeline:
             .abatch_run([{"x": "cat"}, {"x": "dog"}])
         )
         assert len(results) == 2
-        assert provider.received_steps[0].prompt == "A cat"
-        assert provider.received_steps[1].prompt == "A dog"
+        # abatch_run executes items concurrently (asyncio.gather), so the order
+        # the shared provider observes submissions is non-deterministic. Assert
+        # set-equality: both dicts must render their template correctly.
+        assert {s.prompt for s in provider.received_steps} == {"A cat", "A dog"}
 
     def test_rendered_template_in_step(self):
         """User can render manually and pass string to step()."""


### PR DESCRIPTION
## Summary

`Pipeline.arun()` ran model preflight synchronously before its first `await`, so with `preflight=True` (the default) it froze the asyncio event loop while each provider's `validate_model()` performed network I/O (discovery fetch / family probe) inside a `ThreadPoolExecutor` blocked on `as_completed`. In FastAPI / async services a single `await pipe.arun()` stalled every other coroutine for the duration of preflight, and `abatch_run` compounded it.

This offloads the network-bound phase off the event loop while keeping sync `run()` byte-for-byte unchanged.

## Changes

- Extract `_check_step_capabilities()` (CPU-only modality / chain-input checks) as the single source of truth shared by both paths.
- `_validate_steps()` (sync) delegates to `_check_step_capabilities()` then `_validate_models()`. Sync `run()` is unchanged.
- Add `_validate_steps_async()`: runs the cheap checks inline, then `await asyncio.to_thread(self._validate_models)`. `arun()` now awaits it.
- Guard the `_warned_preflight` WARN-dedup set with a `threading.Lock` via a new `_warn_once()` helper. This is load-bearing: `_validate_models` now runs off the loop, and `abatch_run` clones share the set through shallow `copy.copy`, so concurrent worker threads could otherwise race the check-then-add. Logging is done outside the lock.

## Tests

- `TestArunDoesNotBlockEventLoop`: drives the real `arun()` with a 150ms-sleeping provider while a 10ms heartbeat runs concurrently; asserts the loop keeps ticking (a blocked loop yields 0-1).
- `TestWarnOnceConcurrency`: 32 threads race `_warn_once` on one key behind a barrier; asserts exactly one claim is granted.
- Full `genblaze-core` unit suite: 1361 passed, 4 skipped. Lint clean, no new mypy errors.

## Acceptance criteria

- [x] `await pipe.arun(...)` does not stall the event loop during preflight.
- [x] Sync `run()` behavior is unchanged.
- [x] A regression test asserts the loop is not blocked for the preflight duration.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)