### PR TITLE
fix(chat): remove hardcoded _RATES tables from openai and google chat() helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `__enter__`/`__exit__` for callers that manage the lifecycle outside a
   `run()`. **Behavior change:** a run-scoped sink passed to `run()`/`arun()` is
   closed afterward — construct a fresh one per run rather than reusing it (#57).
+- **`genblaze-openai`**, **`genblaze-google`**: remove hardcoded USD per-token
+  rate tables (`_RATES`) from the standalone `chat()` helpers and return
+  `cost_usd=None` unconditionally, consistent with the 0.3.0 contract that
+  vendor pricing flows through the user-registered `PricingContext`/`ModelSpec`
+  rather than static dicts baked into connectors. Callers that relied on
+  `ChatResponse.cost_usd` being non-`None` for known models must now register
+  rates via the documented recipe in `docs/reference/pricing-recipes.md`. Adds
+  `test_pricing_phaseout.py` to `genblaze-core` — a lint-style CI guard that
+  fails if any future connector reintroduces a `_RATES`/`_PRICING` constant (#13).
 - `genblaze-core`: post-submit step-level retries now resume the existing
   upstream prediction instead of submitting a new one, including transient
   checkpoint failures after `submit()` returns by replaying idempotent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,10 +97,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`genblaze-openai`**, **`genblaze-google`**: remove hardcoded USD per-token
   rate tables (`_RATES`) from the standalone `chat()` helpers and return
   `cost_usd=None` unconditionally, consistent with the 0.3.0 contract that
-  vendor pricing flows through the user-registered `PricingContext`/`ModelSpec`
-  rather than static dicts baked into connectors. Callers that relied on
-  `ChatResponse.cost_usd` being non-`None` for known models must now register
-  rates via the documented recipe in `docs/reference/pricing-recipes.md`. Adds
+  connector modules ship zero static rate tables (Pipeline-Step providers
+  register rates via `PricingContext`/`ModelSpec`). The standalone `chat()`
+  helpers have no model registry, so callers that relied on
+  `ChatResponse.cost_usd` being non-`None` for known models must now compute
+  cost from `tokens_in`/`tokens_out` with their own rates (see
+  `docs/reference/pricing-recipes.md`). Adds
   `test_pricing_phaseout.py` to `genblaze-core` — a lint-style CI guard that
   fails if any future connector reintroduces a `_RATES`/`_PRICING` constant (#13).
 - `genblaze-core`: post-submit step-level retries now resume the existing

--- a/docs/features/llm-calls.md
+++ b/docs/features/llm-calls.md
@@ -66,13 +66,15 @@ pipe = Pipeline("hero").step(SoraProvider(), model="sora-2", prompt=description)
   outbound-text-only.
 - Gemini's `system=` kwarg, when set, supersedes any system message in the
   `messages` list. OpenAI / GMICloud keep both (provider behavior).
-- Pricing tables: OpenAI (gpt-4o family, gpt-4.1, gpt-4-turbo, o-series,
-  gpt-3.5), Gemini (1.5 / 2.0 / 2.5 families). GMICloud returns
-  `cost_usd=None` — fleet shifts faster than a table tracks.
+- `cost_usd` is always `None` for all standalone `chat()` helpers
+  (OpenAI, Gemini, GMICloud). Vendor prices drift too fast for static
+  tables to stay accurate, and `chat()` has no model registry. Compute
+  cost from `tokens_in`/`tokens_out` using your own rates (see
+  `docs/reference/pricing-recipes.md`). `PricingContext` populates cost
+  only on the Pipeline-Step provider path, not here.
 - Model ids pass through verbatim — unknown models aren't blocked
-  client-side, they just get `cost_usd=None` until registered. Matches
-  the "unknown models pass through" convention used by the media
-  provider classes.
+  client-side. Matches the "unknown models pass through" convention used
+  by the media provider classes.
 - Errors are wrapped in `ProviderError` with a classified `error_code`.
 
 ## Verification

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -458,7 +458,10 @@ are live before registering rates against them.
 per-model `pricing={(quality, size): rate}` tables in
 `genblaze_openai/dalle.py` prior to `genblaze-core 0.3.0`. Sora pricing
 was always `None` (correct formula requires per-second `(model, size,
-seconds)` billing; a flat dict misreports 10x+).
+seconds)` billing; a flat dict misreports 10x+). The standalone
+`genblaze_openai.chat()` helper returns `cost_usd=None` unconditionally
+— compute cost yourself, e.g.
+`cost = tokens_in/1e6 * in_rate + tokens_out/1e6 * out_rate`.
 **Snapshot date:** 2026-05-05.
 **Verify at:** [openai.com/pricing](https://openai.com/pricing).
 
@@ -550,9 +553,9 @@ tables and register the new slugs as they appear in the catalog.
 
 **Source:** `_VEO_PER_SECOND_RATES` in `genblaze_google/provider.py` and
 `_IMAGEN_PER_IMAGE_RATES` in `genblaze_google/imagen.py` prior to
-`genblaze-core 0.3.0`. Standalone `genblaze_google.chat()` retains its
-own per-token table — chat is out of scope for the catalog-decoupling
-effort because it isn't a Pipeline-Step provider.
+`genblaze-core 0.3.0`. As of 0.3.0 the standalone `genblaze_google.chat()`
+helper returns `cost_usd=None` unconditionally — compute cost from
+`tokens_in`/`tokens_out` and your own rates if needed.
 **Snapshot date:** 2026-05-05.
 **Verify at:** [ai.google.dev/pricing](https://ai.google.dev/pricing)
 and [cloud.google.com/vertex-ai/generative-ai/pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing).

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -553,9 +553,9 @@ tables and register the new slugs as they appear in the catalog.
 
 **Source:** `_VEO_PER_SECOND_RATES` in `genblaze_google/provider.py` and
 `_IMAGEN_PER_IMAGE_RATES` in `genblaze_google/imagen.py` prior to
-`genblaze-core 0.3.0`. As of 0.3.0 the standalone `genblaze_google.chat()`
-helper returns `cost_usd=None` unconditionally — compute cost from
-`tokens_in`/`tokens_out` and your own rates if needed.
+`genblaze-core 0.3.0`. Starting with this release the standalone
+`genblaze_google.chat()` helper returns `cost_usd=None` unconditionally —
+compute cost from `tokens_in`/`tokens_out` and your own rates if needed.
 **Snapshot date:** 2026-05-05.
 **Verify at:** [ai.google.dev/pricing](https://ai.google.dev/pricing)
 and [cloud.google.com/vertex-ai/generative-ai/pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing).

--- a/libs/connectors/google/genblaze_google/chat.py
+++ b/libs/connectors/google/genblaze_google/chat.py
@@ -15,42 +15,6 @@ from genblaze_core.providers.retry import retry_after_from_response
 
 from genblaze_google._errors import map_google_error
 
-# Per-1M-token rates (USD). Input, output. Tiered models (1.5-pro, 2.5-pro)
-# use the small-context rate by default; large-context surcharges aren't
-# applied without inspecting prompt length, which we leave to the caller.
-_RATES: dict[str, tuple[float, float]] = {
-    "gemini-2.5-pro": (1.25, 10.00),
-    "gemini-2.5-flash": (0.30, 2.50),
-    "gemini-2.5-flash-lite": (0.10, 0.40),
-    "gemini-2.0-flash": (0.10, 0.40),
-    "gemini-2.0-flash-lite": (0.075, 0.30),
-    "gemini-1.5-pro": (1.25, 5.00),
-    "gemini-1.5-flash": (0.075, 0.30),
-    "gemini-1.5-flash-8b": (0.0375, 0.15),
-}
-
-
-def _lookup_rate(model: str) -> tuple[float, float] | None:
-    """Resolve rate row, ignoring trailing version suffix like `-001` or `-latest`."""
-    if model in _RATES:
-        return _RATES[model]
-    # Strip a trailing `-NNN` or `-latest` so dated/versioned slugs reuse the family row.
-    parts = model.rsplit("-", 1)
-    if len(parts) == 2 and (parts[1].isdigit() or parts[1] in ("latest", "exp")):
-        return _RATES.get(parts[0])
-    return None
-
-
-def _calc_cost(model: str, tokens_in: int | None, tokens_out: int | None) -> float | None:
-    if tokens_in is None or tokens_out is None:
-        return None
-    rate = _lookup_rate(model)
-    if rate is None:
-        return None
-    in_rate, out_rate = rate
-    return (tokens_in / 1_000_000) * in_rate + (tokens_out / 1_000_000) * out_rate
-
-
 # Gemini uses "model" / "user" roles; "assistant" maps to "model".
 _ROLE_MAP = {"user": "user", "assistant": "model", "system": "user", "tool": "user"}
 
@@ -154,7 +118,7 @@ def _parse_response(model: str, raw: Any) -> ChatResponse:
         tokens_out=tokens_out,
         tokens_cached=cached,
         tool_calls=tool_calls,
-        cost_usd=_calc_cost(model, tokens_in, tokens_out),
+        cost_usd=None,  # chat() reports no cost; compute from tokens_in/out with your own rates.
         raw=raw_dict,
     )
 

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -191,7 +191,7 @@ def test_api_error_wrapped(mock_client):
 
 
 def test_cost_usd_always_none(mock_client):
-    # cost_usd is always None — callers register rates via PricingContext.
+    # cost_usd is always None — callers compute cost from tokens_in/out with their own rates.
     resp = chat("gemini-2.5-flash", prompt="hi", client=mock_client)
     assert resp.cost_usd is None
 

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -9,7 +9,7 @@ import pytest
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.chat import ChatMessage
 from genblaze_core.models.enums import ProviderErrorCode
-from genblaze_google.chat import _calc_cost, _lookup_rate, achat, chat
+from genblaze_google.chat import achat, chat
 
 
 def _mock_response(
@@ -190,21 +190,10 @@ def test_api_error_wrapped(mock_client):
     assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
 
 
-def test_cost_for_known_model(mock_client):
+def test_cost_usd_always_none(mock_client):
+    # cost_usd is always None — callers register rates via PricingContext.
     resp = chat("gemini-2.5-flash", prompt="hi", client=mock_client)
-    # 10 in * 0.30/1M + 5 out * 2.50/1M
-    expected = (10 / 1_000_000) * 0.30 + (5 / 1_000_000) * 2.50
-    assert resp.cost_usd is not None
-    assert abs(resp.cost_usd - expected) < 1e-9
-
-
-def test_lookup_rate_strips_version_suffix():
-    assert _lookup_rate("gemini-2.5-flash-001") == _lookup_rate("gemini-2.5-flash")
-    assert _lookup_rate("gemini-2.5-flash-latest") == _lookup_rate("gemini-2.5-flash")
-
-
-def test_calc_cost_returns_none_when_tokens_missing():
-    assert _calc_cost("gemini-2.5-flash", None, 5) is None
+    assert resp.cost_usd is None
 
 
 def test_achat_runs_in_thread(mock_client):

--- a/libs/connectors/openai/genblaze_openai/chat.py
+++ b/libs/connectors/openai/genblaze_openai/chat.py
@@ -15,45 +15,6 @@ from genblaze_core.providers.retry import retry_after_from_response
 
 from genblaze_openai._errors import map_openai_error
 
-# Per-1M-token rates (USD). Input, output. Cached prompt rate is 50% of input
-# for OpenAI's prompt-caching tier on supported models.
-# Snapshot dates trim to the family slug so dated variants reuse the same row.
-_RATES: dict[str, tuple[float, float]] = {
-    "gpt-4o": (2.50, 10.00),
-    "gpt-4o-mini": (0.15, 0.60),
-    "gpt-4.1": (2.00, 8.00),
-    "gpt-4.1-mini": (0.40, 1.60),
-    "gpt-4.1-nano": (0.10, 0.40),
-    "gpt-4-turbo": (10.00, 30.00),
-    "gpt-4": (30.00, 60.00),
-    "gpt-3.5-turbo": (0.50, 1.50),
-    "o1": (15.00, 60.00),
-    "o1-mini": (3.00, 12.00),
-    "o3-mini": (1.10, 4.40),
-}
-
-
-def _lookup_rate(model: str) -> tuple[float, float] | None:
-    """Resolve a rate row for `model`, stripping dated `-YYYY-MM-DD` suffixes."""
-    if model in _RATES:
-        return _RATES[model]
-    # Strip a `-YYYY-MM-DD` snapshot suffix (e.g. gpt-4o-2024-11-20 → gpt-4o).
-    parts = model.rsplit("-", 3)
-    if len(parts) >= 4 and all(p.isdigit() for p in parts[1:4]):
-        return _RATES.get(parts[0])
-    return None
-
-
-def _calc_cost(model: str, tokens_in: int | None, tokens_out: int | None) -> float | None:
-    """Compute USD cost from token counts; None when model isn't in the table."""
-    if tokens_in is None or tokens_out is None:
-        return None
-    rate = _lookup_rate(model)
-    if rate is None:
-        return None
-    in_rate, out_rate = rate
-    return (tokens_in / 1_000_000) * in_rate + (tokens_out / 1_000_000) * out_rate
-
 
 def _normalize_messages(
     messages: list[ChatMessage] | list[dict] | None,
@@ -138,7 +99,7 @@ def _parse_response(model: str, raw: Any) -> ChatResponse:
         tokens_out=tokens_out,
         tokens_cached=cached,
         tool_calls=tool_calls,
-        cost_usd=_calc_cost(model, tokens_in, tokens_out),
+        cost_usd=None,  # chat() reports no cost; compute from tokens_in/out with your own rates.
         raw=raw_dict,
     )
 

--- a/libs/connectors/openai/tests/test_chat.py
+++ b/libs/connectors/openai/tests/test_chat.py
@@ -8,7 +8,7 @@ import pytest
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.chat import ChatMessage
 from genblaze_core.models.enums import ProviderErrorCode
-from genblaze_openai.chat import _calc_cost, _lookup_rate, achat, chat
+from genblaze_openai.chat import achat, chat
 
 
 def _mock_completion(
@@ -254,27 +254,10 @@ def test_api_error_wrapped(mock_client):
     assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
 
 
-def test_cost_computed_for_known_model(mock_client):
+def test_cost_usd_always_none(mock_client):
+    # cost_usd is always None — callers register rates via PricingContext.
     resp = chat("gpt-4o", prompt="hi", client=mock_client)
-    # 10 in * 2.50/1M + 5 out * 10.00/1M = 0.000025 + 0.00005 = 7.5e-5
-    assert resp.cost_usd is not None
-    assert abs(resp.cost_usd - 7.5e-5) < 1e-9
-
-
-def test_cost_none_for_unknown_model(mock_client):
-    mock_client.chat.completions.create.return_value = _mock_completion(model="foo-bar")
-    resp = chat("foo-bar", prompt="hi", client=mock_client)
     assert resp.cost_usd is None
-
-
-def test_lookup_rate_strips_dated_suffix():
-    assert _lookup_rate("gpt-4o-2024-11-20") == _lookup_rate("gpt-4o")
-    assert _lookup_rate("gpt-4o-mini-2024-07-18") == _lookup_rate("gpt-4o-mini")
-
-
-def test_calc_cost_returns_none_when_tokens_missing():
-    assert _calc_cost("gpt-4o", None, 5) is None
-    assert _calc_cost("gpt-4o", 5, None) is None
 
 
 def test_achat_runs_in_thread(mock_client):

--- a/libs/connectors/openai/tests/test_chat.py
+++ b/libs/connectors/openai/tests/test_chat.py
@@ -255,7 +255,7 @@ def test_api_error_wrapped(mock_client):
 
 
 def test_cost_usd_always_none(mock_client):
-    # cost_usd is always None — callers register rates via PricingContext.
+    # cost_usd is always None — callers compute cost from tokens_in/out with their own rates.
     resp = chat("gpt-4o", prompt="hi", client=mock_client)
     assert resp.cost_usd is None
 

--- a/libs/core/genblaze_core/models/chat.py
+++ b/libs/core/genblaze_core/models/chat.py
@@ -226,7 +226,11 @@ class ChatResponse(BaseModel):
     )
     cost_usd: float | None = Field(
         default=None,
-        description="Estimated USD cost from the connector's static rate table; None if unknown.",
+        description=(
+            "Estimated USD cost. Standalone chat() helpers always return None here — "
+            "callers compute cost from tokens_in/tokens_out using their own rates "
+            "(see docs/reference/pricing-recipes.md)."
+        ),
     )
     raw: dict[str, Any] = Field(
         default_factory=dict, description="Provider's raw response dict — escape hatch."

--- a/libs/core/tests/unit/test_pricing_phaseout.py
+++ b/libs/core/tests/unit/test_pricing_phaseout.py
@@ -1,0 +1,137 @@
+"""Lint-style guard: no hardcoded USD rate tables in connector source files.
+
+The 0.3.0 contract mandates zero `_RATES`-style constants in any
+`libs/connectors/*/genblaze_*/` module. This test enforces that invariant so
+new connectors (including standalone `chat()` helpers) cannot reintroduce
+static pricing tables without failing CI.
+
+Detection is two-step to stay precise:
+1. Find identifiers assigned a dict literal (``NAME = {`` / ``NAME: T = {``).
+2. Flag the name only if one of its words is a money term (rate(s), price(s),
+   pricing, cost(s)).
+
+Requiring a dict literal on the RHS is what separates a rate *table* from a
+benign scalar like ``_rate_limit_max = 5`` or the public ``cost_usd`` field;
+the word match (not a substring match) keeps names like ``_operate`` or
+``sample_rate`` from tripping the guard. See the fixtures below — they pin
+both halves so a future edit can't silently widen or neuter the matcher.
+
+Excluded paths:
+- `tests/` subdirectories
+- `__pycache__` directories
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Root of the monorepo: libs/core/tests/unit/ is 4 levels deep.
+_REPO_ROOT = Path(__file__).parents[4]
+_CONNECTORS_ROOT = _REPO_ROOT / "libs" / "connectors"
+
+# Money terms that mark an identifier as a pricing/rate table when bound to a
+# dict. Matched as whole words (after splitting the identifier), never as
+# substrings, so `_operate` ("rate") and `_corporate` do not trip the guard.
+_MONEY_WORDS = frozenset({"rate", "rates", "price", "prices", "pricing", "cost", "costs"})
+
+# Splits an identifier into its words, handling SCREAMING_SNAKE, snake_case, and
+# camelCase (e.g. `_VEO_PER_SECOND_RATES` -> {veo, per, second, rates}).
+_WORD_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z]+|[a-z]+")
+
+# An assignment whose right-hand side opens a dict literal, with an optional
+# type annotation: `NAME = {`, `NAME: dict[str, float] = {`. MULTILINE so it
+# matches indented class-body assignments too.
+_DICT_ASSIGN_RE = re.compile(
+    r"^[ \t]*(?P<name>[A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*[^\n]*\{",
+    re.MULTILINE,
+)
+
+
+def _is_money_name(name: str) -> bool:
+    """True if any word in the identifier is a pricing/rate/cost term."""
+    return bool({w.lower() for w in _WORD_RE.findall(name)} & _MONEY_WORDS)
+
+
+def _find_rate_tables(source: str) -> list[tuple[int, str]]:
+    """Return (line_number, name) for every money-named dict assignment."""
+    hits: list[tuple[int, str]] = []
+    for match in _DICT_ASSIGN_RE.finditer(source):
+        name = match.group("name")
+        if _is_money_name(name):
+            line = source[: match.start()].count("\n") + 1
+            hits.append((line, name))
+    return hits
+
+
+def _connector_source_files() -> list[Path]:
+    """Return all connector .py source files, excluding tests/ and __pycache__."""
+    files: list[Path] = []
+    for py in _CONNECTORS_ROOT.rglob("*.py"):
+        parts = py.parts
+        # Skip test directories and compiled caches.
+        if any(p in ("tests", "__pycache__") for p in parts):
+            continue
+        files.append(py)
+    return files
+
+
+def test_rate_table_matcher_fixtures():
+    """Pin the matcher: it must fire on rate tables and stay quiet on look-alikes.
+
+    Guards against the matcher silently breaking (a regex that matches nothing
+    would otherwise make the contract test below pass vacuously).
+    """
+    should_match = [
+        "_RATES = {",
+        "_TOKEN_RATES = {",
+        "_VEO_PER_SECOND_RATES = {",  # historical google offender
+        "_IMAGEN_PER_IMAGE_RATES = {",  # historical google offender
+        "_token_rates = {",
+        "MODEL_PRICING = {",
+        "_PRICE_TABLE = {",
+        "_RATES: dict[str, float] = {",
+        "    _COST_PER_SEC = {",  # indented class-body assignment
+    ]
+    should_not_match = [
+        "cost_usd = None",  # the public ChatResponse field
+        "sample_rate = 16000",
+        "_rate_limit_max = 5",  # scalar, not a table
+        "_price = 1.0",  # scalar
+        "_PRICE: float = 1.0",  # annotated scalar
+        "_operate = {",  # 'rate' is a substring, not a word
+        "register_pricing(slug, strategy)",  # registry call, not an assignment
+    ]
+    for snippet in should_match:
+        assert _find_rate_tables(snippet), f"matcher missed rate table: {snippet!r}"
+    for snippet in should_not_match:
+        assert not _find_rate_tables(snippet), f"matcher false-positive: {snippet!r}"
+
+
+def test_no_hardcoded_rate_tables_in_connectors():
+    """All connector modules must be free of hardcoded USD rate dictionaries.
+
+    Pricing must flow through the user-registered model registry
+    (PricingContext / ModelSpec.pricing) for Pipeline-Step providers, or be
+    computed by the caller from token counts for standalone chat() helpers —
+    never a static dict baked into the module.
+    """
+    files = _connector_source_files()
+    # Fail loud if the scan target moved or the tree is absent, so the guard
+    # can never pass vacuously by silently scanning zero files.
+    assert files, f"no connector source files found under {_CONNECTORS_ROOT}"
+
+    offenders: list[str] = []
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        rel = path.relative_to(_REPO_ROOT)
+        for line, name in _find_rate_tables(source):
+            offenders.append(f"{rel}:{line}: {name}")
+
+    assert not offenders, (
+        "Hardcoded USD rate tables found in connector source files. "
+        "Remove the rate/price dict and return cost_usd=None; callers compute "
+        "cost from token counts, or Pipeline-Step providers register rates via "
+        "PricingContext / ModelSpec.pricing. Offenders:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+    )


### PR DESCRIPTION
Closes #13.

## Problem
The standalone `chat()` helpers in `genblaze-openai` and `genblaze-google` still carried hardcoded `_RATES` per-token price dicts plus `_lookup_rate()`/`_calc_cost()`, wiring USD figures into `ChatResponse.cost_usd`. This violated the 0.3.0 contract ("zero `_RATES` constants in any connector module"). `gmicloud`/`nvidia` were already compliant. The promised lint guard was never written, so the regression went undetected.

## Change
- Removed `_RATES`, `_lookup_rate`, `_calc_cost` from both `chat()` helpers; `cost_usd` is now always `None`, consistent with `gmicloud`/`nvidia`.
- Added the missing `test_pricing_phaseout.py` CI guard. Two-step matcher: find dict-literal assignments, then flag only names whose **words** (not substrings) are money terms (rate/price/cost). Requiring a dict RHS separates a rate *table* from scalars like `_rate_limit_max`; word-matching keeps `_operate`/`sample_rate` clean. Catches prefixed/suffixed forms (`_TOKEN_RATES`, `_VEO_PER_SECOND_RATES`) that a naive `_RATES` check misses. Behavior pinned by inline fixtures; fails loud if the scan target is ever empty.
- Updated `ChatResponse.cost_usd` field doc, `docs/features/llm-calls.md`, and `docs/reference/pricing-recipes.md` to reflect the new contract.

## Behavior change for callers
`cost_usd` from these `chat()` helpers is now always `None`. Callers must compute cost from `tokens_in`/`tokens_out` with their own rates (see `docs/reference/pricing-recipes.md`). `PricingContext` populates cost only on the Pipeline-Step provider path, not `chat()`.

## Verification
- `test_pricing_phaseout.py`: 2 passed · openai `test_chat`: 22 passed · google `test_chat`: 14 passed
- `make lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)