### PR TITLE
fix(core): release run-scoped sink resources without breaking reuse/fire-and-forget (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `asyncio.to_thread`, allowing concurrent coroutines to keep running during
   the preflight window. Cheap capability checks (modality, chain-input) still
   run synchronously. `Pipeline.run()` behavior is unchanged (#56).
+- `genblaze-core`: `Pipeline.run()`/`arun()` now release a sink's run-scoped
+  resources in their `finally` block (and on early preflight/validation
+  failure), shutting down the `ObjectStorageSink` eager-upload
+  `ThreadPoolExecutor` and releasing the backend connection pool —
+  `S3StorageBackend.close()` now closes the boto3 client. Previously non-daemon
+  worker threads stayed alive after `run()` returned and in-flight eager-upload
+  futures leaked on error paths that bypassed `write_run`. Sinks declare
+  lifecycle ownership via `BaseSink._close_with_run` (default `True`):
+  run-scoped sinks (`ObjectStorageSink`) are closed by the pipeline and are
+  single-use, while fire-and-forget `WebhookSink` opts out (`False`) so it is
+  never closed — keeping webhook delivery non-blocking and the sink reusable
+  across runs. `batch_run()`/`abatch_run()` close their shared sink once after
+  the whole batch rather than after the first item. `BaseSink` gains
+  `__enter__`/`__exit__` for callers that manage the lifecycle outside a
+  `run()`. **Behavior change:** a run-scoped sink passed to `run()`/`arun()` is
+  closed afterward — construct a fresh one per run rather than reusing it (#57).
 - `genblaze-core`: post-submit step-level retries now resume the existing
   upstream prediction instead of submitting a new one, including transient
   checkpoint failures after `submit()` returns by replaying idempotent

--- a/docs/features/object-storage.md
+++ b/docs/features/object-storage.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-25 -->
+<!-- last_verified: 2026-06-24 -->
 # Object Storage
 
 Upload run assets and manifests to any S3-compatible bucket. **Backblaze B2 is
@@ -34,6 +34,27 @@ storage = ObjectStorageSink(
 )
 
 result = Pipeline("my-pipeline").step(...).run(sink=storage)
+```
+
+After `run()` returns, the pipeline releases the sink automatically
+(`sink.close()` fires in the pipeline's `finally` block). The eager-upload
+pool and the backend connection pool (the `S3StorageBackend` boto3 client) are
+shut down at that point — no manual cleanup needed when you pass the sink to
+`run()`. Because the sink is closed afterward, treat it as single-use:
+construct a fresh `ObjectStorageSink` per run rather than reusing one across
+calls.
+
+For one-off scripts or tests that construct the sink outside a `run()` call,
+use the context-manager form to guarantee cleanup:
+
+```python
+with ObjectStorageSink(
+    S3StorageBackend.for_backblaze("my-bucket"),
+    key_strategy=KeyStrategy.CONTENT_ADDRESSABLE,
+) as sink:
+    # put_asset() / put_assets() calls here
+    sink.put_asset(asset)
+# sink.close() called automatically on exit
 ```
 
 ### What `for_backblaze()` does for you

--- a/examples/b2_storage_pipeline.py
+++ b/examples/b2_storage_pipeline.py
@@ -45,6 +45,9 @@ def main() -> None:
     # Bucket structure:
     #   genblaze-assets/assets/{sha[:2]}/{sha[2:4]}/{sha}.ext
     #   genblaze-assets/manifests/{run_id}.json
+    #
+    # The pipeline closes the sink (releases eager-upload pool + backend
+    # connection pool) automatically when run() returns. No manual cleanup needed.
     sink = ObjectStorageSink(
         backend,
         prefix="genblaze-assets",

--- a/libs/connectors/s3/genblaze_s3/backend.py
+++ b/libs/connectors/s3/genblaze_s3/backend.py
@@ -277,6 +277,17 @@ class S3StorageBackend(StorageBackend):
         self._client = boto3.client("s3", **self._client_kwargs())
         self._transfer_config = self._build_transfer_config()
 
+    def close(self) -> None:
+        """Release the boto3 client's urllib3 connection pool.
+
+        ``ObjectStorageSink.close()`` (and therefore ``Pipeline.run()``)
+        calls this; without it the pooled HTTPS connections survive until
+        GC, leaking sockets in long-running services that build a backend
+        per run/tenant (issue #57). Idempotent — boto3 tolerates a repeat
+        ``close()``.
+        """
+        self._client.close()
+
     @staticmethod
     def _resolve_alias(
         primary_name: str,
@@ -1431,6 +1442,14 @@ class S3StorageBackend(StorageBackend):
 
         self._region = region
         self._endpoint_url = _b2_endpoint(region)
+        # Close the outgoing client's connection pool before replacing it.
+        # Otherwise the first client's urllib3 pool is orphaned and only
+        # reclaimed at GC — close() would later release only the new client,
+        # re-leaking the original on the region auto-correct path (issue #57).
+        try:
+            self._client.close()
+        except Exception:  # noqa: BLE001 — best-effort; must not block reconfigure
+            logger.debug("closing pre-reconfigure S3 client failed", exc_info=True)
         self._client = boto3.client("s3", **self._client_kwargs())
         self._transfer_config = self._build_transfer_config()
 

--- a/libs/connectors/s3/tests/test_backblaze_region_probe.py
+++ b/libs/connectors/s3/tests/test_backblaze_region_probe.py
@@ -433,3 +433,20 @@ class TestProbeHelperDirect:
         assert results["us-west-002"] == 200
         assert results["us-east-005"] == 404
         assert results["eu-central-003"] == 403
+
+
+def test_reconfigure_for_region_closes_old_client(mock_boto3):
+    """Region auto-correct must close the outgoing client's connection pool
+    before replacing it — otherwise the first client's urllib3 pool is orphaned
+    and close() later releases only the new client (issue #57)."""
+    backend, client0 = _make_unverified_backend(mock_boto3)
+    client1 = MagicMock()
+    mock_boto3.client.return_value = client1  # next boto3.client() yields client1
+
+    backend._reconfigure_for_region("us-east-005")
+
+    client0.close.assert_called_once()
+    assert backend._client is client1
+    # close() now releases the current (new) client; the old one was already shut.
+    backend.close()
+    client1.close.assert_called_once()

--- a/libs/connectors/s3/tests/test_s3_backend.py
+++ b/libs/connectors/s3/tests/test_s3_backend.py
@@ -29,6 +29,13 @@ class TestS3StorageBackend:
         backend._region_verified = True
         return backend, mock_client
 
+    def test_close_releases_boto3_client(self, mock_boto3):
+        """close() must close the boto3 client so its urllib3 connection pool
+        is released — the half of issue #57 the base no-op never delivered."""
+        backend, mock_client = self._make_backend(mock_boto3)
+        backend.close()
+        mock_client.close.assert_called_once()
+
     def test_put_uses_upload_fileobj(self, mock_boto3):
         """put() routes through upload_fileobj so small+large payloads share the
         managed-transfer code path (auto-multipart when > threshold)."""
@@ -150,12 +157,6 @@ class TestS3StorageBackend:
             ExpiresIn=600,
         )
         assert url == "https://signed-url"
-
-    def test_close_noop(self, mock_boto3):
-        """close() is a no-op — boto3 clients don't have a close() method."""
-        backend, mock_client = self._make_backend(mock_boto3)
-        backend.close()  # Should not raise
-        mock_client.close.assert_not_called()
 
     def test_exists_true_on_head_success(self, mock_boto3):
         backend, mock_client = self._make_backend(mock_boto3)

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -1580,6 +1580,27 @@ class Pipeline(Runnable[None, PipelineResult]):
         effective_config = config if config is not None else self._config
         return await self.arun(_config_override=effective_config)
 
+    @staticmethod
+    def _close_sink_quietly(sink: BaseSink | None) -> None:
+        """Release a sink's run-scoped resources, swallowing teardown errors.
+
+        No-op when ``sink`` is None or the sink opts out via
+        ``_close_with_run = False`` (process-scoped/fire-and-forget sinks such
+        as WebhookSink manage their own lifecycle and must not be closed — or
+        joined — by the pipeline). A failed close is logged, never raised, so it
+        cannot mask the run's real result. Shared by run()/arun()/batch teardown.
+        """
+        if sink is None or not getattr(sink, "_close_with_run", True):
+            return
+        try:
+            sink.close()
+        except Exception:  # noqa: BLE001 — best-effort cleanup; log and continue
+            logger.warning(
+                "%s.close() raised during pipeline teardown; resources may not have been released",
+                type(sink).__name__,
+                exc_info=True,
+            )
+
     def run(
         self,
         *,
@@ -1594,11 +1615,17 @@ class Pipeline(Runnable[None, PipelineResult]):
         on_step_complete: Any = None,
         on_retry: Any = None,
         _config_override: RunnableConfig | None = None,
+        _owns_sink: bool = True,
     ) -> PipelineResult:
         """Execute all steps synchronously and return a PipelineResult.
 
         Args:
-            sink: Optional sink to write run data to.
+            sink: Optional sink to write run data to. Sinks with run-scoped
+                resources (e.g. ObjectStorageSink) are closed automatically when
+                the run finishes (their ``close()`` fires in a ``finally`` block),
+                so such a sink is spent afterward — construct a fresh one per run.
+                Fire-and-forget sinks like WebhookSink opt out
+                (``_close_with_run = False``) and stay open/reusable.
             fail_fast: If True (default), stop on first failed step.
             raise_on_failure: If ``True``, raise :class:`PipelineError` when any
                 step ends in ``StepStatus.FAILED``. If ``False``, the failed
@@ -1639,11 +1666,19 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
-        # Reject an invalid config-level tenant before model preflight (which may
-        # do network work), so a bad invoke(config={"tenant_id": ...}) fails fast.
-        self._reject_config_tenant(config)
-
-        self._validate_steps()
+        # Preflight runs before the main try/finally. When run() owns the sink
+        # it must still close it on an early preflight/validation failure
+        # (issue #57) — share the same teardown helper, no duplicated close.
+        try:
+            # Reject an invalid config-level tenant before model preflight (which
+            # may do network work), so a bad invoke(config={"tenant_id": ...})
+            # fails fast.
+            self._reject_config_tenant(config)
+            self._validate_steps()
+        except BaseException:
+            if _owns_sink:
+                self._close_sink_quietly(sink)
+            raise
 
         run_id = new_id()
         spinner: Spinner | None = None
@@ -1772,6 +1807,14 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
             if spinner is not None:
                 spinner.stop()
+            # Release the sink's run-scoped resources (eager-upload pool, backend
+            # connection pool). The pipeline is the last user of the sink for
+            # this run, so this fires in the finally to cover both normal
+            # completion and any error path that bypasses write_run (issue #57).
+            # Skipped when a caller (e.g. batch_run) owns the sink across runs,
+            # or when the sink opts out via _close_with_run=False.
+            if _owns_sink:
+                self._close_sink_quietly(sink)
 
     async def arun(
         self,
@@ -1788,6 +1831,7 @@ class Pipeline(Runnable[None, PipelineResult]):
         on_step_complete: Any = None,
         on_retry: Any = None,
         _config_override: RunnableConfig | None = None,
+        _owns_sink: bool = True,
     ) -> PipelineResult:
         """Execute steps asynchronously and return a PipelineResult.
 
@@ -1795,7 +1839,12 @@ class Pipeline(Runnable[None, PipelineResult]):
         When chain=True, steps run sequentially (each feeds the next).
 
         Args:
-            sink: Optional sink to write run data to.
+            sink: Optional sink to write run data to. Sinks with run-scoped
+                resources (e.g. ObjectStorageSink) are closed automatically when
+                the run finishes (their ``close()`` fires in a ``finally`` block),
+                so such a sink is spent afterward — construct a fresh one per run.
+                Fire-and-forget sinks like WebhookSink opt out
+                (``_close_with_run = False``) and stay open/reusable.
             fail_fast: If True (default), stop on first failed step.
             timeout: Per-step timeout in seconds (builds RunnableConfig internally).
             max_retries: Per-step max retries (builds RunnableConfig internally).
@@ -1838,13 +1887,22 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
         else:
             config = self._config
-        # Reject an invalid config-level tenant before model preflight (which may
-        # do network work), so a bad ainvoke(config={"tenant_id": ...}) fails fast.
-        self._reject_config_tenant(config)
-
-        # Offload blocking preflight (ThreadPoolExecutor + provider discovery)
-        # to a thread so the event loop stays free during the preflight window.
-        await self._validate_steps_async()
+        # Preflight runs before the main try/finally. When arun() owns the sink
+        # it must still close it on an early preflight/validation failure
+        # (issue #57); offload the blocking close to a thread to keep the loop
+        # responsive. Share the same teardown helper — no duplicated close.
+        try:
+            # Reject an invalid config-level tenant before model preflight (which
+            # may do network work), so a bad ainvoke(config={"tenant_id": ...})
+            # fails fast.
+            self._reject_config_tenant(config)
+            # Offload blocking preflight (ThreadPoolExecutor + provider discovery)
+            # to a thread so the event loop stays free during the preflight window.
+            await self._validate_steps_async()
+        except BaseException:
+            if _owns_sink:
+                await asyncio.to_thread(self._close_sink_quietly, sink)
+            raise
 
         run_id = new_id()
         # input_from requires sequential execution (needs prior step results)
@@ -2082,6 +2140,14 @@ class Pipeline(Runnable[None, PipelineResult]):
             )
             if spinner is not None:
                 spinner.stop()
+            # Release the sink's run-scoped resources (issue #57). close() is
+            # blocking (ThreadPoolExecutor.shutdown) — offload to a thread so the
+            # event loop stays responsive while it drains. If the surrounding
+            # task is cancelled mid-await the close keeps running in its thread
+            # but is no longer awaited here; acceptable for cleanup. Skipped when
+            # a caller owns the sink (batch) or it opts out (_close_with_run).
+            if _owns_sink:
+                await asyncio.to_thread(self._close_sink_quietly, sink)
 
     def _make_failed_step(self, ps: _PipelineStep, exc: Exception) -> Step:
         """Create a FAILED step from an unhandled exception."""
@@ -2267,7 +2333,9 @@ class Pipeline(Runnable[None, PipelineResult]):
                 ``aspect_ratio``, ``quality``, etc. Mutually exclusive with
                 ``prompts=``.
             max_concurrency: Max concurrent pipeline executions (``abatch_run``).
-            sink: Optional sink to write each run to.
+            sink: Optional sink to write each run to. Shared across all items
+                and closed once after the whole batch (not per item), unless the
+                sink opts out via ``_close_with_run = False``.
             fail_fast: If True (default), stop each pipeline on first failure.
             raise_on_failure: See :meth:`run`. Applied per pipeline.
             timeout: Per-step timeout in seconds.
@@ -2299,6 +2367,9 @@ class Pipeline(Runnable[None, PipelineResult]):
         # if requested. Aborting mid-batch on the first failed item would
         # silently lose the remaining results, which is rarely what callers
         # actually want for asset packs / aspect-ratio sweeps / A/B fan-outs.
+        # The batch owns the shared sink across all items: per-item runs must
+        # NOT close it (_owns_sink=False), or item 2+ would write to a closed
+        # sink. The batch closes it once after the loop (issue #57).
         def _run_one(rebuild_steps: list[_PipelineStep]) -> PipelineResult:
             return _build_pipe(rebuild_steps).run(
                 sink=sink,
@@ -2309,23 +2380,28 @@ class Pipeline(Runnable[None, PipelineResult]):
                 on_progress=on_progress,
                 pipeline_timeout=pipeline_timeout,
                 on_step_complete=on_step_complete,
+                _owns_sink=False,
             )
 
         results: list[PipelineResult] = []
-        if items is not None:
-            for item in items:
-                results.append(_run_one(self._apply_item_to_steps(self._steps, item)))
-        else:
-            assert prompts is not None  # narrowed by _validate_batch_args
-            for prompt_or_vars in prompts:
-                results.append(
-                    _run_one(
-                        [
-                            replace(ps, prompt=self._resolve_prompt(ps, prompt_or_vars))
-                            for ps in self._steps
-                        ]
+        try:
+            if items is not None:
+                for item in items:
+                    results.append(_run_one(self._apply_item_to_steps(self._steps, item)))
+            else:
+                assert prompts is not None  # narrowed by _validate_batch_args
+                for prompt_or_vars in prompts:
+                    results.append(
+                        _run_one(
+                            [
+                                replace(ps, prompt=self._resolve_prompt(ps, prompt_or_vars))
+                                for ps in self._steps
+                            ]
+                        )
                     )
-                )
+        finally:
+            # finally so a pipeline-level error mid-batch still releases the sink.
+            self._close_sink_quietly(sink)
         _maybe_raise_batch_error(results, resolved_raise)
         return results
 
@@ -2367,6 +2443,8 @@ class Pipeline(Runnable[None, PipelineResult]):
             pipe._steps = rebuild_steps
             return pipe
 
+        # The batch owns the shared sink: per-item runs must NOT close it
+        # (_owns_sink=False). The batch closes it once after gather (issue #57).
         async def _run(rebuild_steps: list[_PipelineStep]) -> PipelineResult:
             async with sem:
                 return await _build_pipe(rebuild_steps).arun(
@@ -2378,6 +2456,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                     on_progress=on_progress,
                     pipeline_timeout=pipeline_timeout,
                     on_step_complete=on_step_complete,
+                    _owns_sink=False,
                 )
 
         if items is not None:
@@ -2388,23 +2467,29 @@ class Pipeline(Runnable[None, PipelineResult]):
                 _run([replace(ps, prompt=self._resolve_prompt(ps, p)) for ps in self._steps])
                 for p in prompts
             ]
-        # ``return_exceptions=True`` is load-bearing — without it, a single
-        # ``PipelineTimeoutError`` (or any other non-step exception) would
-        # propagate immediately and cancel every other in-flight task,
-        # silently breaking the "every batch item runs to completion"
-        # promise. Per-item ``PipelineError``s are already suppressed via
-        # ``raise_on_failure=False`` so they never reach this list; anything
-        # we DO see here is a genuine pipeline-level error worth surfacing.
-        results_or_excs = await asyncio.gather(*tasks, return_exceptions=True)
-        results: list[PipelineResult] = []
-        for r in results_or_excs:
-            if isinstance(r, BaseException):
-                # Re-raise the first non-result item so callers see the
-                # original error (timeout, validation, etc.) instead of a
-                # generic BatchPipelineError. Every task has already finished
-                # by the time we get here, so we're not aborting work in flight.
-                raise r
-            results.append(r)
+        try:
+            # ``return_exceptions=True`` is load-bearing — without it, a single
+            # ``PipelineTimeoutError`` (or any other non-step exception) would
+            # propagate immediately and cancel every other in-flight task,
+            # silently breaking the "every batch item runs to completion"
+            # promise. Per-item ``PipelineError``s are already suppressed via
+            # ``raise_on_failure=False`` so they never reach this list; anything
+            # we DO see here is a genuine pipeline-level error worth surfacing.
+            results_or_excs = await asyncio.gather(*tasks, return_exceptions=True)
+            results: list[PipelineResult] = []
+            for r in results_or_excs:
+                if isinstance(r, BaseException):
+                    # Re-raise the first non-result item so callers see the
+                    # original error (timeout, validation, etc.) instead of a
+                    # generic BatchPipelineError. Every task has already finished
+                    # by the time we get here, so we're not aborting work in flight.
+                    raise r
+                results.append(r)
+        finally:
+            # finally so the re-raise path above still releases the shared sink.
+            # Every task has completed before gather returns, so closing once
+            # here cannot race a concurrent on_step_complete/write_run.
+            await asyncio.to_thread(self._close_sink_quietly, sink)
         _maybe_raise_batch_error(results, resolved_raise)
         return results
 

--- a/libs/core/genblaze_core/sinks/base.py
+++ b/libs/core/genblaze_core/sinks/base.py
@@ -14,6 +14,14 @@ from genblaze_core.models.step import Step
 class BaseSink(ABC):
     """Abstract base for event/manifest sinks."""
 
+    # Lifecycle ownership: when True (default), ``Pipeline.run()``/``arun()``
+    # close this sink in their ``finally`` block — appropriate for sinks whose
+    # resources are run-scoped (e.g. ObjectStorageSink's eager-upload pool and
+    # connection pool). Set False for sinks whose lifecycle is process-scoped
+    # and self-managed (e.g. WebhookSink: a fire-and-forget daemon worker that
+    # flushes via atexit); the pipeline must not close — and block joining — those.
+    _close_with_run: bool = True
+
     @abstractmethod
     def write_run(self, run: Run, manifest: Manifest) -> None:
         """Persist a completed run and its manifest."""
@@ -119,5 +127,27 @@ class BaseSink(ABC):
 
     @abstractmethod
     def close(self) -> None:
-        """Release any held resources."""
+        """Release any held resources.
+
+        Must be idempotent. ``__exit__`` may call it after an explicit
+        ``with sink:`` block, and — for sinks with ``_close_with_run = True``
+        (the default) — ``Pipeline.run()``/``arun()`` also call it in their
+        ``finally`` block. Such a sink is spent once passed to ``run()`` —
+        construct a fresh one per run rather than reusing it. Sinks that set
+        ``_close_with_run = False`` are never closed by the pipeline and remain
+        reusable across runs.
+        """
         ...
+
+    # Context-manager support — convenience for callers that own the sink
+    # lifecycle explicitly (e.g. standalone scripts, tests). For sinks the
+    # pipeline closes (``_close_with_run = True``), the with-pattern is optional
+    # but recommended when constructing the sink outside a run(); wrapping such
+    # a sink in `with sink:` AND passing it to run() calls close() twice — safe
+    # because close() is contractually idempotent (see above).
+
+    def __enter__(self) -> BaseSink:
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        self.close()

--- a/libs/core/genblaze_core/storage/sink.py
+++ b/libs/core/genblaze_core/storage/sink.py
@@ -250,6 +250,9 @@ class ObjectStorageSink(BaseSink):
         self._eager_pool: ThreadPoolExecutor | None = None
         self._eager_pending: dict[str, Future] = {}
         self._eager_lock = threading.Lock()
+        # Guards the terminal backend/Parquet teardown so it fires once even
+        # under double-close. Does NOT gate the eager-pool drain — see close().
+        self._closed = False
 
     def write_run(self, run: Run, manifest: Manifest) -> None:
         try:
@@ -596,6 +599,15 @@ class ObjectStorageSink(BaseSink):
         that errored mid-execution and never called ``write_run`` rely on
         this to flush orphan futures.
 
+        Idempotent — safe to call more than once (e.g. when the pipeline's
+        implicit close and an explicit ``with sink:`` block both fire).
+
+        Always drains whatever eager pool currently exists, even across a
+        prior close: ``on_step_complete`` lazily recreates the pool, so a
+        sink reused for a second run holds a fresh pool that must also be
+        shut down (issue #57). The backend/Parquet teardown is terminal and
+        guarded so it fires exactly once.
+
         Args:
             timeout: If ``None`` (default), waits indefinitely for all
                 in-flight uploads. If set, waits at most ``timeout`` seconds
@@ -604,6 +616,9 @@ class ObjectStorageSink(BaseSink):
                 HTTP uploads cannot be preempted in Python; they complete
                 or exit with the process.
         """
+        # Drain the current eager pool on every call — never gate this on
+        # _closed, or a pool recreated after the first close leaks its
+        # non-daemon workers (the exact regression issue #57 fixes).
         with self._eager_lock:
             pool = self._eager_pool
             self._eager_pool = None
@@ -618,6 +633,11 @@ class ObjectStorageSink(BaseSink):
                 pool.shutdown(wait=False, cancel_futures=True)
                 if pending:
                     _futures_wait(pending, timeout=timeout)
+        # Backend/Parquet teardown is terminal — close exactly once so a
+        # double-close (pipeline finally + an explicit `with sink:`) is safe.
+        if self._closed:
+            return
+        self._closed = True
         self._backend.close()
         if self._parquet_sink is not None:
             self._parquet_sink.close()

--- a/libs/core/genblaze_core/webhooks/notifier.py
+++ b/libs/core/genblaze_core/webhooks/notifier.py
@@ -130,6 +130,19 @@ class WebhookNotifier:
         event = payload.get("event", "")
         if not self._should_send(event):
             return
+        # The worker is one-shot: close() joins it and it never restarts. Warn
+        # once rather than silently queueing events that nothing will deliver if
+        # a caller enqueues after explicitly closing the notifier/sink.
+        if self._closed:
+            self._dropped_count += 1
+            if self._dropped_count == 1 or self._dropped_count % 100 == 0:
+                logger.warning(
+                    "Webhook event dropped: notifier is closed (dropped %d so far). "
+                    "Create a new WebhookSink/WebhookNotifier rather than reusing one "
+                    "after close().",
+                    self._dropped_count,
+                )
+            return
         try:
             self._queue.put_nowait(payload)
         except queue.Full:

--- a/libs/core/genblaze_core/webhooks/sink.py
+++ b/libs/core/genblaze_core/webhooks/sink.py
@@ -22,6 +22,12 @@ class WebhookSink(BaseSink):
         Pipeline("my-pipe").step(...).run(sink=sink)
     """
 
+    # Fire-and-forget: the notifier's daemon worker flushes via atexit, so the
+    # pipeline must NOT close (and block joining) this sink at end of run. That
+    # keeps delivery non-blocking and the sink reusable across runs. Callers who
+    # want a synchronous flush still call close()/`with sink:` explicitly.
+    _close_with_run = False
+
     def __init__(self, config: WebhookConfig) -> None:
         self._notifier = WebhookNotifier(config)
 

--- a/libs/core/tests/unit/test_object_storage_sink.py
+++ b/libs/core/tests/unit/test_object_storage_sink.py
@@ -139,6 +139,14 @@ class TestObjectStorageSink:
         sink.close()
         assert backend.closed
 
+    def test_close_is_idempotent(self):
+        """Double-close must not error — pipeline and context manager may both call it."""
+        backend = MemoryBackend()
+        sink = ObjectStorageSink(backend)
+        sink.close()
+        sink.close()  # second close must be a no-op, not an error
+        assert backend.closed
+
     @patch("genblaze_core.storage.transfer._http_get_stream")
     def test_thread_safety(self, mock_urlopen):
         """Multiple threads calling write_run should not crash."""
@@ -472,6 +480,26 @@ class TestEagerTransfer:
         assert sink._eager_pool is not None
         sink.close()
         assert sink._eager_pool is None
+
+    def test_close_drains_pool_recreated_after_prior_close(self):
+        """close() must drain a pool that on_step_complete recreated after an
+        earlier close — otherwise a sink reused across runs re-leaks its
+        non-daemon eager workers (issue #57 regression guard)."""
+        sink = ObjectStorageSink(MemoryBackend(), eager_transfer=True)
+        step = self._succeeded_step(self._asset("file:///nonexistent"))
+        with patch.object(sink._transfer, "transfer", return_value="key"):
+            # First run cycle: create pool, then close it.
+            sink.on_step_complete(step, run_id="r1", tenant_id=None, date_str="2026-04-22")
+            assert sink._eager_pool is not None
+            sink.close()
+            assert sink._eager_pool is None
+            # Second run cycle on the same sink: pool is recreated lazily.
+            sink.on_step_complete(step, run_id="r2", tenant_id=None, date_str="2026-04-22")
+            assert sink._eager_pool is not None
+        # The second close must drain the recreated pool, not no-op on _closed.
+        sink.close()
+        assert sink._eager_pool is None
+        assert not any(t.name.startswith("genblaze-eager") for t in threading.enumerate())
 
     @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
     @patch("genblaze_core.storage.transfer._http_get_stream")

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -2125,3 +2125,250 @@ def test_bytes_credential_in_params_rejected() -> None:
     token_bytes = b"r8_" + b"A" * 25  # matches the Replicate pattern
     with pytest.raises(GenblazeError, match="looks like an API credential"):
         Pipeline("bytes-creds").step(provider, model="m", prompt="p", api_token=token_bytes).run()
+
+
+# --- Sink lifecycle: pipeline must close the sink after run()/arun() ---
+# Issue #57: eager-upload ThreadPoolExecutor and backend connection pool
+# leaked because _finalize() called write_run but never sink.close().
+
+
+def test_run_calls_sink_close_after_success() -> None:
+    """Pipeline.run() must call sink.close() in its finally block so the
+    eager-transfer pool and backend connection pool are always released."""
+    p = MockProvider()
+    sink = _RecordingSink()
+    Pipeline("close-sync").step(p, model="m", prompt="p").run(sink=sink)
+    assert sink.closed, "sink.close() must be called after a successful run()"
+
+
+def test_run_calls_sink_close_after_step_failure() -> None:
+    """Pipeline.run() must call sink.close() even when a step fails and
+    the run raises (fail_fast=True path raises PipelineError)."""
+    from genblaze_core.exceptions import PipelineError
+
+    class FailingProvider(MockProvider):
+        def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+            raise RuntimeError("provider down")
+
+    sink = _RecordingSink()
+    with pytest.raises(PipelineError):
+        Pipeline("close-on-error").step(FailingProvider(), model="m", prompt="p").run(
+            sink=sink, raise_on_failure=True
+        )
+    assert sink.closed, "sink.close() must be called even when the pipeline fails"
+
+
+@pytest.mark.asyncio
+async def test_arun_calls_sink_close_after_success() -> None:
+    """Pipeline.arun() must call sink.close() in its finally block."""
+    p = MockProvider()
+    sink = _RecordingSink()
+    await Pipeline("close-async").step(p, model="m", prompt="p").arun(sink=sink)
+    assert sink.closed, "sink.close() must be called after a successful arun()"
+
+
+@pytest.mark.asyncio
+async def test_arun_calls_sink_close_after_step_failure() -> None:
+    """Pipeline.arun() must call sink.close() when a step fails."""
+    from genblaze_core.exceptions import PipelineError
+
+    class FailingProvider(MockProvider):
+        def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+            raise RuntimeError("provider down")
+
+    sink = _RecordingSink()
+    with pytest.raises(PipelineError):
+        await (
+            Pipeline("close-async-err")
+            .step(FailingProvider(), model="m", prompt="p")
+            .arun(sink=sink, raise_on_failure=True)
+        )
+    assert sink.closed, "sink.close() must be called even when arun() fails"
+
+
+def test_base_sink_context_manager() -> None:
+    """BaseSink.__enter__/__exit__ must call close() on exit."""
+    from genblaze_core.models.manifest import Manifest
+    from genblaze_core.models.run import Run
+    from genblaze_core.sinks.base import BaseSink
+
+    # Concrete BaseSink subclass to test the mixin protocol.
+    class _ConcreteSink(BaseSink):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def write_run(self, run: Run, manifest: Manifest) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    sink = _ConcreteSink()
+    with sink:
+        assert not sink.closed
+    assert sink.closed, "BaseSink context manager must call close() on __exit__"
+
+
+def test_base_sink_context_manager_calls_close_on_exception() -> None:
+    """BaseSink.__exit__ calls close() even when the body raises."""
+    from genblaze_core.models.manifest import Manifest
+    from genblaze_core.models.run import Run
+    from genblaze_core.sinks.base import BaseSink
+
+    class _ConcreteSink(BaseSink):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def write_run(self, run: Run, manifest: Manifest) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    sink = _ConcreteSink()
+    with pytest.raises(ValueError):
+        with sink:
+            raise ValueError("body error")
+    assert sink.closed, "BaseSink context manager must call close() even on exception"
+
+
+# --- Sink ownership across batch runs and preflight failures (issue #57) ---
+
+
+class _CountingSink:
+    """Sink that counts close()/write_run() and rejects writes after close —
+    so a premature close (e.g. per-item in a batch) surfaces as an error."""
+
+    _close_with_run = True
+
+    def __init__(self) -> None:
+        self.writes = 0
+        self.closes = 0
+        self.closed = False
+
+    def on_step_complete(self, step, *, run_id, tenant_id, date_str) -> None:
+        pass
+
+    def write_run(self, run, manifest) -> None:
+        if self.closed:
+            raise RuntimeError("write_run after close — sink was closed too early")
+        self.writes += 1
+
+    def close(self) -> None:
+        self.closes += 1
+        self.closed = True
+
+
+class _FireAndForgetSink(_CountingSink):
+    """A sink the pipeline must never close (lifecycle is caller/process-scoped)."""
+
+    _close_with_run = False
+
+
+def test_batch_run_closes_shared_sink_once_after_batch() -> None:
+    """The shared sink is closed once AFTER the whole batch — not after item 1,
+    which would make items 2+ write to a closed sink (issue #57)."""
+    sink = _CountingSink()
+    results = (
+        Pipeline("batch-close")
+        .step(MockProvider(), model="m")
+        .batch_run(["a", "b", "c"], sink=sink)
+    )
+    assert len(results) == 3
+    assert sink.writes == 3, "every item must write before the sink is closed"
+    assert sink.closes == 1, "shared sink must be closed exactly once after the batch"
+
+
+@pytest.mark.asyncio
+async def test_abatch_run_closes_shared_sink_once_after_batch() -> None:
+    """Async batch closes the shared sink once after gather, not per item."""
+    sink = _CountingSink()
+    results = await (
+        Pipeline("abatch-close").step(MockProvider(), model="m").abatch_run(["a", "b"], sink=sink)
+    )
+    assert len(results) == 2
+    assert sink.writes == 2
+    assert sink.closes == 1
+
+
+def test_batch_run_closes_sink_even_when_batch_raises() -> None:
+    """A finally guards the batch close, so a BatchPipelineError still releases
+    the shared sink (close happens before the raise)."""
+    from genblaze_core.exceptions import BatchPipelineError
+
+    class FailingProvider(MockProvider):
+        def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+            raise RuntimeError("provider down")
+
+    sink = _CountingSink()
+    with pytest.raises(BatchPipelineError):
+        Pipeline("batch-raise").step(FailingProvider(), model="m").batch_run(
+            ["a", "b"], sink=sink, raise_on_failure=True
+        )
+    assert sink.closes == 1, "shared sink must be closed even when the batch raises"
+
+
+@pytest.mark.asyncio
+async def test_abatch_run_closes_sink_even_when_batch_raises() -> None:
+    """Async batch finally releases the shared sink before BatchPipelineError."""
+    from genblaze_core.exceptions import BatchPipelineError
+
+    class FailingProvider(MockProvider):
+        def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
+            raise RuntimeError("provider down")
+
+    sink = _CountingSink()
+    with pytest.raises(BatchPipelineError):
+        await (
+            Pipeline("abatch-raise")
+            .step(FailingProvider(), model="m")
+            .abatch_run(["a", "b"], sink=sink, raise_on_failure=True)
+        )
+    assert sink.closes == 1
+
+
+def test_batch_run_does_not_close_fire_and_forget_sink() -> None:
+    """A sink with _close_with_run=False is never closed by the batch."""
+    sink = _FireAndForgetSink()
+    Pipeline("batch-faf").step(MockProvider(), model="m").batch_run(["a", "b"], sink=sink)
+    assert sink.writes == 2
+    assert sink.closes == 0, "fire-and-forget sink must not be closed by the pipeline"
+
+
+def test_run_closes_owned_sink_on_preflight_failure(monkeypatch) -> None:
+    """If preflight (_validate_steps) raises before the run body, an owned sink
+    is still closed — the cleanup guard wraps preflight too (issue #57). At this
+    point no step has run, so close only releases construction-time resources
+    (e.g. the connection pool); the eager pool was never created."""
+    from genblaze_core.exceptions import GenblazeError
+
+    sink = _CountingSink()
+    pipe = Pipeline("preflight-fail").step(MockProvider(), model="m")
+
+    def _boom() -> None:
+        raise GenblazeError("preflight failed")
+
+    monkeypatch.setattr(pipe, "_validate_steps", _boom)
+    with pytest.raises(GenblazeError):
+        pipe.run(sink=sink)
+    assert sink.closes == 1, "owned sink must be closed when preflight fails"
+    assert sink.writes == 0, "no run happened, so nothing was written"
+
+
+@pytest.mark.asyncio
+async def test_arun_closes_owned_sink_on_preflight_failure(monkeypatch) -> None:
+    """Async preflight failure also closes an owned sink. arun() offloads
+    preflight via _validate_steps_async(), so patch that method."""
+    from genblaze_core.exceptions import GenblazeError
+
+    sink = _CountingSink()
+    pipe = Pipeline("apreflight-fail").step(MockProvider(), model="m")
+
+    async def _boom() -> None:
+        raise GenblazeError("preflight failed")
+
+    monkeypatch.setattr(pipe, "_validate_steps_async", _boom)
+    with pytest.raises(GenblazeError):
+        await pipe.arun(sink=sink)
+    assert sink.closes == 1
+    assert sink.writes == 0

--- a/libs/core/tests/unit/test_webhook.py
+++ b/libs/core/tests/unit/test_webhook.py
@@ -249,14 +249,31 @@ class TestWebhookNotifier:
         assert payload["step_id"] == "s1"
 
     def test_bounded_queue_drops_and_counts(self):
-        """A full queue drops oldest and increments dropped_count rather than blocking."""
+        """A full queue drops and increments dropped_count rather than blocking."""
+        from genblaze_core.webhooks.notifier import _STOP
+
         notifier = WebhookNotifier(WebhookConfig(url="https://example.com"), queue_maxsize=2)
-        notifier.close(timeout=0.1)  # stop worker so queue fills
+        # Stop the worker draining without marking the notifier closed, so the
+        # enqueue path exercises the queue-full branch (not the closed branch).
+        notifier._queue.put(_STOP)
+        notifier._worker.join(timeout=1.0)
 
         for i in range(20):
             notifier.enqueue({"event": "step.completed", "n": i})
 
         assert notifier.dropped_count > 0
+
+    def test_enqueue_after_close_drops_and_warns(self, caplog):
+        """A WebhookSink reused after close() (e.g. across runs now that the
+        pipeline closes the sink) must not silently queue events to a stopped
+        worker — it drops them and warns (issue #57)."""
+        notifier = WebhookNotifier(WebhookConfig(url="https://example.com"))
+        notifier.close(timeout=1.0)
+        assert notifier._closed
+        with caplog.at_level(logging.WARNING, logger="genblaze.webhook"):
+            notifier.enqueue({"event": "step.completed", "n": 1})
+        assert notifier.dropped_count == 1
+        assert any("notifier is closed" in r.message for r in caplog.records)
 
     def test_ssrf_check_runs_per_delivery(self):
         """open_pinned_https_connection (which calls resolve_ssrf) must be invoked
@@ -436,6 +453,25 @@ class TestWebhookRedirectSsrf:
 
 
 class TestWebhookSink:
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_DNS)
+    def test_not_closed_by_pipeline_run_and_reusable(self, _mock_dns):
+        """WebhookSink is fire-and-forget (_close_with_run=False): run() must not
+        close (and block-join) it, so it stays usable across multiple runs.
+        Regression guard for the 5s teardown stall + per-run close (issue #57)."""
+        assert WebhookSink._close_with_run is False
+
+        conn = _make_mock_conn()
+        with _make_http_patches(conn):
+            sink = WebhookSink(WebhookConfig(url="https://example.com"))
+            Pipeline("wh-1").step(MockProvider(), model="m").run(sink=sink)
+            assert not sink._notifier._closed, "run() must not close a WebhookSink"
+            # Reusable: a second run on the same sink still delivers.
+            Pipeline("wh-2").step(MockProvider(), model="m").run(sink=sink)
+            assert not sink._notifier._closed
+            # Explicit close still works (and flushes).
+            sink.close()
+            assert sink._notifier._closed
+
     @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_DNS)
     def test_write_run_posts_completed(self, _mock_dns):
         conn = _make_mock_conn()


### PR DESCRIPTION
## Summary

Fixes #57. `Pipeline.run()`/`arun()` never released `ObjectStorageSink`'s non-daemon eager-upload `ThreadPoolExecutor` or the S3 connection pool after a run, and an error before `write_run` leaked in-flight upload futures.

The pipeline now releases a sink's **run-scoped** resources in a `finally` block (and on early preflight/validation failure). Lifecycle ownership is explicit via `BaseSink._close_with_run` (default `True`), so the fix doesn't break sinks the pipeline shouldn't close.

## What changed

- **Run-scoped sinks are closed; process-scoped ones aren't.** `ObjectStorageSink` (`_close_with_run=True`) is closed by the pipeline and is single-use. `WebhookSink` sets `_close_with_run=False` — the pipeline never closes it, so webhook delivery stays non-blocking and the sink is reusable across runs (its daemon worker flushes via `atexit`).
- **S3 connection pool actually released.** `S3StorageBackend.close()` now closes the boto3 client (the inherited base `close()` was a no-op).
- **Region auto-correct no longer orphans a client.** `S3StorageBackend._reconfigure_for_region()` closes the outgoing client before replacing it — otherwise the first client's pool would leak and `close()` would release only the new client.
- **Reuse no longer re-leaks.** `ObjectStorageSink.close()` always drains the *current* eager pool (`on_step_complete` recreates it lazily); the `_closed` flag guards only the terminal backend/Parquet teardown.
- **Batch reuse fixed.** `batch_run()`/`abatch_run()` pass `_owns_sink=False` to per-item runs and close the shared sink **once after the whole batch**, in a `finally` so the `BatchPipelineError`/re-raise path still releases it.
- **Preflight failures don't leak.** A validation/preflight failure before the run body closes an owned sink via the shared `_close_sink_quietly()` helper.
- `BaseSink` gains `__enter__`/`__exit__` for standalone use; `arun()` offloads the blocking close to a thread.

## Review history

Earlier revisions auto-closed every sink in `run()`. Successive reviews (EM / OSS / DX, plus follow-ups) surfaced: shared-sink reuse in `batch_run`, a 5s `WebhookSink.close()` join breaking fire-and-forget, a validation-before-`finally` leak, a stale base, and the region-reconfigure client orphan. All are addressed here; the lifecycle-ownership redesign was red-teamed before implementation. Rebased onto current `main` (`2369757`).

## Tests

`make test` green across all 13 packages (core **1682 passed**; S3 connector **247**). `make lint` clean. New/updated coverage:
- batch (sync+async): shared sink closed exactly once after the batch with every item written; still closed on the `BatchPipelineError` path; fire-and-forget sink never closed.
- preflight failure (sync+async) closes an owned sink.
- `WebhookSink` is not closed by `run()` and is reusable across runs.
- `S3StorageBackend.close()` closes the boto3 client; `_reconfigure_for_region()` closes the old client; eager pool drained across a second close.

## Acceptance criteria

- [x] After a normal `run()`, no `ObjectStorageSink` worker threads remain and the backend connection pool is released.
- [x] An error before `write_run` does not leak in-flight eager-upload futures.

## Follow-up (out of scope)

`Pipeline.ingest()` → `ingest_assets(sink=...)` has a related never-closed path; worth a separate tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
