### PR TITLE
fix: validate GMICloud video duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Add new entries here. -->
 
+### Changed
+
+- `genblaze-gmicloud`: video `duration` now requires whole-second integer
+  values; fractional numeric and string inputs fail invalid-input validation
+  instead of being silently truncated (#90).
+
 ## [0.4.0] - 2026-06-25
 
 Security hardening (SSRF, URL-only asset verification), two new providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `genblaze-gmicloud`: video `duration` now requires whole-second integer
-  values; fractional numeric and string inputs fail invalid-input validation
-  instead of being silently truncated (#90).
+  values from 1 to 60 seconds; fractional, zero/negative, and oversized
+  inputs fail invalid-input validation instead of being silently truncated
+  or forwarded (#90).
 
 ## [0.4.0] - 2026-06-25
 

--- a/docs/exec-plans/completed/issue-90-gmicloud-duration-validation.md
+++ b/docs/exec-plans/completed/issue-90-gmicloud-duration-validation.md
@@ -1,0 +1,26 @@
+# Issue 90: GMICloud duration validation
+
+## Issue
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/90
+
+GMICloud video specs coerced `duration` with `int` before schema validation. Fractional
+seconds such as `5.5` were silently truncated to `5`, and fractional strings exposed
+the raw `int()` error instead of a typed invalid-input message.
+
+## Plan
+
+1. Add regression tests covering fractional numeric and string durations.
+2. Replace the lossy `int` coercer with a whole-second coercer that preserves
+   invalid values for typed schema validation.
+3. Add a real `IntSchema` for GMICloud video `duration` on family specs and the
+   fallback spec.
+4. Update video parameter docs to note GMICloud's whole-second requirement.
+5. Run the focused GMICloud tests, `make test`, and `make lint`.
+
+## Verification
+
+- `cd libs/connectors/gmicloud && pytest tests/test_gmicloud_provider.py tests/test_catalog_decoupling.py -v`
+- `cd libs/connectors/gmicloud && pytest -v`
+- `make test`
+- `make lint`

--- a/docs/exec-plans/completed/issue-90-gmicloud-duration-validation.md
+++ b/docs/exec-plans/completed/issue-90-gmicloud-duration-validation.md
@@ -14,8 +14,9 @@ the raw `int()` error instead of a typed invalid-input message.
 2. Replace the lossy `int` coercer with a whole-second coercer that preserves
    invalid values for typed schema validation.
 3. Add a real `IntSchema` for GMICloud video `duration` on family specs and the
-   fallback spec.
-4. Update video parameter docs to note GMICloud's whole-second requirement.
+   fallback spec, including a finite 1-60 second bound.
+4. Update video parameter docs and the changelog to note GMICloud's whole-second
+   duration requirement and upper bound.
 5. Run the focused GMICloud tests, `make test`, and `make lint`.
 
 ## Verification

--- a/docs/features/video-params.md
+++ b/docs/features/video-params.md
@@ -22,7 +22,7 @@ Standard `step.params` keys that video/audio providers should map from.
 | Standard Key | Runway | Luma | Google Veo | GMICloud video |
 |-------------|--------|------|------------|----------------|
 | `aspect_ratio` | `ratio` | `aspect_ratio` (native) | `aspect_ratio` (native) | `aspect_ratio` (native) |
-| `duration` | `duration` (native, int) | `duration` | `duration_seconds` | `duration` (native, whole-second int) |
+| `duration` | `duration` (native, int) | `duration` | `duration_seconds` | `duration` (native, whole-second int, 1–60s) |
 | `resolution` | — | `resolution` (native) | `resolution` (native) | `resolution` (native) |
 
 ## Audio Asset Metadata

--- a/docs/features/video-params.md
+++ b/docs/features/video-params.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-07-07 -->
 # Video & Audio Parameter Conventions
 
 Standard `step.params` keys that video/audio providers should map from.
@@ -19,11 +19,11 @@ Standard `step.params` keys that video/audio providers should map from.
 
 ## Provider Mapping
 
-| Standard Key | Runway | Luma | Google Veo |
-|-------------|--------|------|------------|
-| `aspect_ratio` | `ratio` | `aspect_ratio` (native) | `aspect_ratio` (native) |
-| `duration` | `duration` (native, int) | `duration` | `duration_seconds` |
-| `resolution` | — | `resolution` (native) | `resolution` (native) |
+| Standard Key | Runway | Luma | Google Veo | GMICloud video |
+|-------------|--------|------|------------|----------------|
+| `aspect_ratio` | `ratio` | `aspect_ratio` (native) | `aspect_ratio` (native) | `aspect_ratio` (native) |
+| `duration` | `duration` (native, int) | `duration` | `duration_seconds` | `duration` (native, whole-second int) |
+| `resolution` | — | `resolution` (native) | `resolution` (native) | `resolution` (native) |
 
 ## Audio Asset Metadata
 

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -68,22 +68,25 @@ def _coerce_whole_seconds(value: Any) -> Any:
     return value
 
 
+_DURATION_PARAM_CONTRACT = {
+    "param_coercers": {"duration": _coerce_whole_seconds},
+    "param_schemas": {"duration": _DURATION_SECONDS_SCHEMA},
+}
+
+
 def _video_surface_fields(surface: ParamSurface) -> dict[str, Any]:
     fields = surface.build()
-    fields["param_schemas"] = {
-        **fields.get("param_schemas", {}),
-        "duration": _DURATION_SECONDS_SCHEMA,
-    }
+    for key, values in _DURATION_PARAM_CONTRACT.items():
+        fields[key] = {**fields.get(key, {}), **values}
     return fields
 
 
 # Default video surface — universally meaningful video params + GMI's
 # canonical-to-native ``guidance_scale``→``cfg_scale`` rename and
-# whole-second duration validation.
+# shared whole-second duration contract.
 _VIDEO_BASE = (
     ParamSurface.for_modality(Modality.VIDEO)
     .with_aliases(guidance_scale="cfg_scale")
-    .with_coercers(duration=_coerce_whole_seconds)
     .extend("cfg_scale")
 )
 
@@ -226,8 +229,7 @@ _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"guidance_scale": "cfg_scale"},
-    param_coercers={"duration": _coerce_whole_seconds},
-    param_schemas={"duration": _DURATION_SECONDS_SCHEMA},
+    **_DURATION_PARAM_CONTRACT,
     input_mapping=_COMMON_INPUT,
     extras=_ENVELOPE,
 )

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -31,9 +31,11 @@ runtime; preflight surfaces ``OK_PROVISIONAL`` with
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from genblaze_core.models.enums import Modality
 from genblaze_core.providers import (
+    IntSchema,
     ModelFamily,
     ModelRegistry,
     ModelSpec,
@@ -43,13 +45,45 @@ from genblaze_core.providers import (
 
 from .._probe import empty_payload_request_probe
 
+_DURATION_SECONDS_SCHEMA = IntSchema(min=1)
+
+
+def _coerce_whole_seconds(value: Any) -> Any:
+    """Coerce only whole-second duration values.
+
+    Invalid values intentionally pass through so ``IntSchema`` emits the
+    standard typed validation error instead of leaking a raw ``int()`` failure
+    or silently truncating fractional seconds.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if re.fullmatch(r"[+-]?\d+", stripped):
+            return int(stripped)
+    return value
+
+
+def _video_surface_fields(surface: ParamSurface) -> dict[str, Any]:
+    fields = surface.build()
+    fields["param_schemas"] = {
+        **fields.get("param_schemas", {}),
+        "duration": _DURATION_SECONDS_SCHEMA,
+    }
+    return fields
+
+
 # Default video surface — universally meaningful video params + GMI's
 # canonical-to-native ``guidance_scale``→``cfg_scale`` rename and
-# duration coercion.
+# whole-second duration validation.
 _VIDEO_BASE = (
     ParamSurface.for_modality(Modality.VIDEO)
     .with_aliases(guidance_scale="cfg_scale")
-    .with_coercers(duration=int)
+    .with_coercers(duration=_coerce_whole_seconds)
     .extend("cfg_scale")
 )
 
@@ -72,7 +106,7 @@ _GMI_VIDEO_PIXVERSE_FAMILY = ModelFamily(
         modality=Modality.VIDEO,
         input_mapping=_COMMON_INPUT,
         extras=_ENVELOPE,
-        **_PIXVERSE.build(),
+        **_video_surface_fields(_PIXVERSE),
     ),
     description="Pixverse v5.6 family — t2v, i2v, transition.",
     example_slugs=(
@@ -94,7 +128,7 @@ _GMI_VIDEO_WAN_R2V_FAMILY = ModelFamily(
         modality=Modality.VIDEO,
         input_mapping=_COMMON_INPUT,
         extras=_ENVELOPE,
-        **_WAN_REF.build(),
+        **_video_surface_fields(_WAN_REF),
     ),
     description="Wan reference-to-video — keyframe-conditioned generation.",
     example_slugs=("wan2.6-r2v",),
@@ -136,7 +170,7 @@ _GMI_VIDEO_VEO_FAMILY = ModelFamily(
         # "this model produces audio" signal alongside the family
         # definition where future maintainers will look for it.
         extras={**_ENVELOPE, "has_audio": True},
-        **_VIDEO_BASE.build(),
+        **_video_surface_fields(_VIDEO_BASE),
     ),
     description="Google Veo family on GMI — produces video + audio tracks.",
     example_slugs=("Veo3", "Veo3-Fast"),
@@ -179,7 +213,7 @@ _GMI_VIDEO_KLING_V21_FAMILY = ModelFamily(
         modality=Modality.VIDEO,
         input_mapping=_COMMON_INPUT,
         extras=_ENVELOPE,
-        **_VIDEO_BASE.build(),
+        **_video_surface_fields(_VIDEO_BASE),
     ),
     description="Kling V2.1 (Master) — Text2Video / Image2Video on GMI.",
     example_slugs=("Kling-Text2Video-V2.1-Master", "Kling-Image2Video-V2.1-Master"),
@@ -192,7 +226,8 @@ _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"guidance_scale": "cfg_scale"},
-    param_coercers={"duration": int},
+    param_coercers={"duration": _coerce_whole_seconds},
+    param_schemas={"duration": _DURATION_SECONDS_SCHEMA},
     input_mapping=_COMMON_INPUT,
     extras=_ENVELOPE,
 )

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -47,7 +47,11 @@ from genblaze_core.providers import (
 
 from .._probe import empty_payload_request_probe
 
-_DURATION_SECONDS_SCHEMA = IntSchema(min=1)
+# GMICloud does not expose a stable public per-family duration matrix. Keep a
+# finite connector-wide cap so untrusted callers cannot enqueue unbounded,
+# per-second video work through the permissive fallback.
+_MAX_VIDEO_DURATION_SECONDS = 60
+_DURATION_SECONDS_SCHEMA = IntSchema(min=1, max=_MAX_VIDEO_DURATION_SECONDS)
 
 
 class _DurationParamContract(TypedDict):

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -31,7 +31,8 @@ runtime; preflight surfaces ``OK_PROVISIONAL`` with
 from __future__ import annotations
 
 import re
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, TypedDict
 
 from genblaze_core.models.enums import Modality
 from genblaze_core.providers import (
@@ -39,6 +40,7 @@ from genblaze_core.providers import (
     ModelFamily,
     ModelRegistry,
     ModelSpec,
+    ParamSchema,
     ParamSurface,
     route_images,
 )
@@ -46,6 +48,11 @@ from genblaze_core.providers import (
 from .._probe import empty_payload_request_probe
 
 _DURATION_SECONDS_SCHEMA = IntSchema(min=1)
+
+
+class _DurationParamContract(TypedDict):
+    param_coercers: Mapping[str, Callable[[Any], Any]]
+    param_schemas: Mapping[str, ParamSchema]
 
 
 def _coerce_whole_seconds(value: Any) -> Any:
@@ -68,7 +75,7 @@ def _coerce_whole_seconds(value: Any) -> Any:
     return value
 
 
-_DURATION_PARAM_CONTRACT = {
+_DURATION_PARAM_CONTRACT: _DurationParamContract = {
     "param_coercers": {"duration": _coerce_whole_seconds},
     "param_schemas": {"duration": _DURATION_SECONDS_SCHEMA},
 }
@@ -76,8 +83,14 @@ _DURATION_PARAM_CONTRACT = {
 
 def _video_surface_fields(surface: ParamSurface) -> dict[str, Any]:
     fields = surface.build()
-    for key, values in _DURATION_PARAM_CONTRACT.items():
-        fields[key] = {**fields.get(key, {}), **values}
+    fields["param_coercers"] = {
+        **fields.get("param_coercers", {}),
+        **_DURATION_PARAM_CONTRACT["param_coercers"],
+    }
+    fields["param_schemas"] = {
+        **fields.get("param_schemas", {}),
+        **_DURATION_PARAM_CONTRACT["param_schemas"],
+    }
     return fields
 
 
@@ -229,7 +242,8 @@ _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"guidance_scale": "cfg_scale"},
-    **_DURATION_PARAM_CONTRACT,
+    param_coercers=_DURATION_PARAM_CONTRACT["param_coercers"],
+    param_schemas=_DURATION_PARAM_CONTRACT["param_schemas"],
     input_mapping=_COMMON_INPUT,
     extras=_ENVELOPE,
 )

--- a/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
+++ b/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
@@ -174,6 +174,7 @@ class TestVideoFamilyResolution:
             spec = provider._models.get(slug)
             assert "cfg_scale" in spec.param_aliases.values()
             assert "duration" in spec.param_coercers
+            assert "duration" in spec.param_schemas
 
     def test_kling_v21_routes_to_dedicated_family(self) -> None:
         """Kling V2.1 (text2video + image2video) gets its own family

--- a/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
@@ -409,9 +409,7 @@ def test_duration_coerced_to_int(provider):
     assert provider.prepare_payload(step)["duration"] == 10
 
 
-@pytest.mark.parametrize("duration", [5.5, 8.9])
-@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
-def test_fractional_duration_rejected_without_truncation(provider, duration, model):
+def _assert_invalid_duration(provider, model: str, duration):
     step = Step(
         provider="gmicloud",
         model=model,
@@ -426,25 +424,41 @@ def test_fractional_duration_rejected_without_truncation(provider, duration, mod
     assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
     assert "duration" in msg
     assert "Failed to coerce" not in msg
+    assert "invalid literal for int()" not in msg
+
+
+@pytest.mark.parametrize("duration", [5.5, 8.9])
+@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
+def test_fractional_duration_rejected_without_truncation(provider, duration, model):
+    _assert_invalid_duration(provider, model, duration)
 
 
 @pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
 def test_fractional_duration_string_rejected_with_typed_error(provider, model):
+    _assert_invalid_duration(provider, model, "7.5")
+
+
+@pytest.mark.parametrize("duration", [0, -1, 61, 10**9])
+@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
+def test_out_of_range_duration_rejected(provider, duration, model):
+    _assert_invalid_duration(provider, model, duration)
+
+
+@pytest.mark.parametrize("duration", [0, -1, 61, 10**9])
+@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
+def test_invalid_duration_does_not_submit_http_request(provider, duration, model):
     step = Step(
         provider="gmicloud",
         model=model,
         prompt="t",
-        params={"duration": "7.5"},
+        params={"duration": duration},
     )
 
     with pytest.raises(ProviderError) as exc_info:
-        provider.prepare_payload(step)
+        provider.submit(step)
 
-    msg = str(exc_info.value)
     assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
-    assert "duration" in msg
-    assert "Failed to coerce" not in msg
-    assert "invalid literal for int()" not in msg
+    provider._http_client.post.assert_not_called()
 
 
 def test_guidance_scale_aliased_to_cfg_scale(provider):

--- a/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
@@ -422,9 +422,10 @@ def test_fractional_duration_rejected_without_truncation(provider, duration, mod
     with pytest.raises(ProviderError) as exc_info:
         provider.prepare_payload(step)
 
+    msg = str(exc_info.value)
     assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
-    assert "Invalid parameter 'duration'" in str(exc_info.value)
-    assert "expected int, got float" in str(exc_info.value)
+    assert "duration" in msg
+    assert "Failed to coerce" not in msg
 
 
 @pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
@@ -439,10 +440,11 @@ def test_fractional_duration_string_rejected_with_typed_error(provider, model):
     with pytest.raises(ProviderError) as exc_info:
         provider.prepare_payload(step)
 
+    msg = str(exc_info.value)
     assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
-    assert "Invalid parameter 'duration'" in str(exc_info.value)
-    assert "expected int, got str" in str(exc_info.value)
-    assert "invalid literal for int()" not in str(exc_info.value)
+    assert "duration" in msg
+    assert "Failed to coerce" not in msg
+    assert "invalid literal for int()" not in msg
 
 
 def test_guidance_scale_aliased_to_cfg_scale(provider):

--- a/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
@@ -409,6 +409,42 @@ def test_duration_coerced_to_int(provider):
     assert provider.prepare_payload(step)["duration"] == 10
 
 
+@pytest.mark.parametrize("duration", [5.5, 8.9])
+@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
+def test_fractional_duration_rejected_without_truncation(provider, duration, model):
+    step = Step(
+        provider="gmicloud",
+        model=model,
+        prompt="t",
+        params={"duration": duration},
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        provider.prepare_payload(step)
+
+    assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
+    assert "Invalid parameter 'duration'" in str(exc_info.value)
+    assert "expected int, got float" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("model", ["kling-text2video-v1.6-pro", "pixverse-v5.6-t2v"])
+def test_fractional_duration_string_rejected_with_typed_error(provider, model):
+    step = Step(
+        provider="gmicloud",
+        model=model,
+        prompt="t",
+        params={"duration": "7.5"},
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        provider.prepare_payload(step)
+
+    assert exc_info.value.error_code == ProviderErrorCode.INVALID_INPUT
+    assert "Invalid parameter 'duration'" in str(exc_info.value)
+    assert "expected int, got str" in str(exc_info.value)
+    assert "invalid literal for int()" not in str(exc_info.value)
+
+
 def test_guidance_scale_aliased_to_cfg_scale(provider):
     step = Step(
         provider="gmicloud",


### PR DESCRIPTION
## Summary

- Replaces the lossy GMICloud video `duration=int` coercer with whole-second normalization that leaves fractional inputs for typed schema validation.
- Adds a shared duration contract for all GMICloud video family specs and the fallback spec, with `IntSchema(min=1, max=60)` validation attached everywhere.
- Rejects fractional, zero/negative, and oversized video duration values before any GMICloud HTTP request is made.
- Adds regression coverage for fallback and Pixverse video duration handling without pinning connector tests to exact core schema wording.
- Documents the user-visible contract change in `CHANGELOG.md`, updates video parameter docs, and records the completed issue plan.
- Types the shared duration contract so connector type checks pass.

Fixes #90

## Tests

- `mamba run -n genblaze-issue90 pytest tests/test_gmicloud_provider.py tests/test_catalog_decoupling.py -v` from `libs/connectors/gmicloud`
- `mamba run -n genblaze-issue90 pytest -v` from `libs/connectors/gmicloud`
- `mamba run -n genblaze-issue90 mypy libs/connectors/gmicloud/genblaze_*/ --ignore-missing-imports`
- Full connector mypy loop from CI typecheck job
- `make test`
- `mamba run -n genblaze-issue90 make lint`
- `gh pr checks 129 --repo backblaze-labs/genblaze`

## Follow-up notes

- GMICloud video duration remains second-granular and is now bounded to 1-60 seconds locally. Fractional numeric/string, zero/negative, and oversized values fail with `ProviderErrorCode.INVALID_INPUT` instead of being silently truncated, surfacing raw `int()` failures, or reaching submit.
