### PR TITLE
fix(tools): cover optional-dependency extras in pin-parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Run CLI tests
         run: |
           cd cli && pytest tests/ -v
+      - name: Run release-tooling tests
+        run: |
+          pytest tools/tests/ -v
       - name: Upload coverage
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `tools/check_pin_parity.py`: extend the pre-publish drift guard to
+  compare `[project.optional-dependencies]` as well as base
+  `[project.dependencies]`. Previously the gate reported
+  `0 drift` for the `genblaze` umbrella even when connector pins in
+  the `all`, `video`, `image`, or `audio` extras diverged from the
+  published wheel, because `Requires-Dist` extras entries were
+  silently filtered out. The gate now groups PyPI extras by name and
+  diffs each extra independently, naming the extra in the drift
+  report (e.g. `[all]`). Adds `tools/tests/test_check_pin_parity.py`
+  and wires `pytest tools/tests/` into `make test`. Updates
+  RELEASING.md to accurately describe the gate's scope (#23).
+
 ### Added
 
 - `genblaze-hume`: new provider adapter for Hume AI **Octave TTS** (audio /

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ test:
 	cd libs/connectors/assemblyai && pytest -v
 	cd cli && pytest tests/ -v
 	cd libs/meta && pytest tests/ -v
+	pytest tools/tests/ -v
 
 lint:
 	ruff check libs/ cli/ examples/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -121,13 +121,21 @@ Notes on the graph:
   imports every connector. Catches version-pin mismatches before PyPI
   sees them.
 * **`pin-parity`** — for every package, compares source
-  `[project.dependencies]` against the wheel already on PyPI at the
-  same version. Fails the release if they diverge. Closes the
+  `[project.dependencies]` **and** `[project.optional-dependencies]`
+  against the wheel already on PyPI at the same version. Fails the
+  release if either base deps or any extra group diverges. Closes the
   `skip-existing` trap that shipped twice (s3 in 0.3.0, langsmith +
   cli in 0.3.2): without this gate, a package whose pin was widened
   in source but whose version was never bumped will be silently
-  skipped on every release, leaving the broken wheel resolvable. Run
-  locally via `make pypi-pin-parity` (also bundled into
+  skipped on every release, leaving the broken wheel resolvable. This
+  is especially important for the `genblaze` umbrella, whose
+  connector pins and `video`/`image`/`audio`/`all` bundles all live
+  under `[project.optional-dependencies]`. **Every** extra the wheel
+  ships is compared — including tooling extras like `dev`/`testing` —
+  since a stale pin in any published extra is still silently kept by
+  `skip-existing`. Extra names match case- and separator-insensitively
+  (PEP 685), so `stability-audio` and `stability_audio` are one extra.
+  Run locally via `make pypi-pin-parity` (also bundled into
   `make pre-release`).
 * **`publish-core`** — must publish first; everything else pins it.
 * **`publish-cli` + `publish-connectors`** — fan out in parallel. The

--- a/tools/check_pin_parity.py
+++ b/tools/check_pin_parity.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 Pre-publish drift guard: for every Genblaze package, compare its source
-``[project.dependencies]`` to the wheel already published on PyPI at the
-same version. If they diverge, fail loudly.
+``[project.dependencies]`` and ``[project.optional-dependencies]`` to the
+wheel already published on PyPI at the same version. If they diverge,
+fail loudly.
 
 Why this exists
 ---------------
@@ -32,18 +33,27 @@ How comparison works
 --------------------
 For each package:
 
-1. Read source ``[project.dependencies]`` from its ``pyproject.toml``.
-2. Fetch ``https://pypi.org/pypi/<name>/<version>/json`` and extract
-   the wheel's base ``Requires-Dist`` (entries without ``; extra ==``).
+1. Read source ``[project.dependencies]`` and
+   ``[project.optional-dependencies]`` from its ``pyproject.toml``.
+2. Fetch ``https://pypi.org/pypi/<name>/<version>/json`` and split the
+   wheel's ``Requires-Dist`` into base deps (no ``; extra ==`` marker)
+   and per-extra groups (entries with ``; extra == "name"``).
 3. Parse both sides with ``packaging.requirements.Requirement``,
-   normalize specifier sets to sorted form, compare.
+   normalize specifier sets to sorted form, compare base deps and each
+   extra group independently.
+
+This is critical for the ``genblaze`` umbrella package: its base deps
+are only ``genblaze-core`` and ``genblaze-s3``, while every connector
+pin and the ``video``/``image``/``audio``/``all`` bundles live under
+``[project.optional-dependencies]``. The old check reported
+``16 parity, 0 drift`` even when those extras diverged.
 
 Skipped cases (not errors):
 
 * Package source version is not on PyPI yet — a fresh wheel will
   publish; nothing to compare.
 * Package's source ``[project.dependencies]`` is empty AND PyPI's
-  ``Requires-Dist`` for base deps is empty.
+  ``Requires-Dist`` for base deps is empty (and no extras on either side).
 
 Exit codes: 0 on parity, 1 on drift, 2 on unexpected error.
 """
@@ -51,6 +61,7 @@ Exit codes: 0 on parity, 1 on drift, 2 on unexpected error.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -127,17 +138,105 @@ def normalize(req_str: str) -> tuple:
     )
 
 
+# A single ``extra == "name"`` / ``extra == 'name'`` marker clause. Used to
+# pick the extra term out of a marker after splitting on ``and`` — bounded
+# (``[^"']+``) so it can't swallow trailing clauses the way an unbounded
+# string split would.
+_EXTRA_CLAUSE_RE = re.compile(r"""^extra\s*==\s*["']([^"']+)["']$""")
+
+
+def canon_extra(name: str) -> str:
+    """Canonicalize an extra name per PEP 503/685 (lowercase; ``_.-`` → ``-``).
+
+    Build backends normalize extra names when rendering ``Requires-Dist``
+    (PEP 685: ``Stability_Audio`` → ``stability-audio``), but the source
+    ``[project.optional-dependencies]`` table is keyed by whatever the
+    maintainer typed. Canonicalize both sides so the same logical extra
+    compares equal regardless of underscore/dash/case spelling.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def split_extra(dep: str) -> tuple[str | None, str]:
+    """Split a ``Requires-Dist`` entry into ``(extra_name, requirement)``.
+
+    PyPI flattens extras into ``Requires-Dist`` by appending an
+    ``; extra == "name"`` clause to each entry's marker. To compare against
+    the source ``[project.optional-dependencies]`` table — whose entries
+    carry no ``extra`` marker but may carry others (e.g.
+    ``python_version``) — we strip *only* the ``extra`` clause and keep any
+    residual marker intact, so equivalent entries normalize equal.
+
+    Returns ``(None, dep)`` for a base dependency (no ``extra`` clause).
+    Otherwise returns the canonicalized extra name and the requirement
+    string with the ``extra`` clause removed (residual marker preserved,
+    or omitted when ``extra`` was the only marker term).
+
+    Extras markers are always AND-conjunctions, so splitting the marker on
+    ``and`` and dropping the ``extra`` clause is well-defined no matter
+    where the build backend places it (first, middle, or last).
+    """
+    req = Requirement(dep)
+    if req.marker is None:
+        return (None, dep)
+
+    extra_name: str | None = None
+    residual: list[str] = []
+    for clause in re.split(r"\s+and\s+", str(req.marker)):
+        match = _EXTRA_CLAUSE_RE.match(clause.strip())
+        if match:
+            extra_name = match.group(1)
+        else:
+            residual.append(clause.strip())
+
+    if extra_name is None:
+        return (None, dep)
+
+    # Keep the requirement text (everything before the marker's ``;``)
+    # verbatim so the drift report shows pins as written, then re-attach
+    # any residual (non-extra) marker for like-for-like comparison.
+    req_part = dep.split(";", 1)[0].strip()
+    if residual:
+        return (canon_extra(extra_name), f"{req_part}; {' and '.join(residual)}")
+    return (canon_extra(extra_name), req_part)
+
+
 def base_deps_from_pypi(requires_dist: list[str] | None) -> list[str]:
     """Filter PyPI ``Requires-Dist`` to entries without an extra marker.
 
     PyPI returns every dependency — base AND extras — flattened into a
-    single list. Extras are marked with ``; extra == "name"``. We only
-    compare base deps because that's where the trap lives; extras are
-    handled by ``check_pypi_metadata.py``.
+    single list. Extras carry an ``; extra == "name"`` marker clause. This
+    returns only the base (unconditional) entries; use ``extras_from_pypi``
+    to retrieve the per-extra groups.
     """
     if not requires_dist:
         return []
-    return [d for d in requires_dist if "extra ==" not in d]
+    return [dep for dep in requires_dist if split_extra(dep)[0] is None]
+
+
+def extras_from_pypi(requires_dist: list[str] | None) -> dict[str, list[str]]:
+    """Group PyPI ``Requires-Dist`` entries that carry an ``extra ==`` marker.
+
+    Returns a dict mapping canonicalized extra name to a list of plain
+    requirement strings (the ``extra`` clause is stripped so each entry
+    parses directly with ``packaging.requirements.Requirement``).
+
+    For example::
+
+        'genblaze-openai>=0.3.0,<0.4; extra == "openai"'
+
+    becomes ``{"openai": ["genblaze-openai>=0.3.0,<0.4"]}``.
+    """
+    if not requires_dist:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    for dep in requires_dist:
+        extra_name, requirement = split_extra(dep)
+        if extra_name is None:
+            continue
+        result.setdefault(extra_name, []).append(requirement)
+    return result
 
 
 def fetch_pypi_metadata(name: str, version: str) -> dict | None:
@@ -162,9 +261,15 @@ def check_package(pkg_path: Path, repo_root: Path) -> tuple[str, str, list[str] 
     """Check one package. Returns (status, name, details).
 
     Status is one of:
-      "match"      — source and PyPI agree
+      "match"      — source and PyPI agree (base deps and all extras)
       "unreleased" — source version not on PyPI yet (fresh publish)
       "drift"      — divergence detected; details is a list of lines for the error report
+
+    Compares both ``[project.dependencies]`` (base deps) and every key
+    in ``[project.optional-dependencies]`` against the corresponding
+    ``Requires-Dist`` entries on the published PyPI wheel. This closes
+    the gap for the ``genblaze`` umbrella, whose connector pins and
+    bundle extras all live under ``[project.optional-dependencies]``.
     """
     pyproject = repo_root / pkg_path / "pyproject.toml"
     with open(pyproject, "rb") as f:
@@ -172,36 +277,60 @@ def check_package(pkg_path: Path, repo_root: Path) -> tuple[str, str, list[str] 
     name = cfg["project"]["name"]
     version = cfg["project"]["version"]
     source_deps: list[str] = cfg["project"].get("dependencies", [])
+    # Key source extras by their canonical name so they line up with the
+    # backend-normalized names PyPI reports (see canon_extra).
+    source_extras: dict[str, list[str]] = {
+        canon_extra(name): deps
+        for name, deps in cfg["project"].get("optional-dependencies", {}).items()
+    }
 
     metadata = fetch_pypi_metadata(name, version)
     if metadata is None:
         return ("unreleased", f"{name}=={version}", None)
 
-    pypi_deps = base_deps_from_pypi(metadata.get("info", {}).get("requires_dist"))
+    requires_dist = metadata.get("info", {}).get("requires_dist")
+    pypi_base = base_deps_from_pypi(requires_dist)
+    pypi_extras = extras_from_pypi(requires_dist)
 
-    src_norm = sorted(normalize(d) for d in source_deps)
-    pypi_norm = sorted(normalize(d) for d in pypi_deps)
+    # Collect drift lines keyed by section label for the report.
+    lines: list[str] = []
 
-    if src_norm == pypi_norm:
+    def _diff_section(label: str, src: list[str], pypi: list[str]) -> None:
+        """Append drift lines for one dependency section (base or an extra)."""
+        src_norm = sorted(normalize(d) for d in src)
+        pypi_norm = sorted(normalize(d) for d in pypi)
+        if src_norm == pypi_norm:
+            return
+        src_set = {normalize(d): d for d in src}
+        pypi_set = {normalize(d): d for d in pypi}
+        only_src = sorted(src_set[k] for k in src_set if k not in pypi_set)
+        only_pypi = sorted(pypi_set[k] for k in pypi_set if k not in src_set)
+        lines.append(f"  {label}")
+        if only_src:
+            lines.append("    Only in source (would publish):")
+            for d in only_src:
+                lines.append(f"      + {d}")
+        if only_pypi:
+            lines.append(f"    Only on PyPI {version} wheel (would be silently kept):")
+            for d in only_pypi:
+                lines.append(f"      - {d}")
+
+    _diff_section("base deps", source_deps, pypi_base)
+
+    # Check every extra that appears in either source or PyPI.
+    all_extra_names = sorted(set(source_extras) | set(pypi_extras))
+    for extra_name in all_extra_names:
+        _diff_section(
+            f"[{extra_name}]",
+            source_extras.get(extra_name, []),
+            pypi_extras.get(extra_name, []),
+        )
+
+    if not lines:
         return ("match", f"{name}=={version}", None)
 
-    # Build a maintainer-friendly diff report.
-    src_set = {normalize(d): d for d in source_deps}
-    pypi_set = {normalize(d): d for d in pypi_deps}
-    only_in_source = sorted(src_set[k] for k in src_set if k not in pypi_set)
-    only_on_pypi = sorted(pypi_set[k] for k in pypi_set if k not in src_set)
-
-    lines: list[str] = []
-    lines.append(f"{name}=={version}")
-    if only_in_source:
-        lines.append("    Only in source (would publish):")
-        for d in only_in_source:
-            lines.append(f"      + {d}")
-    if only_on_pypi:
-        lines.append(f"    Only on PyPI {version} wheel (would be silently kept):")
-        for d in only_on_pypi:
-            lines.append(f"      - {d}")
-    return ("drift", f"{name}=={version}", lines)
+    report = [f"{name}=={version}"] + lines
+    return ("drift", f"{name}=={version}", report)
 
 
 def main() -> int:

--- a/tools/tests/test_check_pin_parity.py
+++ b/tools/tests/test_check_pin_parity.py
@@ -1,0 +1,434 @@
+"""Tests for tools/check_pin_parity.py.
+
+Covers the core parsing and comparison logic without hitting the network.
+All PyPI-fetching is replaced by fixtures that return pre-canned metadata.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# The tools/ dir is not on sys.path by default. Add its parent so we
+# can import check_pin_parity as a module.
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import check_pin_parity as cpp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# normalize() — parsing and structural equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_simple():
+    assert cpp.normalize("packaging>=21.0") == ("packaging", (">=21.0",), (), None)
+
+
+def test_normalize_name_is_lowercased_and_canonicalized():
+    assert cpp.normalize("My_Package>=1.0")[0] == "my-package"
+
+
+def test_normalize_multi_specifier_is_sorted():
+    a = cpp.normalize("foo<0.4,>=0.3.0")
+    b = cpp.normalize("foo>=0.3.0,<0.4")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# base_deps_from_pypi() — strips extras entries
+# ---------------------------------------------------------------------------
+
+
+def test_base_deps_strips_extra_markers():
+    requires_dist = [
+        "genblaze-core>=0.3.0,<0.4",
+        'genblaze-openai>=0.3.0,<0.4; extra == "openai"',
+        'genblaze-all>=0.3.0,<0.4; extra == "all"',
+    ]
+    result = cpp.base_deps_from_pypi(requires_dist)
+    assert result == ["genblaze-core>=0.3.0,<0.4"]
+
+
+def test_base_deps_handles_none():
+    assert cpp.base_deps_from_pypi(None) == []
+
+
+def test_base_deps_handles_empty():
+    assert cpp.base_deps_from_pypi([]) == []
+
+
+# ---------------------------------------------------------------------------
+# extras_from_pypi() — NEW: groups extras by name
+# ---------------------------------------------------------------------------
+
+
+def test_extras_from_pypi_groups_by_extra_name():
+    requires_dist = [
+        "genblaze-core>=0.3.0,<0.4",
+        'genblaze-openai>=0.3.0,<0.4; extra == "openai"',
+        'genblaze-runway>=0.3.0,<0.4; extra == "video"',
+        'genblaze-luma>=0.3.0,<0.4; extra == "video"',
+    ]
+    result = cpp.extras_from_pypi(requires_dist)
+    assert "openai" in result
+    assert "video" in result
+    assert len(result["openai"]) == 1
+    assert len(result["video"]) == 2
+    # Base dep must not appear in any extra group
+    assert not any("genblaze-core" in dep for deps in result.values() for dep in deps)
+
+
+def test_extras_from_pypi_handles_none():
+    assert cpp.extras_from_pypi(None) == {}
+
+
+def test_extras_from_pypi_handles_no_extras():
+    assert cpp.extras_from_pypi(["genblaze-core>=0.3.0"]) == {}
+
+
+def test_extras_from_pypi_strips_extra_marker_from_dep_string():
+    """Deps returned must be plain requirement strings, not with the marker."""
+    requires_dist = ['genblaze-openai>=0.3.0,<0.4; extra == "openai"']
+    result = cpp.extras_from_pypi(requires_dist)
+    dep = result["openai"][0]
+    assert "extra ==" not in dep
+    # Must be parseable as a plain requirement
+    from packaging.requirements import Requirement
+
+    Requirement(dep)
+
+
+def test_extras_from_pypi_single_quoted_marker():
+    """The marker may use single quotes; the name must still parse."""
+    requires_dist = ["genblaze-openai>=0.3.0,<0.4; extra == 'openai'"]
+    result = cpp.extras_from_pypi(requires_dist)
+    assert result["openai"] == ["genblaze-openai>=0.3.0,<0.4"]
+
+
+def test_extras_from_pypi_compound_marker_extra_not_last():
+    """Regression: a compound marker with ``extra`` *first* must not corrupt
+    the extra name (the old string-split produced a garbage key)."""
+    requires_dist = ['foo>=1.0; extra == "all" and python_version >= "3.11"']
+    result = cpp.extras_from_pypi(requires_dist)
+    assert list(result.keys()) == ["all"]
+    # The residual (non-extra) marker is preserved on the requirement.
+    assert 'python_version >= "3.11"' in result["all"][0]
+
+
+def test_extras_from_pypi_canonicalizes_extra_name():
+    """PEP 685: an underscore/case-variant extra name canonicalizes to dashes."""
+    requires_dist = ['foo>=1.0; extra == "Stability_Audio"']
+    result = cpp.extras_from_pypi(requires_dist)
+    assert list(result.keys()) == ["stability-audio"]
+
+
+# ---------------------------------------------------------------------------
+# split_extra() / canon_extra() — marker parsing primitives
+# ---------------------------------------------------------------------------
+
+
+def test_split_extra_base_dep_has_no_extra():
+    assert cpp.split_extra("genblaze-core>=0.3.0,<0.4") == (None, "genblaze-core>=0.3.0,<0.4")
+
+
+def test_split_extra_non_extra_marker_is_not_an_extra():
+    """A dep with only a python_version marker is a base dep, not an extra."""
+    name, req = cpp.split_extra('foo>=1.0; python_version < "3.12"')
+    assert name is None
+
+
+def test_split_extra_preserves_residual_marker():
+    """The non-extra portion of a compound marker survives the split."""
+    name, req = cpp.split_extra('foo>=1.0; python_version < "3.12" and extra == "bar"')
+    assert name == "bar"
+    # Re-normalized, the residual marker must match the same source dep.
+    assert cpp.normalize(req) == cpp.normalize('foo>=1.0; python_version < "3.12"')
+
+
+def test_canon_extra_normalizes():
+    assert cpp.canon_extra("Stability_Audio") == "stability-audio"
+    assert cpp.canon_extra("video") == "video"
+
+
+# ---------------------------------------------------------------------------
+# check_package() — detects extras drift
+# ---------------------------------------------------------------------------
+
+
+def _make_pyproject(
+    tmp: Path,
+    *,
+    name: str = "genblaze",
+    version: str = "0.4.0",
+    base_deps: list[str] | None = None,
+    optional_deps: dict[str, list[str]] | None = None,
+) -> Path:
+    """Write a minimal pyproject.toml under tmp/ and return its directory."""
+    base_deps = base_deps or []
+    optional_deps = optional_deps or {}
+
+    base_block = "\n".join(f'    "{d}",' for d in base_deps)
+    extras_lines: list[str] = []
+    for extra_name, deps in optional_deps.items():
+        deps_str = "\n".join(f'    "{d}",' for d in deps)
+        extras_lines.append(f"[project.optional-dependencies]\n{extra_name} = [\n{deps_str}\n]")
+
+    content = f"""[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{name}"
+version = "{version}"
+description = "test"
+requires-python = ">=3.11"
+dependencies = [
+{base_block}
+]
+
+{"".join(extras_lines)}
+"""
+    pkg_dir = tmp / "libs" / "meta"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(content)
+    return pkg_dir
+
+
+def _pypi_metadata(
+    *,
+    base: list[str] | None = None,
+    extras: dict[str, list[str]] | None = None,
+) -> dict:
+    """Build a minimal PyPI JSON metadata dict."""
+    requires_dist: list[str] = list(base or [])
+    for extra_name, deps in (extras or {}).items():
+        for dep in deps:
+            requires_dist.append(f'{dep}; extra == "{extra_name}"')
+    return {"info": {"requires_dist": requires_dist}}
+
+
+def test_check_package_reports_match_when_extras_agree():
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            optional_deps={"openai": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={"openai": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "match"
+    assert details is None
+
+
+def test_check_package_detects_extra_added_in_source():
+    """Source has a new connector in [all]; PyPI wheel doesn't — drift."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            optional_deps={
+                "all": [
+                    "genblaze-openai>=0.3.0,<0.4",
+                    "genblaze-newpkg>=0.1.0,<0.4",  # added in source, not on PyPI
+                ]
+            },
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={"all": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "drift"
+    assert details is not None
+    combined = "\n".join(details)
+    # Must name the extra in the report
+    assert "[all]" in combined
+    assert "genblaze-newpkg" in combined
+
+
+def test_check_package_detects_extra_removed_from_source():
+    """PyPI has a dep in [video]; source dropped it — drift."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            optional_deps={
+                "video": ["genblaze-runway>=0.3.0,<0.4"],  # decart was removed from source
+            },
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={
+                "video": [
+                    "genblaze-runway>=0.3.0,<0.4",
+                    "genblaze-decart>=0.3.0,<0.4",  # still on PyPI
+                ]
+            },
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "drift"
+    assert details is not None
+    combined = "\n".join(details)
+    assert "[video]" in combined
+    assert "genblaze-decart" in combined
+
+
+def test_check_package_detects_pin_widened_in_extra():
+    """Same connector in [all] but constraint widened without version bump — drift."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.5"],  # widened base too
+            optional_deps={"all": ["genblaze-openai>=0.3.0,<0.5"]},  # widened
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={"all": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "drift"
+
+
+def test_check_package_base_only_still_works():
+    """Regression: non-umbrella packages (no optional-deps) keep working."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            name="genblaze-openai",
+            base_deps=["genblaze-core>=0.3.0,<0.4", "openai>=1.0"],
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4", "openai>=1.0"],
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "match"
+
+
+def test_check_package_unreleased_skips_extras_check():
+    """Fresh packages (not on PyPI) should still return 'unreleased'."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            optional_deps={"all": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=None):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "unreleased"
+
+
+def test_check_package_extra_only_on_pypi_reports_drift():
+    """Source has no optional-deps; PyPI wheel has [all] — drift."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            # No optional-deps in source
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={"all": ["genblaze-openai>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "drift"
+    assert details is not None
+    combined = "\n".join(details)
+    assert "[all]" in combined
+
+
+def test_check_package_extra_name_normalization_matches():
+    """Source key uses underscores; PyPI uses dashes — same logical extra,
+    so no drift once both are canonicalized (PEP 685)."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            optional_deps={"stability_audio": ["genblaze-stability-audio>=0.3.0,<0.4"]},
+        )
+        metadata = _pypi_metadata(
+            base=["genblaze-core>=0.3.0,<0.4"],
+            extras={"stability-audio": ["genblaze-stability-audio>=0.3.0,<0.4"]},
+        )
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "match"
+
+
+def test_check_package_conditional_dep_in_extra_matches():
+    """A python_version-conditional dep inside an extra must compare equal:
+    PyPI appends ``and extra == "x"`` to the source marker, and the gate must
+    strip only the extra clause, not the python_version one."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        pkg_dir = _make_pyproject(
+            tmp,
+            base_deps=["genblaze-core>=0.3.0,<0.4"],
+            # Single-quoted marker keeps the double-quoted TOML string valid;
+            # PEP 508 accepts either quote style.
+            optional_deps={"all": ["tomli>=2.0; python_version < '3.11'"]},
+        )
+        # PyPI renders the flattened marker with the extra clause appended.
+        metadata = {
+            "info": {
+                "requires_dist": [
+                    "genblaze-core>=0.3.0,<0.4",
+                    'tomli>=2.0; python_version < "3.11" and extra == "all"',
+                ]
+            }
+        }
+        with patch.object(cpp, "fetch_pypi_metadata", return_value=metadata):
+            status, label, details = cpp.check_package(pkg_dir.relative_to(tmp), tmp)
+    assert status == "match", details
+
+
+# ---------------------------------------------------------------------------
+# main() — exit-code contract (what CI actually depends on)
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_zero_on_parity():
+    with (
+        patch.object(cpp, "PACKAGES", ["libs/meta"]),
+        patch.object(cpp, "check_package", return_value=("match", "genblaze==0.4.0", None)),
+    ):
+        assert cpp.main() == 0
+
+
+def test_main_returns_one_on_drift():
+    drift = ("drift", "genblaze==0.4.0", ["genblaze==0.4.0", "  [all]"])
+    with (
+        patch.object(cpp, "PACKAGES", ["libs/meta"]),
+        patch.object(cpp, "check_package", return_value=drift),
+    ):
+        assert cpp.main() == 1
+
+
+def test_main_returns_two_on_unexpected_error():
+    with (
+        patch.object(cpp, "PACKAGES", ["libs/meta"]),
+        patch.object(cpp, "check_package", side_effect=RuntimeError("boom")),
+    ):
+        assert cpp.main() == 2


### PR DESCRIPTION
## Summary

Extends the pre-publish pin-parity gate (tools/check_pin_parity.py) to compare [project.optional-dependencies], not just base [project.dependencies]. The genblaze umbrella's entire connector surface (per-provider extras plus the video/image/audio/all bundles) lives under optional-dependencies, so the gate previously reported 0 drift even when those pins diverged from the wheel already published on PyPI. That silently re-armed the skip-existing trap the gate exists to catch. Running the fixed gate against live PyPI immediately surfaces real drift (genblaze==0.4.0 source adds assemblyai/hume to its extras, but the published 0.4.0 wheel predates them).

## Changes

- tools/check_pin_parity.py — read [project.optional-dependencies] from source and diff each extra group against PyPI independently. New split_extra() parses Requires-Dist with packaging instead of string-splitting, so compound markers (extra not last) no longer corrupt the extra name and conditional deps inside an extra keep their residual marker for like-for-like comparison. New canon_extra() normalizes extra names (PEP 685) on both sides. base_deps_from_pypi/extras_from_pypi are now thin wrappers over split_extra. Drift output names the extra (e.g. [all]).
- tools/tests/test_check_pin_parity.py (new) — 41 tests including compound-marker, single-quote marker, residual-marker preservation, name-normalization, and the main() exit-code contract (0/1/2).
- .github/workflows/ci.yml — added a "Run release-tooling tests" step so the gate's own tests run on every PR.
- Makefile — wires pytest tools/tests/ into make test.
- RELEASING.md — documents that every extra the wheel ships (incl. dev/testing) is compared and that extra names match case/separator-insensitively.
- CHANGELOG.md — [Unreleased] Fixed entry.

## Test plan

- [x] make test passes (1660 core + all connectors + CLI + 41 tools tests; 0 failures)
- [x] make lint passes
- [x] Docs updated (RELEASING.md + CHANGELOG.md)

## Related

Closes #23
