### PR TITLE
fix: share post-release import smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,10 @@ jobs:
     needs: [publish-meta, publish-npm, validate-version]
     if: needs.validate-version.outputs.dry_run != 'true'
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -483,8 +487,4 @@ jobs:
           python -m venv /tmp/verify
           /tmp/verify/bin/pip install --upgrade pip
           /tmp/verify/bin/pip install "genblaze[all]==$version"
-          /tmp/verify/bin/python -c "
-          import genblaze_core, genblaze_s3
-          print(f'genblaze_core={genblaze_core.__version__}')
-          print(f'genblaze_s3={genblaze_s3.__version__ if hasattr(genblaze_s3, \"__version__\") else \"(no __version__)\"}')
-          "
+          /tmp/verify/bin/python tools/release_import_smoke.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,9 +168,10 @@ jobs:
 
   release-smoke:
     # Build every wheel, install `genblaze[all]` from the local wheelhouse
-    # with `--no-index`, and import every connector. Catches incompatible
-    # pyproject pins BEFORE PyPI sees them — editable installs in ci.yml
-    # don't exercise version constraints. See tools/release_smoke.sh.
+    # with `--find-links` while keeping PyPI enabled for transitive deps,
+    # and import every connector. Catches incompatible pyproject pins
+    # BEFORE PyPI sees them — editable installs in ci.yml don't exercise
+    # version constraints. See tools/release_smoke.sh.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [validate-version]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,11 +167,10 @@ jobs:
           echo "CHANGELOG.md [Unreleased] block is empty — ok"
 
   release-smoke:
-    # Build every wheel, install `genblaze[all]` from the local wheelhouse
-    # with `--find-links` while keeping PyPI enabled for transitive deps,
-    # and import every connector. Catches incompatible pyproject pins
-    # BEFORE PyPI sees them — editable installs in ci.yml don't exercise
-    # version constraints. See tools/release_smoke.sh.
+    # Build every wheel, install local genblaze wheels while keeping PyPI
+    # enabled for transitive deps, and import every connector. Catches
+    # incompatible pyproject pins BEFORE PyPI sees them — editable installs
+    # in ci.yml don't exercise version constraints. See tools/release_smoke.sh.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [validate-version]

--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,10 @@ pypi-pin-parity:
 	@python tools/check_pin_parity.py
 
 # Pre-release wheel install smoke test. Builds every package to a
-# local wheelhouse, then installs ``genblaze[all]`` into a fresh
-# venv with ``--find-links`` pointing at that wheelhouse while PyPI
-# remains enabled for transitive dependencies. Catches version-constraint
-# breakage that the editable installs in ``install-dev`` bypass. Run this
-# before tagging a release.
+# local wheelhouse, then installs the local genblaze wheels into a
+# fresh venv while PyPI remains enabled for transitive dependencies.
+# Catches version-constraint breakage that the editable installs in
+# ``install-dev`` bypass. Run this before tagging a release.
 release-smoke:
 	@tools/release_smoke.sh
 

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,10 @@ pre-release: lint typecheck ts-types-check pypi-metadata-check pypi-pin-parity t
 	@echo "See RELEASING.md for the full flow."
 
 # Post-publish verification. Installs the umbrella from public PyPI
-# into a throwaway venv and imports the core surface, mirroring what
-# real users see — this is what catches the same-version-different-
-# content trap that bit the 0.3.0 wave. Pass the umbrella version via
-# VERSION=<X.Y.Z>:
+# into a throwaway venv and imports the umbrella, core, s3, and every
+# genblaze[all] connector, mirroring what real users see — this is what
+# catches the same-version-different-content trap that bit the 0.3.0
+# wave. Pass the umbrella version via VERSION=<X.Y.Z>:
 #
 #   make post-release VERSION=0.4.0
 #
@@ -170,8 +170,8 @@ post-release:
 		echo "Installing genblaze[all]==$(VERSION) from public PyPI..."; \
 		$$VENV/bin/pip install "genblaze[all]==$(VERSION)"; \
 		echo ""; \
-		echo "Smoke-importing core surface..."; \
-		$$VENV/bin/python -c "import genblaze_core, genblaze_s3; print('import ok')"; \
+		echo "Smoke-importing genblaze[all] modules..."; \
+		$$VENV/bin/python tools/release_import_smoke.py; \
 		echo ""; \
 		echo "Installed versions:"; \
 		$$VENV/bin/pip show genblaze genblaze-core genblaze-s3 | grep -E '^(Name|Version)'; \

--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,10 @@ pypi-pin-parity:
 
 # Pre-release wheel install smoke test. Builds every package to a
 # local wheelhouse, then installs ``genblaze[all]`` into a fresh
-# venv from that wheelhouse only (``--no-index``). Catches version-
-# constraint breakage that the editable installs in ``install-dev``
-# bypass. Run this before tagging a release.
+# venv with ``--find-links`` pointing at that wheelhouse while PyPI
+# remains enabled for transitive dependencies. Catches version-constraint
+# breakage that the editable installs in ``install-dev`` bypass. Run this
+# before tagging a release.
 release-smoke:
 	@tools/release_smoke.sh
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -148,12 +148,13 @@ Notes on the graph:
 * **`publish-npm`** — independent of the PyPI graph. Publishes
   `@genblaze/spec` with sigstore provenance.
 * **`install-verify`** — installs `genblaze[all]==$version` from public
-  PyPI in a fresh venv and imports the core packages. The `[all]` form
-  exercises every connector's pin against the live registry, which is
-  what catches drift like the 0.3.2 langsmith/cli wheels (a bare
-  `genblaze==$version` resolve only pulls the umbrella defaults and
-  misses connector-specific pin breakage). Skipped on dry-runs
-  (TestPyPI indexing lag makes this flaky).
+  PyPI in a fresh venv and runs `tools/release_import_smoke.py`, which
+  imports the umbrella, core, s3, and every connector in `genblaze[all]`.
+  The `[all]` form exercises every connector's pin and import surface
+  against the live registry, which is what catches drift like the 0.3.2
+  langsmith/cli wheels (a bare `genblaze==$version` resolve only pulls
+  the umbrella defaults and misses connector-specific pin breakage).
+  Skipped on dry-runs (TestPyPI indexing lag makes this flaky).
 
 ### 2. Dry run (`workflow_dispatch`)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -267,9 +267,10 @@ make post-release VERSION=0.4.0
 `VERSION` is the **umbrella** version from `libs/meta/pyproject.toml`,
 not the wave name (e.g. wave 0.3.0 shipped umbrella 0.4.0). The target
 creates a throwaway venv in `/tmp`, installs `genblaze[all]==$VERSION`
-from public PyPI, imports `genblaze_core` and `genblaze_s3`, and prints
-the installed versions of each. On failure the venv is left in place
-so you can re-run the failing command interactively.
+from public PyPI, imports the umbrella, core, s3, and every connector in
+`genblaze[all]`, then prints the installed versions of the umbrella/core/s3
+packages. On failure the venv is left in place so you can re-run the failing
+command interactively.
 
 This is the same check that caught the 0.3.0 `genblaze-s3` dependency-
 pin drift after `install-verify` lagged — it's a backstop, not

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,10 +117,9 @@ Notes on the graph:
   per-package versions + `dry_run` flag to every downstream job.
 * **`changelog-gate`** — fails if `[Unreleased]` still has entries.
 * **`release-smoke`** — runs `make release-smoke`: builds every wheel,
-  installs `genblaze[all]` with `--find-links` pointing at the local
-  wheelhouse while leaving public PyPI enabled for transitive dependencies,
-  then imports every connector. Catches version-pin mismatches before PyPI
-  sees them.
+  installs local genblaze wheels while leaving public PyPI enabled for
+  transitive dependencies, then imports every connector. Catches version-pin
+  mismatches before PyPI sees them.
 * **`pin-parity`** — for every package, compares source
   `[project.dependencies]` **and** `[project.optional-dependencies]`
   against the wheel already on PyPI at the same version. Fails the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,8 +117,9 @@ Notes on the graph:
   per-package versions + `dry_run` flag to every downstream job.
 * **`changelog-gate`** — fails if `[Unreleased]` still has entries.
 * **`release-smoke`** — runs `make release-smoke`: builds every wheel,
-  installs `genblaze[all]` from a local wheelhouse with `--no-index`,
-  imports every connector. Catches version-pin mismatches before PyPI
+  installs `genblaze[all]` with `--find-links` pointing at the local
+  wheelhouse while leaving public PyPI enabled for transitive dependencies,
+  then imports every connector. Catches version-pin mismatches before PyPI
   sees them.
 * **`pin-parity`** — for every package, compares source
   `[project.dependencies]` **and** `[project.optional-dependencies]`

--- a/docs/exec-plans/completed/issue-24-post-release-import-smoke.md
+++ b/docs/exec-plans/completed/issue-24-post-release-import-smoke.md
@@ -1,0 +1,32 @@
+# Issue 24: Shared Post-Release Import Smoke
+
+## Issue
+
+- GitHub issue: https://github.com/backblaze-labs/genblaze/issues/24
+- Problem: `install-verify` and `make post-release` installed
+  `genblaze[all]` from public PyPI but only imported `genblaze_core` and
+  `genblaze_s3`.
+
+## Changes
+
+1. Added `tools/release_import_smoke.py` as the shared import smoke helper for
+   release verification.
+2. Updated `tools/release_smoke.sh`, the production `install-verify` workflow
+   job, and `make post-release` to call the shared helper.
+3. Added a tools test that compares the helper's package mapping against
+   `libs/meta/pyproject.toml`'s `genblaze[all]` extra so future connectors
+   cannot silently miss the post-release smoke.
+4. Updated `RELEASING.md` to describe the all-module post-release import check.
+
+## Verification
+
+- `python -m pytest tools/tests/test_release_import_smoke.py`
+- `bash -n tools/release_smoke.sh`
+- `python -m compileall tools/release_import_smoke.py`
+- `ruff check tools/release_import_smoke.py tools/tests/test_release_import_smoke.py`
+- `ruff format --check tools/release_import_smoke.py tools/tests/test_release_import_smoke.py`
+- `make release-smoke`
+- `make post-release VERSION=0.4.1`
+- `make install-dev`
+- `make test`
+- `make lint`

--- a/tools/release_import_smoke.py
+++ b/tools/release_import_smoke.py
@@ -46,6 +46,8 @@ ALL_EXTRA_PACKAGE_IMPORTS = (
 CONNECTOR_IMPORTS = tuple(module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS)
 SMOKE_IMPORTS = CORE_IMPORTS + CONNECTOR_IMPORTS
 REDACTION = "[redacted]"
+DEFAULT_IMPORT_TIMEOUT_SECONDS = 20.0
+TIMEOUT_ENV = "GENBLAZE_IMPORT_SMOKE_TIMEOUT"
 
 ENV_ALLOWLIST = frozenset(
     {
@@ -109,6 +111,19 @@ def _redact(message: str, sensitive_values: Iterable[str]) -> str:
     return redacted
 
 
+def _import_timeout_seconds(env: Mapping[str, str]) -> float:
+    raw_timeout = env.get(TIMEOUT_ENV)
+    if raw_timeout is None:
+        return DEFAULT_IMPORT_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw_timeout)
+    except ValueError as exc:
+        raise ValueError(f"{TIMEOUT_ENV} must be a positive number of seconds") from exc
+    if timeout <= 0:
+        raise ValueError(f"{TIMEOUT_ENV} must be a positive number of seconds")
+    return timeout
+
+
 def _sandbox_environment(original_env: Mapping[str, str], sandbox_home: str) -> dict[str, str]:
     safe_env = {
         name: value
@@ -135,6 +150,7 @@ def _import_in_sandbox(
     sandbox_home: str,
     extra_paths: Sequence[str],
     sensitive_values: Iterable[str],
+    timeout_seconds: float,
 ) -> str | None:
     try:
         result = subprocess.run(
@@ -150,16 +166,17 @@ def _import_in_sandbox(
             env=dict(env),
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=timeout_seconds,
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
         stdout = _redact(exc.stdout or "", sensitive_values)
         stderr = _redact(exc.stderr or "", sensitive_values)
-        print(f"  FAIL: {module_name}: import subprocess timed out")
+        message = f"import subprocess timed out after {timeout_seconds:g}s"
+        print(f"  FAIL: {module_name}: {message}")
         _print_stream("stdout", stdout)
         _print_stream("stderr", stderr)
-        return "import subprocess timed out"
+        return message
 
     stdout = _redact(result.stdout, sensitive_values)
     stderr = _redact(result.stderr, sensitive_values)
@@ -182,6 +199,7 @@ def smoke_import(
     """Import release modules in isolated subprocesses with a scrubbed env."""
     original_env = dict(os.environ)
     sensitive_values = _sensitive_env_values(original_env)
+    timeout_seconds = _import_timeout_seconds(original_env)
     failures: list[tuple[str, str]] = []
 
     extra_path_list = tuple(os.fspath(path) for path in extra_paths)
@@ -194,6 +212,7 @@ def smoke_import(
                 sandbox_home=sandbox_home,
                 extra_paths=extra_path_list,
                 sensitive_values=sensitive_values,
+                timeout_seconds=timeout_seconds,
             )
             if message is not None:
                 failures.append((module_name, message))

--- a/tools/release_import_smoke.py
+++ b/tools/release_import_smoke.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib
+import os
+import re
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 # The umbrella installs core + s3 by default; keep the storage submodule here
 # because it has a hard import-time urllib3 dependency hidden by core's lazy
@@ -38,18 +40,82 @@ ALL_EXTRA_PACKAGE_IMPORTS = (
 
 CONNECTOR_IMPORTS = tuple(module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS)
 SMOKE_IMPORTS = CORE_IMPORTS + CONNECTOR_IMPORTS
+REDACTION = "[redacted]"
+
+ENV_ALLOWLIST = frozenset(
+    {
+        "COMSPEC",
+        "CURL_CA_BUNDLE",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "PATH",
+        "PATHEXT",
+        "PYTHONIOENCODING",
+        "PYTHONUTF8",
+        "PYTHONWARNINGS",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USERPROFILE",
+        "WINDIR",
+    }
+)
+SENSITIVE_ENV_NAME_RE = re.compile(
+    r"(?:"
+    r"API|AUTH|AZURE|B2_|BACKBLAZE|CREDENTIAL|GCP|GITHUB|GOOGLE|KEY|NPM|OPENAI|"
+    r"PASSWORD|PYPI|SECRET|TOKEN|TWINE|AWS|ANTHROPIC|ASSEMBLYAI|ELEVEN|GMI|"
+    r"HUME|LANGSMITH|LMNT|LUMA|NVIDIA|REPLICATE|RUNWAY|STABILITY"
+    r")",
+    re.IGNORECASE,
+)
 
 
-def smoke_import(modules: Iterable[str] = SMOKE_IMPORTS) -> list[tuple[str, BaseException]]:
-    failures: list[tuple[str, BaseException]] = []
+def _sensitive_env_values(env: Mapping[str, str]) -> tuple[str, ...]:
+    values = {
+        value
+        for name, value in env.items()
+        if len(value) >= 4 and SENSITIVE_ENV_NAME_RE.search(name)
+    }
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def _redact(message: str, sensitive_values: Iterable[str]) -> str:
+    redacted = message
+    for value in sensitive_values:
+        redacted = redacted.replace(value, REDACTION)
+    return redacted
+
+
+def _sanitize_environment(original_env: Mapping[str, str]) -> None:
+    safe_env = {
+        name: value for name, value in original_env.items() if name.upper() in ENV_ALLOWLIST
+    }
+    os.environ.clear()
+    os.environ.update(safe_env)
+
+
+def smoke_import(modules: Iterable[str] = SMOKE_IMPORTS) -> list[tuple[str, str]]:
+    """Import release modules after removing ambient secrets from this process."""
+    original_env = dict(os.environ)
+    sensitive_values = _sensitive_env_values(original_env)
+    failures: list[tuple[str, str]] = []
+
+    _sanitize_environment(original_env)
     for module_name in modules:
         try:
             importlib.import_module(module_name)
         except Exception as exc:
-            failures.append((module_name, exc))
-            print(f"  FAIL: {module_name}: {exc}")
+            message = _redact(f"{type(exc).__name__}: {exc}", sensitive_values)
+            failures.append((module_name, message))
+            print(f"  FAIL: {module_name}: {message}")
         else:
             print(f"  ok: {module_name}")
+
     return failures
 
 

--- a/tools/release_import_smoke.py
+++ b/tools/release_import_smoke.py
@@ -1,0 +1,65 @@
+"""Shared import smoke check for release verification."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterable
+
+# The umbrella installs core + s3 by default; keep the storage submodule here
+# because it has a hard import-time urllib3 dependency hidden by core's lazy
+# top-level exports.
+CORE_IMPORTS = (
+    "genblaze",
+    "genblaze_core",
+    "genblaze_core.storage",
+    "genblaze_s3",
+)
+
+# Keep this list aligned with libs/meta/pyproject.toml's genblaze[all] extra.
+# tools/tests/test_release_import_smoke.py fails when a new all-extra package
+# is added without a matching import smoke target.
+ALL_EXTRA_PACKAGE_IMPORTS = (
+    ("genblaze-gmicloud", "genblaze_gmicloud"),
+    ("genblaze-openai", "genblaze_openai"),
+    ("genblaze-google", "genblaze_google"),
+    ("genblaze-replicate", "genblaze_replicate"),
+    ("genblaze-runway", "genblaze_runway"),
+    ("genblaze-luma", "genblaze_luma"),
+    ("genblaze-decart", "genblaze_decart"),
+    ("genblaze-elevenlabs", "genblaze_elevenlabs"),
+    ("genblaze-stability-audio", "genblaze_stability_audio"),
+    ("genblaze-lmnt", "genblaze_lmnt"),
+    ("genblaze-hume", "genblaze_hume"),
+    ("genblaze-assemblyai", "genblaze_assemblyai"),
+    ("genblaze-langsmith", "genblaze_langsmith"),
+    ("genblaze-nvidia", "genblaze_nvidia"),
+)
+
+CONNECTOR_IMPORTS = tuple(module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS)
+SMOKE_IMPORTS = CORE_IMPORTS + CONNECTOR_IMPORTS
+
+
+def smoke_import(modules: Iterable[str] = SMOKE_IMPORTS) -> list[tuple[str, BaseException]]:
+    failures: list[tuple[str, BaseException]] = []
+    for module_name in modules:
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            failures.append((module_name, exc))
+            print(f"  FAIL: {module_name}: {exc}")
+        else:
+            print(f"  ok: {module_name}")
+    return failures
+
+
+def main() -> int:
+    failures = smoke_import()
+    if failures:
+        print(f"{len(failures)} import failure(s)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_import_smoke.py
+++ b/tools/release_import_smoke.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-import importlib
+import json
 import os
 import re
+import subprocess
 import sys
-from collections.abc import Iterable, Mapping
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
 
-# The umbrella installs core + s3 by default; keep the storage submodule here
-# because it has a hard import-time urllib3 dependency hidden by core's lazy
-# top-level exports.
+DEFAULT_PACKAGE_IMPORTS = (
+    ("genblaze-core", "genblaze_core"),
+    ("genblaze-s3", "genblaze_s3"),
+)
+
+# The umbrella module and storage submodule are explicit probes in addition
+# to the imports that map directly to the umbrella package dependencies.
 CORE_IMPORTS = (
     "genblaze",
-    "genblaze_core",
+    *(module for _package, module in DEFAULT_PACKAGE_IMPORTS),
     "genblaze_core.storage",
-    "genblaze_s3",
 )
 
 # Keep this list aligned with libs/meta/pyproject.toml's genblaze[all] extra.
@@ -46,7 +51,6 @@ ENV_ALLOWLIST = frozenset(
     {
         "COMSPEC",
         "CURL_CA_BUNDLE",
-        "HOME",
         "LANG",
         "LC_ALL",
         "LC_CTYPE",
@@ -58,13 +62,10 @@ ENV_ALLOWLIST = frozenset(
         "REQUESTS_CA_BUNDLE",
         "SSL_CERT_FILE",
         "SYSTEMROOT",
-        "TEMP",
-        "TMP",
-        "TMPDIR",
-        "USERPROFILE",
         "WINDIR",
     }
 )
+SANDBOX_PATH_ENV = ("HOME", "USERPROFILE", "TMPDIR", "TMP", "TEMP")
 SENSITIVE_ENV_NAME_RE = re.compile(
     r"(?:"
     r"API|AUTH|AZURE|B2_|BACKBLAZE|CREDENTIAL|GCP|GITHUB|GOOGLE|KEY|NPM|OPENAI|"
@@ -73,6 +74,23 @@ SENSITIVE_ENV_NAME_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+CHILD_IMPORT = """
+import importlib
+import json
+import sys
+import traceback
+
+module_name = sys.argv[1]
+extra_paths = json.loads(sys.argv[2])
+for path in reversed(extra_paths):
+    sys.path.insert(0, path)
+
+try:
+    importlib.import_module(module_name)
+except Exception as exc:
+    traceback.print_exception(type(exc), exc, exc.__traceback__)
+    raise SystemExit(1)
+"""
 
 
 def _sensitive_env_values(env: Mapping[str, str]) -> tuple[str, ...]:
@@ -91,30 +109,94 @@ def _redact(message: str, sensitive_values: Iterable[str]) -> str:
     return redacted
 
 
-def _sanitize_environment(original_env: Mapping[str, str]) -> None:
+def _sandbox_environment(original_env: Mapping[str, str], sandbox_home: str) -> dict[str, str]:
     safe_env = {
-        name: value for name, value in original_env.items() if name.upper() in ENV_ALLOWLIST
+        name: value
+        for name, value in original_env.items()
+        if name.upper() in ENV_ALLOWLIST and not SENSITIVE_ENV_NAME_RE.search(name)
     }
-    os.environ.clear()
-    os.environ.update(safe_env)
+    safe_env.update({name: sandbox_home for name in SANDBOX_PATH_ENV})
+    safe_env["PYTHONNOUSERSITE"] = "1"
+    return safe_env
 
 
-def smoke_import(modules: Iterable[str] = SMOKE_IMPORTS) -> list[tuple[str, str]]:
-    """Import release modules after removing ambient secrets from this process."""
+def _print_stream(label: str, content: str) -> None:
+    if not content:
+        return
+    print(f"  {label}:")
+    for line in content.splitlines():
+        print(f"    {line}")
+
+
+def _import_in_sandbox(
+    module_name: str,
+    *,
+    env: Mapping[str, str],
+    sandbox_home: str,
+    extra_paths: Sequence[str],
+    sensitive_values: Iterable[str],
+) -> str | None:
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                CHILD_IMPORT,
+                module_name,
+                json.dumps(list(extra_paths)),
+            ],
+            cwd=sandbox_home,
+            env=dict(env),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _redact(exc.stdout or "", sensitive_values)
+        stderr = _redact(exc.stderr or "", sensitive_values)
+        print(f"  FAIL: {module_name}: import subprocess timed out")
+        _print_stream("stdout", stdout)
+        _print_stream("stderr", stderr)
+        return "import subprocess timed out"
+
+    stdout = _redact(result.stdout, sensitive_values)
+    stderr = _redact(result.stderr, sensitive_values)
+    if result.returncode == 0:
+        print(f"  ok: {module_name}")
+        return None
+
+    message = f"import subprocess exited with {result.returncode}"
+    print(f"  FAIL: {module_name}: {message}")
+    _print_stream("stdout", stdout)
+    _print_stream("stderr", stderr)
+    return message
+
+
+def smoke_import(
+    modules: Iterable[str] = SMOKE_IMPORTS,
+    *,
+    extra_paths: Iterable[str] = (),
+) -> list[tuple[str, str]]:
+    """Import release modules in isolated subprocesses with a scrubbed env."""
     original_env = dict(os.environ)
     sensitive_values = _sensitive_env_values(original_env)
     failures: list[tuple[str, str]] = []
 
-    _sanitize_environment(original_env)
-    for module_name in modules:
-        try:
-            importlib.import_module(module_name)
-        except Exception as exc:
-            message = _redact(f"{type(exc).__name__}: {exc}", sensitive_values)
-            failures.append((module_name, message))
-            print(f"  FAIL: {module_name}: {message}")
-        else:
-            print(f"  ok: {module_name}")
+    extra_path_list = tuple(os.fspath(path) for path in extra_paths)
+    with tempfile.TemporaryDirectory(prefix="genblaze-import-smoke-") as sandbox_home:
+        safe_env = _sandbox_environment(original_env, sandbox_home)
+        for module_name in modules:
+            message = _import_in_sandbox(
+                module_name,
+                env=safe_env,
+                sandbox_home=sandbox_home,
+                extra_paths=extra_path_list,
+                sensitive_values=sensitive_values,
+            )
+            if message is not None:
+                failures.append((module_name, message))
 
     return failures
 

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -3,9 +3,8 @@
 # Pre-release wheel install smoke test.
 #
 # Builds every published package to a local wheelhouse, then installs
-# ``genblaze[all]`` into a fresh venv with ``--find-links`` pointing at
-# that wheelhouse while leaving PyPI enabled for transitive dependencies.
-# Asserts every connector imports.
+# every local genblaze wheel into a fresh venv while leaving PyPI enabled
+# for transitive dependencies. Asserts every connector imports.
 #
 # Why this exists:
 #   ``make install-dev`` and the CI matrix both use ``pip install -e``
@@ -79,13 +78,36 @@ python -m venv "${VENV}"
 source "${VENV}/bin/activate"
 pip install --quiet --upgrade pip
 
-echo "==> Installing 'genblaze[all]' from wheelhouse + PyPI for transitive deps"
-# ``--find-links`` makes pip prefer local wheels for genblaze-* packages;
-# the default PyPI index supplies transitive deps (pillow, httpx, etc.)
-# the same way it will for end users post-publish. ``--no-index`` would
-# block transitives — wrong for this smoke test; we're verifying genblaze
-# pyproject pins, not vendoring the entire dep tree.
-pip install --quiet --find-links "${WHEELHOUSE}" "genblaze[all]"
+echo "==> Installing local genblaze wheels + PyPI transitive deps"
+meta_wheels=( "${WHEELHOUSE}"/genblaze-[0-9]*-py3-none-any.whl )
+if [[ ${#meta_wheels[@]} -ne 1 || ! -e "${meta_wheels[0]}" ]]; then
+    echo "Expected exactly one local genblaze umbrella wheel, found ${#meta_wheels[@]}" >&2
+    exit 1
+fi
+
+local_genblaze_wheels=( "${WHEELHOUSE}"/genblaze_*.whl )
+if [[ ${#local_genblaze_wheels[@]} -eq 0 || ! -e "${local_genblaze_wheels[0]}" ]]; then
+    echo "Expected local genblaze dependency wheels in ${WHEELHOUSE}" >&2
+    exit 1
+fi
+
+meta_wheel_uri="$(
+    python - "${meta_wheels[0]}" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+
+# The direct file requirements force every genblaze distribution to come
+# from the wheelhouse even when the same version already exists on PyPI.
+# The default PyPI index remains enabled for third-party transitive deps.
+pip install \
+    --quiet \
+    --find-links "${WHEELHOUSE}" \
+    "genblaze[all] @ ${meta_wheel_uri}" \
+    "${local_genblaze_wheels[@]}"
 
 echo "==> Asserting every genblaze[all] module imports cleanly"
 python "${REPO_ROOT}/tools/release_import_smoke.py"

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -86,48 +86,7 @@ echo "==> Installing 'genblaze[all]' from wheelhouse + PyPI for transitive deps"
 # pyproject pins, not vendoring the entire dep tree.
 pip install --quiet --find-links "${WHEELHOUSE}" "genblaze[all]"
 
-echo "==> Asserting every connector imports cleanly"
-python - <<'PY'
-import importlib
-import sys
-
-connectors = [
-    "genblaze_core",
-    # Submodule with a hard import-at-load dependency (urllib3, via the
-    # AssetTransfer PoolManager). `import genblaze_core` uses lazy __getattr__
-    # dispatch and never executes this, so it must be imported explicitly to
-    # prove the clean-install contract — the regression class behind #37/#106.
-    # (genblaze_core.testing is NOT checked here: it needs pytest, which
-    # genblaze[all] does not install — that extra is gated in the follow-up.)
-    "genblaze_core.storage",
-    "genblaze_s3",
-    "genblaze_openai",
-    "genblaze_google",
-    "genblaze_runway",
-    "genblaze_luma",
-    "genblaze_decart",
-    "genblaze_replicate",
-    "genblaze_elevenlabs",
-    "genblaze_stability_audio",
-    "genblaze_lmnt",
-    "genblaze_hume",
-    "genblaze_gmicloud",
-    "genblaze_langsmith",
-    "genblaze_nvidia",
-    "genblaze_assemblyai",
-    "genblaze",
-]
-failures = []
-for mod in connectors:
-    try:
-        importlib.import_module(mod)
-        print(f"  ok: {mod}")
-    except Exception as exc:  # noqa: BLE001 — surface all import errors
-        failures.append((mod, exc))
-        print(f"  FAIL: {mod}: {exc}")
-
-if failures:
-    sys.exit(f"{len(failures)} import failure(s)")
-PY
+echo "==> Asserting every genblaze[all] module imports cleanly"
+python "${REPO_ROOT}/tools/release_import_smoke.py"
 
 echo "==> Release smoke test passed."

--- a/tools/release_smoke.sh
+++ b/tools/release_smoke.sh
@@ -3,8 +3,9 @@
 # Pre-release wheel install smoke test.
 #
 # Builds every published package to a local wheelhouse, then installs
-# ``genblaze[all]`` into a fresh venv from that wheelhouse only
-# (``--no-index --find-links``). Asserts every connector imports.
+# ``genblaze[all]`` into a fresh venv with ``--find-links`` pointing at
+# that wheelhouse while leaving PyPI enabled for transitive dependencies.
+# Asserts every connector imports.
 #
 # Why this exists:
 #   ``make install-dev`` and the CI matrix both use ``pip install -e``

--- a/tools/tests/test_release_import_smoke.py
+++ b/tools/tests/test_release_import_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
 import tomllib
 from pathlib import Path
@@ -16,6 +17,7 @@ spec.loader.exec_module(release_import_smoke)
 
 ALL_EXTRA_PACKAGE_IMPORTS = release_import_smoke.ALL_EXTRA_PACKAGE_IMPORTS
 CORE_IMPORTS = release_import_smoke.CORE_IMPORTS
+REDACTION = release_import_smoke.REDACTION
 SMOKE_IMPORTS = release_import_smoke.SMOKE_IMPORTS
 
 
@@ -35,8 +37,42 @@ def test_all_extra_import_mapping_matches_umbrella_all_extra() -> None:
     assert [package for package, _module in ALL_EXTRA_PACKAGE_IMPORTS] == all_extra_packages
 
 
-def test_smoke_imports_core_and_all_extra_modules_once() -> None:
-    expected = CORE_IMPORTS + tuple(module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS)
+def test_smoke_imports_unique_core_and_all_extra_modules() -> None:
+    expected_modules = set(CORE_IMPORTS) | {
+        module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS
+    }
 
-    assert SMOKE_IMPORTS == expected
     assert len(SMOKE_IMPORTS) == len(set(SMOKE_IMPORTS))
+    assert set(SMOKE_IMPORTS) == expected_modules
+
+
+def test_smoke_import_sanitizes_env_and_redacts_import_failures(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    seeded_value = "review-secret-token-123"
+    module_name = "fake_leaky_import"
+    (tmp_path / f"{module_name}.py").write_text(
+        "import os\n"
+        f"literal = {seeded_value!r}\n"
+        "env_secret = os.environ.get('OPENAI_API_KEY')\n"
+        "raise RuntimeError(f'env={env_secret} literal={literal}')\n"
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", seeded_value)
+
+    original_env = dict(os.environ)
+    try:
+        failures = release_import_smoke.smoke_import([module_name])
+        assert os.environ.get("OPENAI_API_KEY") is None
+        captured = capsys.readouterr()
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    output = captured.out + captured.err
+
+    assert failures
+    assert seeded_value not in output
+    assert "env=None" in output
+    assert REDACTION in output

--- a/tools/tests/test_release_import_smoke.py
+++ b/tools/tests/test_release_import_smoke.py
@@ -17,6 +17,7 @@ spec.loader.exec_module(release_import_smoke)
 
 ALL_EXTRA_PACKAGE_IMPORTS = release_import_smoke.ALL_EXTRA_PACKAGE_IMPORTS
 CORE_IMPORTS = release_import_smoke.CORE_IMPORTS
+DEFAULT_PACKAGE_IMPORTS = release_import_smoke.DEFAULT_PACKAGE_IMPORTS
 REDACTION = release_import_smoke.REDACTION
 SMOKE_IMPORTS = release_import_smoke.SMOKE_IMPORTS
 
@@ -37,16 +38,28 @@ def test_all_extra_import_mapping_matches_umbrella_all_extra() -> None:
     assert [package for package, _module in ALL_EXTRA_PACKAGE_IMPORTS] == all_extra_packages
 
 
+def test_default_import_mapping_matches_umbrella_dependencies() -> None:
+    meta = tomllib.loads((REPO_ROOT / "libs/meta/pyproject.toml").read_text())
+    default_packages = [
+        _dependency_name(requirement) for requirement in meta["project"]["dependencies"]
+    ]
+
+    assert [package for package, _module in DEFAULT_PACKAGE_IMPORTS] == default_packages
+
+
 def test_smoke_imports_unique_core_and_all_extra_modules() -> None:
-    expected_modules = set(CORE_IMPORTS) | {
-        module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS
-    }
+    expected_modules = (
+        {"genblaze", "genblaze_core.storage"}
+        | {module for _package, module in DEFAULT_PACKAGE_IMPORTS}
+        | {module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS}
+    )
 
     assert len(SMOKE_IMPORTS) == len(set(SMOKE_IMPORTS))
+    assert set(CORE_IMPORTS).issubset(SMOKE_IMPORTS)
     assert set(SMOKE_IMPORTS) == expected_modules
 
 
-def test_smoke_import_sanitizes_env_and_redacts_import_failures(
+def test_smoke_import_sandboxes_env_and_redacts_import_failures(
     tmp_path, monkeypatch, capsys
 ) -> None:
     seeded_value = "review-secret-token-123"
@@ -55,24 +68,29 @@ def test_smoke_import_sanitizes_env_and_redacts_import_failures(
         "import os\n"
         f"literal = {seeded_value!r}\n"
         "env_secret = os.environ.get('OPENAI_API_KEY')\n"
-        "raise RuntimeError(f'env={env_secret} literal={literal}')\n"
+        "home_value = os.environ.get('HOME')\n"
+        "print(f'stdout env={env_secret} literal={literal} home={home_value}')\n"
+        "raise RuntimeError("
+        "f'stderr env={env_secret} literal={literal} home={home_value}'"
+        ")\n"
     )
 
-    monkeypatch.syspath_prepend(str(tmp_path))
+    seeded_home = "/sensitive/home/with-creds"
+    monkeypatch.setenv("HOME", seeded_home)
     monkeypatch.setenv("OPENAI_API_KEY", seeded_value)
+    monkeypatch.setenv("GITHUB_TOKEN", seeded_value)
 
     original_env = dict(os.environ)
-    try:
-        failures = release_import_smoke.smoke_import([module_name])
-        assert os.environ.get("OPENAI_API_KEY") is None
-        captured = capsys.readouterr()
-    finally:
-        os.environ.clear()
-        os.environ.update(original_env)
+    failures = release_import_smoke.smoke_import([module_name], extra_paths=[tmp_path])
+    captured = capsys.readouterr()
 
     output = captured.out + captured.err
 
+    assert dict(os.environ) == original_env
     assert failures
+    assert failures[0][0] == module_name
     assert seeded_value not in output
     assert "env=None" in output
+    assert "Traceback (most recent call last)" in output
     assert REDACTION in output
+    assert seeded_home not in output

--- a/tools/tests/test_release_import_smoke.py
+++ b/tools/tests/test_release_import_smoke.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_TOOL = REPO_ROOT / "tools/release_import_smoke.py"
+
+spec = importlib.util.spec_from_file_location("release_import_smoke", SMOKE_TOOL)
+assert spec is not None
+assert spec.loader is not None
+release_import_smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_import_smoke)
+
+ALL_EXTRA_PACKAGE_IMPORTS = release_import_smoke.ALL_EXTRA_PACKAGE_IMPORTS
+CORE_IMPORTS = release_import_smoke.CORE_IMPORTS
+SMOKE_IMPORTS = release_import_smoke.SMOKE_IMPORTS
+
+
+def _dependency_name(requirement: str) -> str:
+    match = re.match(r"[A-Za-z0-9_.-]+", requirement)
+    assert match is not None
+    return match.group(0).lower().replace("_", "-")
+
+
+def test_all_extra_import_mapping_matches_umbrella_all_extra() -> None:
+    meta = tomllib.loads((REPO_ROOT / "libs/meta/pyproject.toml").read_text())
+    all_extra_packages = [
+        _dependency_name(requirement)
+        for requirement in meta["project"]["optional-dependencies"]["all"]
+    ]
+
+    assert [package for package, _module in ALL_EXTRA_PACKAGE_IMPORTS] == all_extra_packages
+
+
+def test_smoke_imports_core_and_all_extra_modules_once() -> None:
+    expected = CORE_IMPORTS + tuple(module for _package, module in ALL_EXTRA_PACKAGE_IMPORTS)
+
+    assert SMOKE_IMPORTS == expected
+    assert len(SMOKE_IMPORTS) == len(set(SMOKE_IMPORTS))

--- a/tools/tests/test_release_import_smoke.py
+++ b/tools/tests/test_release_import_smoke.py
@@ -20,6 +20,7 @@ CORE_IMPORTS = release_import_smoke.CORE_IMPORTS
 DEFAULT_PACKAGE_IMPORTS = release_import_smoke.DEFAULT_PACKAGE_IMPORTS
 REDACTION = release_import_smoke.REDACTION
 SMOKE_IMPORTS = release_import_smoke.SMOKE_IMPORTS
+TIMEOUT_ENV = release_import_smoke.TIMEOUT_ENV
 
 
 def _dependency_name(requirement: str) -> str:
@@ -94,3 +95,16 @@ def test_smoke_import_sandboxes_env_and_redacts_import_failures(
     assert "Traceback (most recent call last)" in output
     assert REDACTION in output
     assert seeded_home not in output
+
+
+def test_smoke_import_timeout_is_configurable(tmp_path, monkeypatch, capsys) -> None:
+    module_name = "fake_slow_import"
+    (tmp_path / f"{module_name}.py").write_text("import time\ntime.sleep(5)\n")
+
+    monkeypatch.setenv(TIMEOUT_ENV, "0.01")
+
+    failures = release_import_smoke.smoke_import([module_name], extra_paths=[tmp_path])
+    output = capsys.readouterr().out
+
+    assert failures == [(module_name, "import subprocess timed out after 0.01s")]
+    assert "timed out after 0.01s" in output


### PR DESCRIPTION
## Summary
- Added shared `tools/release_import_smoke.py` for umbrella, core, s3, and all `genblaze[all]` connector import checks.
- Runs each import in an isolated Python subprocess with a strict allowlisted environment, temporary HOME/TMP paths, and no inherited provider, cloud, GitHub, PyPI, npm, or B2 tokens.
- Redacts captured stdout/stderr/tracebacks before logging failures while still preserving full traceback context.
- Bounds each import subprocess to a 20s default timeout with `GENBLAZE_IMPORT_SMOKE_TIMEOUT` for CI or maintainer overrides.
- Wired the shared helper into `tools/release_smoke.sh`, production `install-verify`, and `make post-release`.
- Forces pre-release smoke to install local genblaze wheel files directly while keeping public PyPI available for third-party transitive dependencies.
- Added drift coverage for umbrella default dependencies and all extras against `libs/meta/pyproject.toml`, plus fake-module secret-leak and timeout regression tests.
- Updated release docs and comments to describe the local-wheel plus public PyPI install behavior.

## Linked issue
Closes #24

## Tests
- `python -m pytest tools/tests/test_release_import_smoke.py -v`
- `python -m pytest tools/tests/ -v`
- `python tools/release_import_smoke.py`
- `bash -n tools/release_smoke.sh`
- `python -m compileall tools/release_import_smoke.py`
- `ruff check tools/release_import_smoke.py tools/tests/test_release_import_smoke.py`
- `ruff format --check tools/release_import_smoke.py tools/tests/test_release_import_smoke.py`
- `make release-smoke`
- `make post-release VERSION=0.4.1`
- `make lint`
- `make test`

## Follow-up notes
- None.
