### PR TITLE
Fix PyPI README relative links

### DIFF
--- a/docs/dev-workflows.md
+++ b/docs/dev-workflows.md
@@ -138,6 +138,8 @@ Reports land in `docs/reference/`. `not_found` means the slug is dead and should
 
 Every slug used in any README quickstart, provider docstring, or `examples/*_pipeline.py` script **must also appear in its family's `example_slugs` tuple** (or `unstable_examples` for known-flaky slugs). Keeps the manual check above tractable — one source of truth per family.
 
+Connector package READMEs are also PyPI long descriptions. Cross-file links in those READMEs must use absolute GitHub URLs so they resolve on PyPI; repository-relative links such as `../../../docs/...` fail the PyPI metadata gate. In-page anchors (`#usage`) and `mailto:` links are allowed.
+
 ## Doc Update Mapping
 
 | Change Type | Update Location |

--- a/docs/exec-plans/completed/pypi-readme-relative-link-gate.md
+++ b/docs/exec-plans/completed/pypi-readme-relative-link-gate.md
@@ -15,8 +15,8 @@ READMEs fail before release.
 |------|--------|
 | `libs/connectors/gmicloud/README.md` | Replaced relative docs links with absolute GitHub blob URLs. |
 | `libs/connectors/nvidia/README.md` | Replaced the relative pricing docs link with an absolute GitHub blob URL. |
-| `tools/check_pypi_metadata.py` | Reads package `readme` files from published pyprojects and rejects relative Markdown link targets. |
-| `tools/tests/test_check_pypi_metadata.py` | Covers rejection of relative README links and allowance of absolute URLs, anchors, and mailto links. |
+| `tools/check_pypi_metadata.py` | Reads package `readme` files from published pyprojects, rejects unsafe README paths, and rejects relative Markdown link targets. |
+| `tools/tests/test_check_pypi_metadata.py` | Covers rejection of relative README links, nested-bracket labels, unsafe README paths, and allowance of absolute URLs, anchors, and mailto links. |
 
 ## Verification
 

--- a/docs/exec-plans/completed/pypi-readme-relative-link-gate.md
+++ b/docs/exec-plans/completed/pypi-readme-relative-link-gate.md
@@ -1,0 +1,28 @@
+<!-- created: 2026-07-01 -->
+# PyPI README relative link gate
+
+**Status:** Complete (2026-07-01) · **Issue:** #14 · **Shape:** D + test/tooling guard
+
+## Goal
+
+Fix the GMICloud and NVIDIA package READMEs so links rendered on PyPI resolve, and
+extend the PyPI metadata gate so relative Markdown links in shipped Markdown
+READMEs fail before release.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `libs/connectors/gmicloud/README.md` | Replaced relative docs links with absolute GitHub blob URLs. |
+| `libs/connectors/nvidia/README.md` | Replaced the relative pricing docs link with an absolute GitHub blob URL. |
+| `tools/check_pypi_metadata.py` | Reads package `readme` files from published pyprojects and rejects relative Markdown link targets. |
+| `tools/tests/test_check_pypi_metadata.py` | Covers rejection of relative README links and allowance of absolute URLs, anchors, and mailto links. |
+
+## Verification
+
+- `make pypi-metadata-check`
+- `pytest tools/tests -v`
+- `make test`
+- `make lint`
+- `ruff check tools/check_pypi_metadata.py tools/tests/test_check_pypi_metadata.py`
+- `ruff format --check tools/check_pypi_metadata.py tools/tests/test_check_pypi_metadata.py`

--- a/docs/guides/new-provider.md
+++ b/docs/guides/new-provider.md
@@ -98,6 +98,8 @@ testpaths = ["tests"]
 
 The entry point under `genblaze.providers` is how `discover_providers()` and the CLI `replay` command find your provider at runtime. Ship a `py.typed` marker file inside the package so consumers get type-checker support.
 
+The package `README.md` is rendered directly on PyPI. Any cross-file links in that README must use absolute GitHub URLs, for example `https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md`; PyPI does not rewrite repository-relative links such as `../../../docs/...`. In-page anchors such as `#usage` and `mailto:` links are allowed.
+
 ## 3. Implement the provider
 
 ### Sync provider (recommended for most APIs)

--- a/libs/connectors/gmicloud/README.md
+++ b/libs/connectors/gmicloud/README.md
@@ -10,7 +10,7 @@
 - **One API, dozens of models** — text-to-video (Seedance, Kling, Veo, Sora, Wan), text-to-image (Seedream, FLUX, Gemini, Reve), audio (ElevenLabs, MiniMax TTS/Music).
 - **LLM access too** — standalone `chat()` wrapper for Llama, DeepSeek, Qwen over GMICloud's OpenAI-compatible inference endpoint (see below).
 - **Provenance by default** — SHA-256-verified manifest with provider, model, prompt, params, cost.
-- **Cost tracking** — register a pricing strategy from [`docs/reference/pricing-recipes.md`](../../../docs/reference/pricing-recipes.md) and `step.cost_usd` is populated automatically.
+- **Cost tracking** — register a pricing strategy from [`docs/reference/pricing-recipes.md`](https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md) and `step.cost_usd` is populated automatically.
 - **Production-ready** — retries, timeouts, progress streaming, step caching.
 - **Durable storage** — plug `genblaze-s3` in for Backblaze B2 / AWS S3 / R2 / MinIO persistence.
 
@@ -111,7 +111,7 @@ print(resp.text, resp.tokens_out)
 
 Any GMICloud-hosted chat model is accepted — model ids pass through to the inference endpoint verbatim, so you can use models the connector hasn't been updated for. `cost_usd` is always `None` for this connector; compute cost from `tokens_in` / `tokens_out` yourself if needed.
 
-Full signature and `ChatResponse` shape: [`docs/features/llm-calls.md`](../../../docs/features/llm-calls.md).
+Full signature and `ChatResponse` shape: [`docs/features/llm-calls.md`](https://github.com/backblaze-labs/genblaze/blob/main/docs/features/llm-calls.md).
 
 ## Credentials
 

--- a/libs/connectors/nvidia/README.md
+++ b/libs/connectors/nvidia/README.md
@@ -211,7 +211,7 @@ so a retired slug like the historical `nvidia/riva-tts` surfaces as
 | Chat | n/a — `NATIVE` discovery | Any NIM chat model id |
 
 Pricing is **not shipped** — register a strategy from
-[`docs/reference/pricing-recipes.md`](../../../docs/reference/pricing-recipes.md)
+[`docs/reference/pricing-recipes.md`](https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md)
 when one is published for the model line you use. Until then,
 `step.cost_usd` is `None`.
 

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -28,6 +28,7 @@ package whose PyPI page renders empty.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import stat
 import sys
@@ -51,7 +52,7 @@ _REQUIRED_PROJECT_URLS = ("Homepage", "Documentation", "Repository", "Issues")
 _DESCRIPTION_MAX_CHARS = 200  # Plan suggested 120 but real packages run a bit longer
 _README_MAX_BYTES = 1_000_000
 
-_FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
+_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
 _REFERENCE_LINK_RE = re.compile(r"^\s{0,3}\[[^\]\n]+\]:\s*([^\s]+)")
 _ALLOWED_MARKDOWN_URL_SCHEMES = {"http", "https", "mailto"}
 
@@ -116,7 +117,7 @@ def _iter_inline_markdown_targets(line: str) -> list[str]:
             target_end = line.find(">", cursor + 1)
             if target_end != -1:
                 targets.append(line[cursor : target_end + 1])
-                index = target_end + 1
+                index = _link_end_index(line, target_end + 1) + 1
                 continue
             index = cursor + 1
             continue
@@ -140,22 +141,70 @@ def _iter_inline_markdown_targets(line: str) -> list[str]:
 
         if cursor > target_start:
             targets.append(line[target_start:cursor])
-        index = cursor + 1
+            index = _link_end_index(line, cursor) + 1
+        else:
+            index = cursor + 1
 
     return targets
 
 
-def _iter_markdown_link_targets(readme_path: Path) -> list[tuple[int, str]]:
+def _link_end_index(line: str, cursor: int) -> int:
+    """Return the index of the closing ``)`` for an inline Markdown link."""
+    quote: str | None = None
+    paren_depth = 0
+    while cursor < len(line):
+        char = line[cursor]
+        if char == "\\":
+            cursor += 2
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+        elif char in {'"', "'"}:
+            quote = char
+        elif char == "(":
+            paren_depth += 1
+        elif char == ")":
+            if paren_depth == 0:
+                return cursor
+            paren_depth -= 1
+        cursor += 1
+    return cursor
+
+
+def _stat_identity(stat_result: os.stat_result) -> tuple[int, int, int, int]:
+    """Return stable identity fields for detecting read-after-validate swaps."""
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat.S_IFMT(stat_result.st_mode),
+        stat_result.st_size,
+    )
+
+
+def _iter_markdown_link_targets(
+    readme_path: Path, expected_stat: os.stat_result
+) -> list[tuple[int, str]]:
     """Return ``(line_number, target)`` pairs for Markdown links in a file."""
     targets: list[tuple[int, str]] = []
-    in_fence = False
+    fence_marker: str | None = None
 
     with readme_path.open(encoding="utf-8") as readme_handle:
+        opened_stat = os.fstat(readme_handle.fileno())
+        if _stat_identity(opened_stat) != _stat_identity(expected_stat):
+            raise OSError("readme file changed after validation")
+
         for line_number, line in enumerate(readme_handle, start=1):
-            if _FENCE_RE.match(line):
-                in_fence = not in_fence
-                continue
-            if in_fence:
+            fence_match = _FENCE_RE.match(line)
+            if fence_match:
+                marker = fence_match.group(1)
+                if fence_marker is None:
+                    fence_marker = marker
+                    continue
+                if marker[0] == fence_marker[0] and len(marker) >= len(fence_marker):
+                    fence_marker = None
+                    continue
+            if fence_marker is not None:
                 continue
 
             for match in _REFERENCE_LINK_RE.finditer(line):
@@ -166,13 +215,15 @@ def _iter_markdown_link_targets(readme_path: Path) -> list[tuple[int, str]]:
     return targets
 
 
-def _validated_readme_path(path: Path, readme_file: str) -> tuple[Path | None, list[str]]:
+def _validated_readme_path(
+    path: Path, readme_file: str
+) -> tuple[Path | None, os.stat_result | None, list[str]]:
     """Validate a package README path before opening it."""
     declared = Path(readme_file)
     if declared.is_absolute():
-        return None, [f"readme path must be relative: {readme_file}"]
+        return None, None, [f"readme path must be relative: {readme_file}"]
     if any(part == ".." for part in declared.parts):
-        return None, [f"readme path must stay within package: {readme_file}"]
+        return None, None, [f"readme path must stay within package: {readme_file}"]
 
     current = path.parent
     for part in declared.parts:
@@ -180,22 +231,26 @@ def _validated_readme_path(path: Path, readme_file: str) -> tuple[Path | None, l
         try:
             stat_result = current.lstat()
         except FileNotFoundError:
-            return None, [f"readme file not found: {readme_file}"]
+            return None, None, [f"readme file not found: {readme_file}"]
         except OSError as exc:
-            return None, [f"readme file cannot be inspected: {readme_file}: {exc}"]
+            return None, None, [f"readme file cannot be inspected: {readme_file}: {exc}"]
 
         if stat.S_ISLNK(stat_result.st_mode):
-            return None, [f"readme path must not contain symlinks: {readme_file}"]
+            return None, None, [f"readme path must not contain symlinks: {readme_file}"]
 
     if not stat.S_ISREG(stat_result.st_mode):
-        return None, [f"readme path is not a regular file: {readme_file}"]
+        return None, None, [f"readme path is not a regular file: {readme_file}"]
     if stat_result.st_size > _README_MAX_BYTES:
-        return None, [
-            f"readme file too large: {readme_file} "
-            f"({stat_result.st_size} bytes > {_README_MAX_BYTES})"
-        ]
+        return (
+            None,
+            None,
+            [
+                f"readme file too large: {readme_file} "
+                f"({stat_result.st_size} bytes > {_README_MAX_BYTES})"
+            ],
+        )
 
-    return current, []
+    return current, stat_result, []
 
 
 def _check_readme_links(path: Path, readme: object) -> list[str]:
@@ -215,14 +270,14 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     if not readme_file:
         return ["readme must reference a file path"]
 
-    readme_path, issues = _validated_readme_path(path, readme_file)
-    if issues or readme_path is None:
+    readme_path, stat_result, issues = _validated_readme_path(path, readme_file)
+    if issues or readme_path is None or stat_result is None:
         return issues
     if readme_path.suffix.lower() != ".md":
         return []
 
     try:
-        targets = _iter_markdown_link_targets(readme_path)
+        targets = _iter_markdown_link_targets(readme_path, stat_result)
     except (OSError, UnicodeError) as exc:
         return [f"readme file cannot be read: {readme_file}: {exc}"]
 

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -174,9 +174,6 @@ def _validated_readme_path(path: Path, readme_file: str) -> tuple[Path | None, l
     if any(part == ".." for part in declared.parts):
         return None, [f"readme path must stay within package: {readme_file}"]
 
-    if declared.suffix.lower() != ".md":
-        return None, []
-
     current = path.parent
     for part in declared.parts:
         current = current / part
@@ -215,6 +212,8 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     readme_path, issues = _validated_readme_path(path, readme_file)
     if issues or readme_path is None:
         return issues
+    if readme_path.suffix.lower() != ".md":
+        return []
 
     try:
         targets = _iter_markdown_link_targets(readme_path)

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -53,16 +53,21 @@ _README_MAX_BYTES = 1_000_000
 
 _FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
 _REFERENCE_LINK_RE = re.compile(r"^\s{0,3}\[[^\]\n]+\]:\s*([^\s]+)")
+_ALLOWED_MARKDOWN_URL_SCHEMES = {"http", "https", "mailto"}
 
 
-def _is_relative_markdown_target(target: str) -> bool:
-    """Return True when ``target`` would resolve relative to PyPI."""
+def _markdown_target_issue_kind(target: str) -> str | None:
+    """Return the PyPI-rendering issue kind for ``target`` if it is invalid."""
     clean_target = target.strip().strip("<>")
     if not clean_target or clean_target.startswith("#"):
-        return False
-    if clean_target.startswith("//"):
-        return False
-    return not urlparse(clean_target).scheme
+        return None
+
+    scheme = urlparse(clean_target).scheme
+    if scheme in _ALLOWED_MARKDOWN_URL_SCHEMES:
+        return None
+    if scheme:
+        return "unsupported markdown link scheme"
+    return "relative markdown link"
 
 
 def _iter_inline_markdown_targets(line: str) -> list[str]:
@@ -216,11 +221,12 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     except (OSError, UnicodeError) as exc:
         return [f"readme file cannot be read: {readme_file}: {exc}"]
 
-    return [
-        f"relative markdown link in {readme_file}:{line_number} -> {target}"
-        for line_number, target in targets
-        if _is_relative_markdown_target(target)
-    ]
+    link_issues: list[str] = []
+    for line_number, target in targets:
+        issue_kind = _markdown_target_issue_kind(target)
+        if issue_kind:
+            link_issues.append(f"{issue_kind} in {readme_file}:{line_number} -> {target}")
+    return link_issues
 
 
 def _check_package(path: Path) -> list[str]:

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -211,9 +211,14 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     if issues or readme_path is None:
         return issues
 
+    try:
+        targets = _iter_markdown_link_targets(readme_path)
+    except (OSError, UnicodeError) as exc:
+        return [f"readme file cannot be read: {readme_file}: {exc}"]
+
     return [
         f"relative markdown link in {readme_file}:{line_number} -> {target}"
-        for line_number, target in _iter_markdown_link_targets(readme_path)
+        for line_number, target in targets
         if _is_relative_markdown_target(target)
     ]
 

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import stat
 import sys
 import tomllib
 from pathlib import Path
@@ -49,9 +50,9 @@ _REQUIRED_PROJECT_URLS = ("Homepage", "Documentation", "Repository", "Issues")
 
 # Description must fit comfortably in PyPI's search-result preview.
 _DESCRIPTION_MAX_CHARS = 200  # Plan suggested 120 but real packages run a bit longer
+_README_MAX_BYTES = 1_000_000
 
 _FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
-_INLINE_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(\s*([^\s)]+)")
 _REFERENCE_LINK_RE = re.compile(r"^\s{0,3}\[[^\]\n]+\]:\s*([^\s]+)")
 
 
@@ -65,24 +66,135 @@ def _is_relative_markdown_target(target: str) -> bool:
     return not urlparse(clean_target).scheme
 
 
+def _iter_inline_markdown_targets(line: str) -> list[str]:
+    """Return inline Markdown link targets from ``line``.
+
+    This intentionally implements only the syntax shape this gate needs:
+    balanced link labels followed by ``(...)`` destinations. It is stricter
+    than a full Markdown parser, but catches nested-bracket labels that simple
+    regular expressions miss.
+    """
+    targets: list[str] = []
+    index = 0
+    while index < len(line):
+        label_start = line.find("[", index)
+        if label_start == -1:
+            break
+
+        cursor = label_start + 1
+        label_depth = 1
+        while cursor < len(line) and label_depth:
+            char = line[cursor]
+            if char == "\\":
+                cursor += 2
+                continue
+            if char == "[":
+                label_depth += 1
+            elif char == "]":
+                label_depth -= 1
+            cursor += 1
+
+        if label_depth:
+            index = label_start + 1
+            continue
+
+        while cursor < len(line) and line[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(line) or line[cursor] != "(":
+            index = cursor
+            continue
+
+        cursor += 1
+        while cursor < len(line) and line[cursor] in " \t":
+            cursor += 1
+
+        if cursor < len(line) and line[cursor] == "<":
+            target_end = line.find(">", cursor + 1)
+            if target_end != -1:
+                targets.append(line[cursor : target_end + 1])
+                index = target_end + 1
+                continue
+            index = cursor + 1
+            continue
+
+        target_start = cursor
+        paren_depth = 0
+        while cursor < len(line):
+            char = line[cursor]
+            if char == "\\":
+                cursor += 2
+                continue
+            if char == "(":
+                paren_depth += 1
+            elif char == ")":
+                if paren_depth == 0:
+                    break
+                paren_depth -= 1
+            elif char in " \t":
+                break
+            cursor += 1
+
+        if cursor > target_start:
+            targets.append(line[target_start:cursor])
+        index = cursor + 1
+
+    return targets
+
+
 def _iter_markdown_link_targets(readme_path: Path) -> list[tuple[int, str]]:
     """Return ``(line_number, target)`` pairs for Markdown links in a file."""
     targets: list[tuple[int, str]] = []
     in_fence = False
 
-    for line_number, line in enumerate(readme_path.read_text().splitlines(), start=1):
-        if _FENCE_RE.match(line):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
+    with readme_path.open(encoding="utf-8") as readme_handle:
+        for line_number, line in enumerate(readme_handle, start=1):
+            if _FENCE_RE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
 
-        for match in _REFERENCE_LINK_RE.finditer(line):
-            targets.append((line_number, match.group(1)))
-        for match in _INLINE_LINK_RE.finditer(line):
-            targets.append((line_number, match.group(1)))
+            for match in _REFERENCE_LINK_RE.finditer(line):
+                targets.append((line_number, match.group(1)))
+            for target in _iter_inline_markdown_targets(line):
+                targets.append((line_number, target))
 
     return targets
+
+
+def _validated_readme_path(path: Path, readme_file: str) -> tuple[Path | None, list[str]]:
+    """Validate a package README path before opening it."""
+    declared = Path(readme_file)
+    if declared.is_absolute():
+        return None, [f"readme path must be relative: {readme_file}"]
+    if any(part == ".." for part in declared.parts):
+        return None, [f"readme path must stay within package: {readme_file}"]
+
+    if declared.suffix.lower() != ".md":
+        return None, []
+
+    current = path.parent
+    for part in declared.parts:
+        current = current / part
+        try:
+            stat_result = current.lstat()
+        except FileNotFoundError:
+            return None, [f"readme file not found: {readme_file}"]
+        except OSError as exc:
+            return None, [f"readme file cannot be inspected: {readme_file}: {exc}"]
+
+        if stat.S_ISLNK(stat_result.st_mode):
+            return None, [f"readme path must not contain symlinks: {readme_file}"]
+
+    if not stat.S_ISREG(stat_result.st_mode):
+        return None, [f"readme path is not a regular file: {readme_file}"]
+    if stat_result.st_size > _README_MAX_BYTES:
+        return None, [
+            f"readme file too large: {readme_file} "
+            f"({stat_result.st_size} bytes > {_README_MAX_BYTES})"
+        ]
+
+    return current, []
 
 
 def _check_readme_links(path: Path, readme: object) -> list[str]:
@@ -93,12 +205,12 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     elif isinstance(readme, dict) and isinstance(readme.get("file"), str):
         readme_file = readme["file"]
 
-    if not readme_file or Path(readme_file).suffix.lower() != ".md":
+    if not readme_file:
         return []
 
-    readme_path = path.parent / readme_file
-    if not readme_path.exists():
-        return [f"readme file not found: {readme_file}"]
+    readme_path, issues = _validated_readme_path(path, readme_file)
+    if issues or readme_path is None:
+        return issues
 
     return [
         f"relative markdown link in {readme_file}:{line_number} -> {target}"

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -5,15 +5,14 @@ Walks ``libs/**/pyproject.toml`` plus ``cli/pyproject.toml`` and asserts
 every published Python package has the metadata fields users expect to
 see on PyPI:
 
-* ``description`` — single sentence, ≤ 120 chars
+* ``description`` — single sentence, ≤ 200 chars
 * ``readme`` — set (per-package README.md, not just root link)
 * ``authors`` — populated
 * ``license`` — set
 * ``requires-python`` — ``>=3.11`` (matches AGENTS.md invariant)
 * ``classifiers`` — License (MIT), Python versions (3.11/3.12/3.13),
   Topic, Development Status
-* ``project_urls`` — Homepage, Documentation, Repository, Issues,
-  Changelog
+* ``project_urls`` — Homepage, Documentation, Repository, Issues
 * ``keywords`` — non-empty
 * ``readme`` Markdown links — absolute URLs only for files rendered on PyPI
 
@@ -222,7 +221,7 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
 def _check_package(path: Path) -> list[str]:
     """Return a list of human-readable issues found in ``path`` (empty
     list = clean)."""
-    raw = tomllib.loads(path.read_text())
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
     project = raw.get("project")
     if not project:
         return []  # not a published package (e.g. workspace-root pyproject)

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -15,6 +15,7 @@ see on PyPI:
 * ``project_urls`` — Homepage, Documentation, Repository, Issues,
   Changelog
 * ``keywords`` — non-empty
+* ``readme`` Markdown links — absolute URLs only for files rendered on PyPI
 
 Run from the repo root:
 
@@ -28,9 +29,11 @@ package whose PyPI page renders empty.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import tomllib
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Required classifier prefixes — at least one classifier in each group
 # must be present.
@@ -46,6 +49,62 @@ _REQUIRED_PROJECT_URLS = ("Homepage", "Documentation", "Repository", "Issues")
 
 # Description must fit comfortably in PyPI's search-result preview.
 _DESCRIPTION_MAX_CHARS = 200  # Plan suggested 120 but real packages run a bit longer
+
+_FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
+_INLINE_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(\s*([^\s)]+)")
+_REFERENCE_LINK_RE = re.compile(r"^\s{0,3}\[[^\]\n]+\]:\s*([^\s]+)")
+
+
+def _is_relative_markdown_target(target: str) -> bool:
+    """Return True when ``target`` would resolve relative to PyPI."""
+    clean_target = target.strip().strip("<>")
+    if not clean_target or clean_target.startswith("#"):
+        return False
+    if clean_target.startswith("//"):
+        return False
+    return not urlparse(clean_target).scheme
+
+
+def _iter_markdown_link_targets(readme_path: Path) -> list[tuple[int, str]]:
+    """Return ``(line_number, target)`` pairs for Markdown links in a file."""
+    targets: list[tuple[int, str]] = []
+    in_fence = False
+
+    for line_number, line in enumerate(readme_path.read_text().splitlines(), start=1):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        for match in _REFERENCE_LINK_RE.finditer(line):
+            targets.append((line_number, match.group(1)))
+        for match in _INLINE_LINK_RE.finditer(line):
+            targets.append((line_number, match.group(1)))
+
+    return targets
+
+
+def _check_readme_links(path: Path, readme: object) -> list[str]:
+    """Return PyPI-rendering issues for the package README."""
+    readme_file: str | None = None
+    if isinstance(readme, str):
+        readme_file = readme
+    elif isinstance(readme, dict) and isinstance(readme.get("file"), str):
+        readme_file = readme["file"]
+
+    if not readme_file or Path(readme_file).suffix.lower() != ".md":
+        return []
+
+    readme_path = path.parent / readme_file
+    if not readme_path.exists():
+        return [f"readme file not found: {readme_file}"]
+
+    return [
+        f"relative markdown link in {readme_file}:{line_number} -> {target}"
+        for line_number, target in _iter_markdown_link_targets(readme_path)
+        if _is_relative_markdown_target(target)
+    ]
 
 
 def _check_package(path: Path) -> list[str]:
@@ -70,6 +129,8 @@ def _check_package(path: Path) -> list[str]:
     readme = project.get("readme")
     if not readme:
         issues.append("missing `readme`")
+    else:
+        issues.extend(_check_readme_links(path, readme))
 
     # authors
     authors = project.get("authors")

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -203,11 +203,17 @@ def _check_readme_links(path: Path, readme: object) -> list[str]:
     readme_file: str | None = None
     if isinstance(readme, str):
         readme_file = readme
-    elif isinstance(readme, dict) and isinstance(readme.get("file"), str):
-        readme_file = readme["file"]
+    elif isinstance(readme, dict):
+        file_value = readme.get("file")
+        if isinstance(file_value, str):
+            readme_file = file_value
+        else:
+            return ["readme must reference a file path"]
+    else:
+        return ["readme must reference a file path"]
 
     if not readme_file:
-        return []
+        return ["readme must reference a file path"]
 
     readme_path, issues = _validated_readme_path(path, readme_file)
     if issues or readme_path is None:

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -6,7 +6,7 @@ every published Python package has the metadata fields users expect to
 see on PyPI:
 
 * ``description`` — single sentence, ≤ 200 chars
-* ``readme`` — set (per-package README.md, not just root link)
+* ``readme`` — set (safe per-package README file path, not just root link)
 * ``authors`` — populated
 * ``license`` — set
 * ``requires-python`` — ``>=3.11`` (matches AGENTS.md invariant)

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -12,7 +12,7 @@ see on PyPI:
 * ``requires-python`` — ``>=3.11`` (matches AGENTS.md invariant)
 * ``classifiers`` — License (MIT), Python versions (3.11/3.12/3.13),
   Topic, Development Status
-* ``project_urls`` — Homepage, Documentation, Repository, Issues
+* ``project.urls`` — Homepage, Documentation, Repository, Issues
 * ``keywords`` — non-empty
 * ``readme`` Markdown links — absolute URLs only for files rendered on PyPI
 

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -95,6 +95,38 @@ def test_check_package_reports_relative_link_wrapped_around_badge(tmp_path: Path
     ]
 
 
+def test_check_package_ignores_mismatched_fence_marker_inside_code_block(
+    tmp_path: Path,
+):
+    pyproject = _write_package(
+        tmp_path,
+        "\n".join(
+            [
+                "```text",
+                "~~~",
+                "See [pricing](../../../docs/reference/pricing-recipes.md).",
+                "```",
+            ]
+        ),
+    )
+
+    assert cpm._check_package(pyproject) == []
+
+
+def test_check_package_does_not_rescan_markdown_link_title(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "See [docs](https://example.com/docs "
+        '"[ignored](../../../docs/reference/pricing-recipes.md)") and '
+        '[pricing](../../../docs/reference/pricing-recipes.md "Pricing docs").\n',
+    )
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: relative markdown link in README.md:1 -> "
+        "../../../docs/reference/pricing-recipes.md"
+    ]
+
+
 def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,
@@ -238,3 +270,30 @@ def test_check_package_reports_unreadable_readme(tmp_path: Path):
 
     assert len(issues) == 1
     assert issues[0].startswith("genblaze-example: readme file cannot be read: README.md: ")
+
+
+def test_check_package_rejects_readme_swapped_after_validation(
+    tmp_path: Path,
+    monkeypatch,
+):
+    pyproject = _write_package(tmp_path, "See [docs](https://example.com/docs).\n")
+    original_validate = cpm._validated_readme_path
+
+    def replacing_validate(path: Path, readme_file: str):
+        readme_path, stat_result, issues = original_validate(path, readme_file)
+        if readme_path is not None and stat_result is not None:
+            readme_path.write_text(
+                "See [pricing](../../../docs/reference/pricing-recipes.md).\n",
+                encoding="utf-8",
+            )
+        return readme_path, stat_result, issues
+
+    monkeypatch.setattr(cpm, "_validated_readme_path", replacing_validate)
+
+    issues = cpm._check_package(pyproject)
+
+    assert len(issues) == 1
+    assert issues[0] == (
+        "genblaze-example: readme file cannot be read: README.md: "
+        "readme file changed after validation"
+    )

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -1,0 +1,73 @@
+"""Tests for tools/check_pypi_metadata.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import check_pypi_metadata as cpm  # noqa: E402
+
+
+def _write_package(tmp_path: Path, readme_text: str) -> Path:
+    package_dir = tmp_path / "libs" / "example"
+    package_dir.mkdir(parents=True)
+    (package_dir / "README.md").write_text(readme_text)
+    pyproject = package_dir / "pyproject.toml"
+    pyproject.write_text(
+        """[project]
+name = "genblaze-example"
+version = "0.1.0"
+description = "Example package for metadata tests"
+authors = [{name = "Backblaze Labs"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Multimedia",
+]
+keywords = ["genblaze"]
+
+[project.urls]
+Homepage = "https://github.com/backblaze-labs/genblaze"
+Documentation = "https://github.com/backblaze-labs/genblaze#readme"
+Repository = "https://github.com/backblaze-labs/genblaze"
+Issues = "https://github.com/backblaze-labs/genblaze/issues"
+"""
+    )
+    return pyproject
+
+
+def test_check_package_reports_relative_readme_links(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "See [pricing](../../../docs/reference/pricing-recipes.md).\n",
+    )
+
+    issues = cpm._check_package(pyproject)
+
+    assert issues == [
+        "genblaze-example: relative markdown link in README.md:1 -> "
+        "../../../docs/reference/pricing-recipes.md"
+    ]
+
+
+def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "\n".join(
+            [
+                "See [pricing](https://github.com/backblaze-labs/genblaze/blob/main/docs/reference/pricing-recipes.md).",
+                "Jump to [usage](#usage).",
+                "Contact [maintainers](mailto:oss@backblaze.com).",
+            ]
+        ),
+    )
+
+    assert cpm._check_package(pyproject) == []

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -149,3 +149,13 @@ def test_check_package_rejects_oversized_readme_before_reading(tmp_path: Path):
         "genblaze-example: readme file too large: README.md "
         f"({cpm._README_MAX_BYTES + 1} bytes > {cpm._README_MAX_BYTES})"
     ]
+
+
+def test_check_package_reports_unreadable_readme(tmp_path: Path):
+    pyproject = _write_package(tmp_path, None)
+    (pyproject.parent / "README.md").write_bytes(b"\xff")
+
+    issues = cpm._check_package(pyproject)
+
+    assert len(issues) == 1
+    assert issues[0].startswith("genblaze-example: readme file cannot be read: README.md: ")

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -95,6 +95,27 @@ def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
     assert cpm._check_package(pyproject) == []
 
 
+def test_check_package_rejects_unsupported_readme_link_schemes(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "\n".join(
+            [
+                "Avoid [script](javascript:alert(1)).",
+                "Avoid [local](file:///tmp/secret.md).",
+                r"Avoid [drive](C:\docs\readme.md).",
+            ]
+        ),
+    )
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: unsupported markdown link scheme in README.md:1 -> javascript:alert(1)",
+        "genblaze-example: unsupported markdown link scheme in README.md:2 -> "
+        "file:///tmp/secret.md",
+        "genblaze-example: unsupported markdown link scheme in README.md:3 -> "
+        r"C:\docs\readme.md",
+    ]
+
+
 def test_check_package_rejects_absolute_readme_path(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -12,18 +12,26 @@ if str(_TOOLS_DIR) not in sys.path:
 import check_pypi_metadata as cpm  # noqa: E402
 
 
-def _write_package(tmp_path: Path, readme_text: str) -> Path:
+def _write_package(
+    tmp_path: Path,
+    readme_text: str | None,
+    *,
+    readme_file: str = "README.md",
+) -> Path:
     package_dir = tmp_path / "libs" / "example"
     package_dir.mkdir(parents=True)
-    (package_dir / "README.md").write_text(readme_text)
+    if readme_text is not None:
+        readme_path = package_dir / readme_file
+        readme_path.parent.mkdir(parents=True, exist_ok=True)
+        readme_path.write_text(readme_text)
     pyproject = package_dir / "pyproject.toml"
     pyproject.write_text(
-        """[project]
+        f"""[project]
 name = "genblaze-example"
 version = "0.1.0"
 description = "Example package for metadata tests"
-authors = [{name = "Backblaze Labs"}]
-readme = "README.md"
+authors = [{{name = "Backblaze Labs"}}]
+readme = "{readme_file}"
 requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
@@ -58,6 +66,20 @@ def test_check_package_reports_relative_readme_links(tmp_path: Path):
     ]
 
 
+def test_check_package_reports_relative_link_with_nested_bracket_label(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "See [pricing [recipes]](../../../docs/reference/pricing-recipes.md).\n",
+    )
+
+    issues = cpm._check_package(pyproject)
+
+    assert issues == [
+        "genblaze-example: relative markdown link in README.md:1 -> "
+        "../../../docs/reference/pricing-recipes.md"
+    ]
+
+
 def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,
@@ -71,3 +93,59 @@ def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
     )
 
     assert cpm._check_package(pyproject) == []
+
+
+def test_check_package_rejects_absolute_readme_path(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        None,
+        readme_file=str(tmp_path / "README.md"),
+    )
+
+    assert cpm._check_package(pyproject) == [
+        f"genblaze-example: readme path must be relative: {tmp_path / 'README.md'}"
+    ]
+
+
+def test_check_package_rejects_out_of_package_readme_path(tmp_path: Path):
+    (tmp_path / "outside.md").write_text(
+        "See [pricing](../../../docs/reference/pricing-recipes.md).\n"
+    )
+    pyproject = _write_package(
+        tmp_path,
+        None,
+        readme_file="../../outside.md",
+    )
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: readme path must stay within package: ../../outside.md"
+    ]
+
+
+def test_check_package_rejects_symlinked_readme_without_reading_target(tmp_path: Path):
+    target = tmp_path / "target.md"
+    target.write_text("See [pricing](../../../docs/reference/pricing-recipes.md).\n")
+    pyproject = _write_package(tmp_path, None)
+    (pyproject.parent / "README.md").symlink_to(target)
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: readme path must not contain symlinks: README.md"
+    ]
+
+
+def test_check_package_rejects_non_regular_readme(tmp_path: Path):
+    pyproject = _write_package(tmp_path, None)
+    (pyproject.parent / "README.md").mkdir()
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: readme path is not a regular file: README.md"
+    ]
+
+
+def test_check_package_rejects_oversized_readme_before_reading(tmp_path: Path):
+    pyproject = _write_package(tmp_path, "x" * (cpm._README_MAX_BYTES + 1))
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: readme file too large: README.md "
+        f"({cpm._README_MAX_BYTES + 1} bytes > {cpm._README_MAX_BYTES})"
+    ]

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -132,6 +132,25 @@ def test_check_package_does_not_scan_non_markdown_readme_links(tmp_path: Path):
     assert cpm._check_package(pyproject) == []
 
 
+def test_check_package_rejects_readme_table_without_file(tmp_path: Path):
+    pyproject = _write_package(tmp_path, None)
+    pyproject.write_text(
+        pyproject.read_text().replace(
+            'readme = "README.md"',
+            'readme = {text = "embedded", content-type = "text/markdown"}',
+        )
+    )
+
+    assert cpm._check_package(pyproject) == ["genblaze-example: readme must reference a file path"]
+
+
+def test_check_package_rejects_non_string_readme_value(tmp_path: Path):
+    pyproject = _write_package(tmp_path, None)
+    pyproject.write_text(pyproject.read_text().replace('readme = "README.md"', "readme = 42"))
+
+    assert cpm._check_package(pyproject) == ["genblaze-example: readme must reference a file path"]
+
+
 def test_check_package_rejects_absolute_readme_path(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -81,6 +81,20 @@ def test_check_package_reports_relative_link_with_nested_bracket_label(tmp_path:
     ]
 
 
+def test_check_package_reports_relative_link_wrapped_around_badge(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "[![Docs](https://example.com/badge.svg)](../../../docs/reference/pricing-recipes.md)\n",
+    )
+
+    issues = cpm._check_package(pyproject)
+
+    assert issues == [
+        "genblaze-example: relative markdown link in README.md:1 -> "
+        "../../../docs/reference/pricing-recipes.md"
+    ]
+
+
 def test_check_package_allows_absolute_readme_links_and_anchors(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -110,9 +110,9 @@ def test_check_package_rejects_unsupported_readme_link_schemes(tmp_path: Path):
     assert cpm._check_package(pyproject) == [
         "genblaze-example: unsupported markdown link scheme in README.md:1 -> javascript:alert(1)",
         "genblaze-example: unsupported markdown link scheme in README.md:2 -> "
-        "file:///tmp/secret.md",
+        + "file:///tmp/secret.md",
         "genblaze-example: unsupported markdown link scheme in README.md:3 -> "
-        r"C:\docs\readme.md",
+        + r"C:\docs\readme.md",
     ]
 
 

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -23,7 +23,7 @@ def _write_package(
     if readme_text is not None:
         readme_path = package_dir / readme_file
         readme_path.parent.mkdir(parents=True, exist_ok=True)
-        readme_path.write_text(readme_text)
+        readme_path.write_text(readme_text, encoding="utf-8")
     pyproject = package_dir / "pyproject.toml"
     pyproject.write_text(
         f"""[project]
@@ -47,7 +47,8 @@ Homepage = "https://github.com/backblaze-labs/genblaze"
 Documentation = "https://github.com/backblaze-labs/genblaze#readme"
 Repository = "https://github.com/backblaze-labs/genblaze"
 Issues = "https://github.com/backblaze-labs/genblaze/issues"
-"""
+""",
+        encoding="utf-8",
     )
     return pyproject
 
@@ -135,10 +136,11 @@ def test_check_package_does_not_scan_non_markdown_readme_links(tmp_path: Path):
 def test_check_package_rejects_readme_table_without_file(tmp_path: Path):
     pyproject = _write_package(tmp_path, None)
     pyproject.write_text(
-        pyproject.read_text().replace(
+        pyproject.read_text(encoding="utf-8").replace(
             'readme = "README.md"',
             'readme = {text = "embedded", content-type = "text/markdown"}',
-        )
+        ),
+        encoding="utf-8",
     )
 
     assert cpm._check_package(pyproject) == ["genblaze-example: readme must reference a file path"]
@@ -146,7 +148,10 @@ def test_check_package_rejects_readme_table_without_file(tmp_path: Path):
 
 def test_check_package_rejects_non_string_readme_value(tmp_path: Path):
     pyproject = _write_package(tmp_path, None)
-    pyproject.write_text(pyproject.read_text().replace('readme = "README.md"', "readme = 42"))
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace('readme = "README.md"', "readme = 42"),
+        encoding="utf-8",
+    )
 
     assert cpm._check_package(pyproject) == ["genblaze-example: readme must reference a file path"]
 
@@ -165,7 +170,8 @@ def test_check_package_rejects_absolute_readme_path(tmp_path: Path):
 
 def test_check_package_rejects_out_of_package_readme_path(tmp_path: Path):
     (tmp_path / "outside.md").write_text(
-        "See [pricing](../../../docs/reference/pricing-recipes.md).\n"
+        "See [pricing](../../../docs/reference/pricing-recipes.md).\n",
+        encoding="utf-8",
     )
     pyproject = _write_package(
         tmp_path,
@@ -180,7 +186,10 @@ def test_check_package_rejects_out_of_package_readme_path(tmp_path: Path):
 
 def test_check_package_rejects_symlinked_readme_without_reading_target(tmp_path: Path):
     target = tmp_path / "target.md"
-    target.write_text("See [pricing](../../../docs/reference/pricing-recipes.md).\n")
+    target.write_text(
+        "See [pricing](../../../docs/reference/pricing-recipes.md).\n",
+        encoding="utf-8",
+    )
     pyproject = _write_package(tmp_path, None)
     (pyproject.parent / "README.md").symlink_to(target)
 

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -116,6 +116,22 @@ def test_check_package_rejects_unsupported_readme_link_schemes(tmp_path: Path):
     ]
 
 
+def test_check_package_validates_non_markdown_readme_path(tmp_path: Path):
+    pyproject = _write_package(tmp_path, None, readme_file="README.rst")
+
+    assert cpm._check_package(pyproject) == ["genblaze-example: readme file not found: README.rst"]
+
+
+def test_check_package_does_not_scan_non_markdown_readme_links(tmp_path: Path):
+    pyproject = _write_package(
+        tmp_path,
+        "See `docs/reference/pricing-recipes.md <../../../docs/reference/pricing-recipes.md>`_.\n",
+        readme_file="README.rst",
+    )
+
+    assert cpm._check_package(pyproject) == []
+
+
 def test_check_package_rejects_absolute_readme_path(tmp_path: Path):
     pyproject = _write_package(
         tmp_path,


### PR DESCRIPTION
## Summary
- Replaced the three PyPI-broken relative README links in genblaze-gmicloud and genblaze-nvidia with absolute GitHub blob URLs.
- Added a PyPI metadata gate that rejects relative Markdown links and unsupported link schemes in package README files rendered on PyPI.
- Hardened README validation to reject unsafe paths, parent traversal, symlinks, non-regular files, oversized files, unreadable files, non-file README declarations, and read-after-validate swaps before release.
- Kept non-Markdown README files path-validated while limiting Markdown link scanning to Markdown READMEs.
- Improved Markdown scanning for nested labels, linked badges, matching fenced code blocks, and inline-link titles.
- Added regression tests for nested-bracket Markdown labels, linked badges, fenced code blocks, inline-link titles, unsafe paths, unsupported schemes, unreadable READMEs, non-Markdown README handling, non-file README declarations, read-after-validate swaps, and UTF-8 fixture determinism.
- Documented the PyPI package README link policy in contributor-facing docs, plus completed execution plan `docs/exec-plans/completed/pypi-readme-relative-link-gate.md`.

## Linked Issue
Closes #14

## Tests
- `make pypi-metadata-check`
- `pytest tools/tests -v`
- `python -m pytest tools/tests/test_check_pypi_metadata.py -v`
- `make test`
- `make lint`
- `ruff check tools/check_pypi_metadata.py tools/tests/test_check_pypi_metadata.py`
- `ruff format --check tools/check_pypi_metadata.py tools/tests/test_check_pypi_metadata.py`

## Follow-up Notes
- None.