### PR TITLE
fix: render literal braces in PromptTemplate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-20 -->
+<!-- last_verified: 2026-07-08 -->
 # Architecture
 
 ## Components
@@ -111,7 +111,7 @@
 - Large MP4 support: MP4 handler uses seek-based I/O for files 500 MB–2 GB (in-memory for smaller files)
 - FFmpeg compositing: `FFmpegCompositor` SyncProvider muxes video + audio into MP4 via ffmpeg subprocess
 - FFmpeg transforms: `FFmpegTransform` SyncProvider for resize, crop, overlay_text, audio_normalize, and format conversion
-- Prompt templates: `PromptTemplate` with `{variable}` placeholders for batch workflows; `batch_run` accepts `list[dict]`
+- Prompt templates: `PromptTemplate` with `{variable}` placeholders for batch workflows, while non-placeholder braces remain literal prompt text; `batch_run` accepts `list[dict]`
 - Pipeline templates: `PipelineTemplate` serializable pipeline definitions (JSON); `Pipeline.to_template()` for export
 - Moderation hooks: `ModerationHook` ABC with `check_prompt`/`check_output` pre/post-step content screening
 - Webhook notifications: `WebhookNotifier` fire-and-forget HTTP status events via background thread; HTTPS-only URLs validated at construction, DNS-resolved against private IP ranges on first dispatch

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,7 @@
 - Large MP4 support: MP4 handler uses seek-based I/O for files 500 MB–2 GB (in-memory for smaller files)
 - FFmpeg compositing: `FFmpegCompositor` SyncProvider muxes video + audio into MP4 via ffmpeg subprocess
 - FFmpeg transforms: `FFmpegTransform` SyncProvider for resize, crop, overlay_text, audio_normalize, and format conversion
-- Prompt templates: `PromptTemplate` with `{variable}` placeholders for batch workflows, while non-placeholder braces remain literal prompt text; `batch_run` accepts `list[dict]`
+- Prompt templates: `PromptTemplate` with named Python format fields for batch workflows, while non-field braces remain literal prompt text; `batch_run` accepts `list[dict]`
 - Pipeline templates: `PipelineTemplate` serializable pipeline definitions (JSON); `Pipeline.to_template()` for export
 - Moderation hooks: `ModerationHook` ABC with `check_prompt`/`check_output` pre/post-step content screening
 - Webhook notifications: `WebhookNotifier` fire-and-forget HTTP status events via background thread; HTTPS-only URLs validated at construction, DNS-resolved against private IP ranges on first dispatch

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,7 @@
 - Large MP4 support: MP4 handler uses seek-based I/O for files 500 MB–2 GB (in-memory for smaller files)
 - FFmpeg compositing: `FFmpegCompositor` SyncProvider muxes video + audio into MP4 via ffmpeg subprocess
 - FFmpeg transforms: `FFmpegTransform` SyncProvider for resize, crop, overlay_text, audio_normalize, and format conversion
-- Prompt templates: `PromptTemplate` with named Python format fields for batch workflows, while non-field braces remain literal prompt text; `batch_run` accepts `list[dict]`
+- Prompt templates: `PromptTemplate` with top-level format fields for batch workflows, while non-field braces remain literal prompt text and attribute/item traversal is rejected; `batch_run` accepts `list[dict]`
 - Pipeline templates: `PipelineTemplate` serializable pipeline definitions (JSON); `Pipeline.to_template()` for export
 - Moderation hooks: `ModerationHook` ABC with `check_prompt`/`check_output` pre/post-step content screening
 - Webhook notifications: `WebhookNotifier` fire-and-forget HTTP status events via background thread; HTTPS-only URLs validated at construction, DNS-resolved against private IP ranges on first dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Add new entries here. -->
 
+### Security
+
+- `genblaze-core`: `PromptTemplate` now rejects attribute and item traversal
+  such as `{user.api_key}` and `{settings[voice]}`. Pass explicit top-level
+  values instead, for example `{api_key}` or `{voice}`. Top-level format specs
+  and conversions such as `{price:.2f}` and `{name!r}` remain supported (#88).
+
 ## [0.4.0] - 2026-06-25
 
 Security hardening (SSRF, URL-only asset verification), two new providers

--- a/docs/exec-plans/completed/prompt-template-literal-braces.md
+++ b/docs/exec-plans/completed/prompt-template-literal-braces.md
@@ -1,0 +1,17 @@
+<!-- completed: 2026-07-08 -->
+# Prompt Template Literal Braces
+
+## Summary
+
+Fix issue #88: `PromptTemplate` should render real `{variable}` placeholders without letting literal braces in JSON, code, dict, or set examples trip Python format parsing.
+
+## Scope
+
+- Replace `str.format_map()` parsing with `{identifier}`-only substitution.
+- Keep doubled braces as an escape for placeholder-shaped literal text.
+- Add regression coverage for JSON-shaped prompts, lone literal braces, and missing variables.
+- Update prompt-template behavior docs and the architecture feature list.
+
+## Verification
+
+- `pytest libs/core/tests/unit/test_prompt_template.py -q`

--- a/docs/exec-plans/completed/prompt-template-literal-braces.md
+++ b/docs/exec-plans/completed/prompt-template-literal-braces.md
@@ -7,9 +7,10 @@ Fix issue #88: `PromptTemplate` should render real `{variable}` placeholders wit
 
 ## Scope
 
-- Replace `str.format_map()` parsing with `{identifier}`-only substitution.
+- Replace whole-string `str.format_map()` parsing with field-by-field rendering.
+- Preserve named Python format fields, including format specs, conversions, attributes, and item lookups.
 - Keep doubled braces as an escape for placeholder-shaped literal text.
-- Add regression coverage for JSON-shaped prompts, lone literal braces, and missing variables.
+- Add regression coverage for JSON-shaped prompts, lone literal braces, missing variables, format fields, and placeholders adjacent to literal braces.
 - Update prompt-template behavior docs and the architecture feature list.
 
 ## Verification

--- a/docs/exec-plans/completed/prompt-template-literal-braces.md
+++ b/docs/exec-plans/completed/prompt-template-literal-braces.md
@@ -8,9 +8,9 @@ Fix issue #88: `PromptTemplate` should render real `{variable}` placeholders wit
 ## Scope
 
 - Replace whole-string `str.format_map()` parsing with field-by-field rendering.
-- Preserve named Python format fields, including format specs, conversions, attributes, and item lookups.
+- Preserve top-level Python format specs and conversions while rejecting attribute and item traversal.
 - Keep doubled braces as an escape for placeholder-shaped literal text.
-- Add regression coverage for JSON-shaped prompts, lone literal braces, missing variables, format fields, and placeholders adjacent to literal braces.
+- Add regression coverage for JSON-shaped prompts, lone literal braces, missing variables, format fields, rejected traversal, and placeholders adjacent to literal braces.
 - Update prompt-template behavior docs and the architecture feature list.
 
 ## Verification

--- a/docs/features/prompt-templates.md
+++ b/docs/features/prompt-templates.md
@@ -36,7 +36,8 @@ Dict items render `PromptTemplate` steps; plain string steps keep their original
 
 - Missing variables raise `ValueError`
 - Extra variables are silently ignored (useful when one dict serves multiple steps with different templates)
-- Only `{identifier}` placeholders are substituted; JSON, code blocks, dicts, sets, and other literal braces render as written
+- Named Python format fields are supported, including format specs (`{price:.2f}`), conversions (`{name!r}`), attributes (`{user.name}`), and item lookups (`{items[0]}`)
+- Single braces that do not start a named format field render as written, so JSON, code blocks, dicts, sets, and other literal braces are safe in prompts
 - Use doubled braces (`{{identifier}}`) when you need literal text that looks exactly like a placeholder
 - Unrendered templates in `run()` raise `GenblazeError` — use `batch_run(dicts)` or call `.render()` manually
 

--- a/docs/features/prompt-templates.md
+++ b/docs/features/prompt-templates.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-03-17 -->
+<!-- last_verified: 2026-07-08 -->
 # Prompt Templates
 
 `PromptTemplate` provides `{variable}` placeholders for reusable, parameterized prompts in batch workflows.
@@ -36,7 +36,8 @@ Dict items render `PromptTemplate` steps; plain string steps keep their original
 
 - Missing variables raise `ValueError`
 - Extra variables are silently ignored (useful when one dict serves multiple steps with different templates)
-- Literal braces use `{{` / `}}` per Python `str.format_map()` convention
+- Only `{identifier}` placeholders are substituted; JSON, code blocks, dicts, sets, and other literal braces render as written
+- Use doubled braces (`{{identifier}}`) when you need literal text that looks exactly like a placeholder
 - Unrendered templates in `run()` raise `GenblazeError` — use `batch_run(dicts)` or call `.render()` manually
 
 ## Serialization

--- a/docs/features/prompt-templates.md
+++ b/docs/features/prompt-templates.md
@@ -37,8 +37,8 @@ Dict items render `PromptTemplate` steps; plain string steps keep their original
 - Missing variables raise `ValueError`
 - Extra variables are silently ignored (useful when one dict serves multiple steps with different templates)
 - Named Python format fields are supported, including format specs (`{price:.2f}`), conversions (`{name!r}`), attributes (`{user.name}`), and item lookups (`{items[0]}`)
-- Single braces that do not start a named format field render as written, so JSON, code blocks, dicts, sets, and other literal braces are safe in prompts
-- Doubled braces in literal text collapse to single braces, matching Python format escaping; write `{{identifier}}` for literal `{identifier}`, or `{{{{ value }}}}` for literal `{{ value }}`
+- Single braces that cannot start a named format field render as written, including quoted-key JSON like `{"name": "{subject}"}` and code with whitespace or punctuation after `{`
+- Field-looking literal text must be escaped: write `{{identifier}}` for literal `{identifier}`, `{{name: "cat"}}` for literal `{name: "cat"}`, or `{{{{ value }}}}` for literal `{{ value }}`
 - Unrendered templates in `run()` raise `GenblazeError` — use `batch_run(dicts)` or call `.render()` manually
 
 ## Serialization

--- a/docs/features/prompt-templates.md
+++ b/docs/features/prompt-templates.md
@@ -36,10 +36,28 @@ Dict items render `PromptTemplate` steps; plain string steps keep their original
 
 - Missing variables raise `ValueError`
 - Extra variables are silently ignored (useful when one dict serves multiple steps with different templates)
-- Named Python format fields are supported, including format specs (`{price:.2f}`), conversions (`{name!r}`), attributes (`{user.name}`), and item lookups (`{items[0]}`)
+- Top-level named fields are supported, including format specs (`{price:.2f}`) and conversions (`{name!r}`)
+- Attribute and item traversal is rejected. Pass flattened values instead of templates such as `{user.name}`, `{settings[voice]}`, or `{items[0]}`
+- Nested fields inside format specs, such as `{value:{width}}`, are rejected
 - Single braces that cannot start a named format field render as written, including quoted-key JSON like `{"name": "{subject}"}` and code with whitespace or punctuation after `{`
 - Field-looking literal text must be escaped: write `{{identifier}}` for literal `{identifier}`, `{{name: "cat"}}` for literal `{name: "cat"}`, or `{{{{ value }}}}` for literal `{{ value }}`
 - Unrendered templates in `run()` raise `GenblazeError` — use `batch_run(dicts)` or call `.render()` manually
+
+## Migration from `str.format_map`
+
+`PromptTemplate` no longer exposes arbitrary Python formatter traversal. Existing templates that used attribute or item lookup should flatten the data before rendering:
+
+```python
+tpl = PromptTemplate(template="Voice: {voice}")
+tpl.render(voice=settings["voice"])
+```
+
+Format specs and conversions on top-level variables remain supported:
+
+```python
+PromptTemplate(template="Price: {price:.2f}").render(price=1.2)
+PromptTemplate(template="Name: {name!r}").render(name="Ada")
+```
 
 ## Serialization
 

--- a/docs/features/prompt-templates.md
+++ b/docs/features/prompt-templates.md
@@ -38,7 +38,7 @@ Dict items render `PromptTemplate` steps; plain string steps keep their original
 - Extra variables are silently ignored (useful when one dict serves multiple steps with different templates)
 - Named Python format fields are supported, including format specs (`{price:.2f}`), conversions (`{name!r}`), attributes (`{user.name}`), and item lookups (`{items[0]}`)
 - Single braces that do not start a named format field render as written, so JSON, code blocks, dicts, sets, and other literal braces are safe in prompts
-- Use doubled braces (`{{identifier}}`) when you need literal text that looks exactly like a placeholder
+- Doubled braces in literal text collapse to single braces, matching Python format escaping; write `{{identifier}}` for literal `{identifier}`, or `{{{{ value }}}}` for literal `{{ value }}`
 - Unrendered templates in `run()` raise `GenblazeError` — use `batch_run(dicts)` or call `.render()` manually
 
 ## Serialization

--- a/libs/core/genblaze_core/models/prompt_template.py
+++ b/libs/core/genblaze_core/models/prompt_template.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import re
+import string
+from collections.abc import Iterator
 from typing import Any
 
 from pydantic import BaseModel
 
-_VARIABLE_PATTERN = re.compile(r"(?<!\{)\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}(?!\})")
+_FORMATTER = string.Formatter()
 
 
 def _unescape_literal_braces(text: str) -> str:
@@ -15,12 +16,115 @@ def _unescape_literal_braces(text: str) -> str:
     return text.replace("{{", "{").replace("}}", "}")
 
 
+def _looks_like_field_start(char: str) -> bool:
+    return char == "_" or char.isalpha()
+
+
+def _parse_single_field(field: str) -> tuple[str, str, str | None]:
+    text = "{" + field + "}"
+    try:
+        parsed = list(_FORMATTER.parse(text))
+    except ValueError as exc:
+        raise ValueError(f"Invalid template field: {text}") from exc
+
+    if len(parsed) != 1:
+        raise ValueError(f"Invalid template field: {text}")
+
+    literal, field_name, format_spec, conversion = parsed[0]
+    if literal or field_name is None:
+        raise ValueError(f"Invalid template field: {text}")
+
+    root = _root_variable_name(field_name)
+    if root is None:
+        raise ValueError(
+            f"Unsupported template field: {text}. Use a named variable such as {{name}}."
+        )
+
+    return root, format_spec, conversion
+
+
+def _root_variable_name(field_name: str) -> str | None:
+    stop = len(field_name)
+    for delimiter in (".", "["):
+        index = field_name.find(delimiter)
+        if index != -1:
+            stop = min(stop, index)
+
+    root = field_name[:stop]
+    if root.isidentifier():
+        return root
+    return None
+
+
+def _is_valid_single_field(text: str) -> bool:
+    try:
+        _parse_single_field(text[1:-1])
+    except ValueError:
+        return False
+    return True
+
+
+def _find_field_end(template: str, start: int) -> int:
+    search_from = start + 1
+    while True:
+        end = template.find("}", search_from)
+        if end == -1:
+            raise ValueError(f"Invalid template field starting at: {template[start:]}")
+
+        if _is_valid_single_field(template[start : end + 1]):
+            return end
+
+        search_from = end + 1
+
+
+def _iter_template_parts(template: str) -> Iterator[tuple[str, str]]:
+    cursor = 0
+    index = 0
+
+    while index < len(template):
+        char = template[index]
+        if char == "{":
+            if index + 1 < len(template) and template[index + 1] == "{":
+                index += 2
+                continue
+
+            if index + 1 < len(template) and _looks_like_field_start(template[index + 1]):
+                end = _find_field_end(template, index)
+                yield "literal", _unescape_literal_braces(template[cursor:index])
+                yield "field", template[index + 1 : end]
+                index = end + 1
+                cursor = index
+                continue
+
+        index += 1
+
+    yield "literal", _unescape_literal_braces(template[cursor:])
+
+
+def _field_variables(field: str) -> set[str]:
+    root, format_spec, _ = _parse_single_field(field)
+    variables = {root}
+    for kind, value in _iter_template_parts(format_spec):
+        if kind == "field":
+            variables.update(_field_variables(value))
+    return variables
+
+
+def _render_field(field: str, kwargs: dict[str, Any]) -> str:
+    text = "{" + field + "}"
+    try:
+        return _FORMATTER.vformat(text, (), kwargs)
+    except (KeyError, IndexError, AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(f"Could not render template field {text}: {exc}") from exc
+
+
 class PromptTemplate(BaseModel):
     """A prompt template with {variable} placeholders for batch workflows.
 
-    Substitutes only ``{identifier}`` placeholders. Other braces are treated as
-    literal prompt text so JSON, code snippets, and dict/set examples render as
-    written.
+    Supports named Python format fields such as ``{name}``, ``{price:.2f}``,
+    ``{user.name}``, and ``{items[0]}``. Braces that do not start a named field
+    are treated as literal prompt text so JSON, code snippets, and dict/set
+    examples render as written.
 
     Example::
 
@@ -34,7 +138,11 @@ class PromptTemplate(BaseModel):
     @property
     def variables(self) -> set[str]:
         """Return placeholder variable names found in the template."""
-        return {match.group("name") for match in _VARIABLE_PATTERN.finditer(self.template)}
+        variables: set[str] = set()
+        for kind, value in _iter_template_parts(self.template):
+            if kind == "field":
+                variables.update(_field_variables(value))
+        return variables
 
     def render(self, **kwargs: Any) -> str:
         """Render the template with the given variables.
@@ -48,11 +156,10 @@ class PromptTemplate(BaseModel):
         if missing:
             raise ValueError(f"Missing template variables: {', '.join(sorted(missing))}")
 
-        parts: list[str] = []
-        cursor = 0
-        for match in _VARIABLE_PATTERN.finditer(self.template):
-            parts.append(_unescape_literal_braces(self.template[cursor : match.start()]))
-            parts.append(str(kwargs[match.group("name")]))
-            cursor = match.end()
-        parts.append(_unescape_literal_braces(self.template[cursor:]))
-        return "".join(parts)
+        rendered: list[str] = []
+        for kind, value in _iter_template_parts(self.template):
+            if kind == "literal":
+                rendered.append(value)
+            else:
+                rendered.append(_render_field(value, kwargs))
+        return "".join(rendered)

--- a/libs/core/genblaze_core/models/prompt_template.py
+++ b/libs/core/genblaze_core/models/prompt_template.py
@@ -9,6 +9,8 @@ from typing import Any
 from pydantic import BaseModel
 
 _FORMATTER = string.Formatter()
+_MAX_TEMPLATE_FIELD_LENGTH = 256
+_SUPPORTED_CONVERSIONS = {None, "a", "r", "s"}
 
 
 def _unescape_literal_braces(text: str) -> str:
@@ -21,6 +23,12 @@ def _looks_like_field_start(char: str) -> bool:
 
 
 def _parse_single_field(field: str) -> tuple[str, str, str | None]:
+    if len(field) > _MAX_TEMPLATE_FIELD_LENGTH:
+        raise ValueError(
+            "Template field exceeds maximum length "
+            f"({_MAX_TEMPLATE_FIELD_LENGTH} characters): {{{field[:32]}...}}"
+        )
+
     text = "{" + field + "}"
     try:
         parsed = list(_FORMATTER.parse(text))
@@ -34,47 +42,53 @@ def _parse_single_field(field: str) -> tuple[str, str, str | None]:
     if literal or field_name is None:
         raise ValueError(f"Invalid template field: {text}")
 
-    root = _root_variable_name(field_name)
-    if root is None:
+    if not field_name.isidentifier():
         raise ValueError(
-            f"Unsupported template field: {text}. Use a named variable such as {{name}}."
+            f"Unsupported template field: {text}. PromptTemplate supports only "
+            "top-level variables such as {name}; pass flattened values instead "
+            "of using attribute or item lookups."
         )
 
-    return root, format_spec or "", conversion
+    if conversion not in _SUPPORTED_CONVERSIONS:
+        raise ValueError(
+            f"Unsupported template conversion in {text}. Supported conversions are !s, !r, and !a."
+        )
+
+    if format_spec and ("{" in format_spec or "}" in format_spec):
+        raise ValueError(f"Nested template fields in format specs are not supported: {text}")
+
+    return field_name, format_spec or "", conversion
 
 
-def _root_variable_name(field_name: str) -> str | None:
-    stop = len(field_name)
-    for delimiter in (".", "["):
-        index = field_name.find(delimiter)
-        if index != -1:
-            stop = min(stop, index)
-
-    root = field_name[:stop]
-    if root.isidentifier():
-        return root
-    return None
-
-
-def _is_valid_single_field(text: str) -> bool:
-    try:
-        _parse_single_field(text[1:-1])
-    except ValueError:
-        return False
-    return True
+def _field_preview(template: str, start: int) -> str:
+    return template[start : start + _MAX_TEMPLATE_FIELD_LENGTH + 1]
 
 
 def _find_field_end(template: str, start: int) -> int:
     search_from = start + 1
+    search_until = min(len(template), start + _MAX_TEMPLATE_FIELD_LENGTH + 2)
+    last_error: ValueError | None = None
+
     while True:
-        end = template.find("}", search_from)
+        end = template.find("}", search_from, search_until)
         if end == -1:
+            if len(template) - (start + 1) > _MAX_TEMPLATE_FIELD_LENGTH:
+                raise ValueError(
+                    "Template field exceeds maximum length "
+                    f"({_MAX_TEMPLATE_FIELD_LENGTH} characters) starting at: "
+                    f"{_field_preview(template, start)}..."
+                )
+            if last_error is not None:
+                raise last_error
             raise ValueError(f"Invalid template field starting at: {template[start:]}")
 
-        if _is_valid_single_field(template[start : end + 1]):
+        try:
+            _parse_single_field(template[start + 1 : end])
+        except ValueError as exc:
+            last_error = exc
+            search_from = end + 1
+        else:
             return end
-
-        search_from = end + 1
 
 
 def _iter_template_parts(template: str) -> Iterator[tuple[str, str]]:
@@ -102,30 +116,40 @@ def _iter_template_parts(template: str) -> Iterator[tuple[str, str]]:
 
 
 def _field_variables(field: str) -> set[str]:
-    root, format_spec, _ = _parse_single_field(field)
-    variables = {root}
-    for kind, value in _iter_template_parts(format_spec):
-        if kind == "field":
-            variables.update(_field_variables(value))
-    return variables
+    name, _, _ = _parse_single_field(field)
+    return {name}
+
+
+def _apply_conversion(value: Any, conversion: str | None) -> Any:
+    if conversion == "a":
+        return ascii(value)
+    if conversion == "r":
+        return repr(value)
+    if conversion == "s":
+        return str(value)
+    return value
 
 
 def _render_field(field: str, kwargs: dict[str, Any]) -> str:
+    name, format_spec, conversion = _parse_single_field(field)
     text = "{" + field + "}"
     try:
-        return _FORMATTER.vformat(text, (), kwargs)
-    except (KeyError, IndexError, AttributeError, TypeError, ValueError) as exc:
+        value = _apply_conversion(kwargs[name], conversion)
+        return format(value, format_spec)
+    except (KeyError, TypeError, ValueError) as exc:
         raise ValueError(f"Could not render template field {text}: {exc}") from exc
 
 
 class PromptTemplate(BaseModel):
     """A prompt template with {variable} placeholders for batch workflows.
 
-    Supports named Python format fields such as ``{name}``, ``{price:.2f}``,
-    ``{user.name}``, and ``{items[0]}``. Braces that do not start a named field
-    are literal prompt text, which keeps JSON/code with quoted keys, whitespace,
-    or punctuation after ``{`` intact. Literal text that starts like a field,
-    such as ``{name: "cat"}``, must use doubled braces.
+    Supports top-level named fields such as ``{name}``, plus safe Python
+    format specs and conversions such as ``{price:.2f}`` and ``{name!r}``.
+    Attribute and item traversal are rejected; pass flattened values instead.
+    Braces that do not start a named field are literal prompt text, which keeps
+    JSON/code with quoted keys, whitespace, or punctuation after ``{`` intact.
+    Literal text that starts like a field, such as ``{name: "cat"}``, must use
+    doubled braces.
 
     Example::
 

--- a/libs/core/genblaze_core/models/prompt_template.py
+++ b/libs/core/genblaze_core/models/prompt_template.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
-import string
+import re
 from typing import Any
 
 from pydantic import BaseModel
+
+_VARIABLE_PATTERN = re.compile(r"(?<!\{)\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}(?!\})")
+
+
+def _unescape_literal_braces(text: str) -> str:
+    """Collapse doubled braces in literal template segments."""
+    return text.replace("{{", "{").replace("}}", "}")
 
 
 class PromptTemplate(BaseModel):
     """A prompt template with {variable} placeholders for batch workflows.
 
-    Uses Python str.format_map() syntax — no external dependencies.
+    Substitutes only ``{identifier}`` placeholders. Other braces are treated as
+    literal prompt text so JSON, code snippets, and dict/set examples render as
+    written.
 
     Example::
 
@@ -25,8 +34,7 @@ class PromptTemplate(BaseModel):
     @property
     def variables(self) -> set[str]:
         """Return placeholder variable names found in the template."""
-        formatter = string.Formatter()
-        return {name for _, name, _, _ in formatter.parse(self.template) if name is not None}
+        return {match.group("name") for match in _VARIABLE_PATTERN.finditer(self.template)}
 
     def render(self, **kwargs: Any) -> str:
         """Render the template with the given variables.
@@ -39,4 +47,12 @@ class PromptTemplate(BaseModel):
         missing = required - set(kwargs.keys())
         if missing:
             raise ValueError(f"Missing template variables: {', '.join(sorted(missing))}")
-        return self.template.format_map(kwargs)
+
+        parts: list[str] = []
+        cursor = 0
+        for match in _VARIABLE_PATTERN.finditer(self.template):
+            parts.append(_unescape_literal_braces(self.template[cursor : match.start()]))
+            parts.append(str(kwargs[match.group("name")]))
+            cursor = match.end()
+        parts.append(_unescape_literal_braces(self.template[cursor:]))
+        return "".join(parts)

--- a/libs/core/genblaze_core/models/prompt_template.py
+++ b/libs/core/genblaze_core/models/prompt_template.py
@@ -40,7 +40,7 @@ def _parse_single_field(field: str) -> tuple[str, str, str | None]:
             f"Unsupported template field: {text}. Use a named variable such as {{name}}."
         )
 
-    return root, format_spec, conversion
+    return root, format_spec or "", conversion
 
 
 def _root_variable_name(field_name: str) -> str | None:

--- a/libs/core/genblaze_core/models/prompt_template.py
+++ b/libs/core/genblaze_core/models/prompt_template.py
@@ -123,8 +123,9 @@ class PromptTemplate(BaseModel):
 
     Supports named Python format fields such as ``{name}``, ``{price:.2f}``,
     ``{user.name}``, and ``{items[0]}``. Braces that do not start a named field
-    are treated as literal prompt text so JSON, code snippets, and dict/set
-    examples render as written.
+    are literal prompt text, which keeps JSON/code with quoted keys, whitespace,
+    or punctuation after ``{`` intact. Literal text that starts like a field,
+    such as ``{name: "cat"}``, must use doubled braces.
 
     Example::
 

--- a/libs/core/tests/unit/test_prompt_template.py
+++ b/libs/core/tests/unit/test_prompt_template.py
@@ -78,25 +78,35 @@ class TestPromptTemplate:
         assert tpl.variables == {"price"}
         assert tpl.render(price=1.2) == "Price: 1.20"
 
+    def test_render_alignment_format_spec(self):
+        tpl = PromptTemplate(template="Name: {name:>10}")
+        assert tpl.variables == {"name"}
+        assert tpl.render(name="Ada") == "Name:        Ada"
+
     def test_render_conversion(self):
         tpl = PromptTemplate(template="Name: {name!r}")
         assert tpl.variables == {"name"}
         assert tpl.render(name="Ada") == "Name: 'Ada'"
 
-    def test_render_attribute_lookup(self):
-        tpl = PromptTemplate(template="User: {user.name}")
-        assert tpl.variables == {"user"}
-        assert tpl.render(user=SimpleNamespace(name="Ada")) == "User: Ada"
-
-    def test_render_index_lookup(self):
-        tpl = PromptTemplate(template="First: {items[0]}")
-        assert tpl.variables == {"items"}
-        assert tpl.render(items=["cat", "dog"]) == "First: cat"
-
-    def test_render_mapping_lookup(self):
-        tpl = PromptTemplate(template="User: {user[name]}")
-        assert tpl.variables == {"user"}
-        assert tpl.render(user={"name": "Ada"}) == "User: Ada"
+    @pytest.mark.parametrize(
+        ("template", "kwargs"),
+        [
+            ("User: {user.api_key}", {"user": SimpleNamespace(api_key="secret")}),
+            ("User: {user._token}", {"user": SimpleNamespace(_token="secret")}),
+            (
+                "User: {user.__dict__[api_key]}",
+                {"user": SimpleNamespace(api_key="secret")},
+            ),
+            ("Voice: {settings[voice]}", {"settings": {"voice": "secret"}}),
+            ("First: {items[0]}", {"items": ["cat", "dog"]}),
+        ],
+    )
+    def test_render_rejects_attribute_and_item_lookup(self, template, kwargs):
+        tpl = PromptTemplate(template=template)
+        with pytest.raises(ValueError, match="Unsupported template field"):
+            _ = tpl.variables
+        with pytest.raises(ValueError, match="Unsupported template field"):
+            tpl.render(**kwargs)
 
     def test_render_placeholder_before_literal_closing_brace(self):
         tpl = PromptTemplate(template='Return JSON {"count": {count}}')
@@ -105,13 +115,27 @@ class TestPromptTemplate:
 
     def test_render_invalid_field_conversion_raises_value_error(self):
         tpl = PromptTemplate(template="Name: {name!z}")
-        with pytest.raises(ValueError, match="Could not render template field"):
+        with pytest.raises(ValueError, match="Unsupported template conversion"):
             tpl.render(name="Ada")
 
     def test_render_unclosed_field_raises_value_error(self):
         tpl = PromptTemplate(template="Name: {name")
         with pytest.raises(ValueError, match="Invalid template field"):
             tpl.render(name="Ada")
+
+    def test_render_nested_format_spec_raises_value_error(self):
+        tpl = PromptTemplate(template="Value: {value:{width}}")
+        with pytest.raises(ValueError, match="Nested template fields"):
+            _ = tpl.variables
+        with pytest.raises(ValueError, match="Nested template fields"):
+            tpl.render(value=7, width=3)
+
+    def test_render_large_malformed_field_raises_value_error(self):
+        tpl = PromptTemplate(template="Value: {value:" + ("{" * 300) + "}")
+        with pytest.raises(ValueError, match="exceeds maximum length"):
+            _ = tpl.variables
+        with pytest.raises(ValueError, match="exceeds maximum length"):
+            tpl.render(value=7)
 
     def test_serialization_roundtrip(self):
         tpl = PromptTemplate(template="A {animal} in {style} style")

--- a/libs/core/tests/unit/test_prompt_template.py
+++ b/libs/core/tests/unit/test_prompt_template.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from genblaze_core.exceptions import GenblazeError
@@ -71,6 +72,46 @@ class TestPromptTemplate:
         tpl = PromptTemplate(template='Return JSON like {"name": "{subject}"}')
         with pytest.raises(ValueError, match="Missing template variables: subject"):
             tpl.render()
+
+    def test_render_format_spec(self):
+        tpl = PromptTemplate(template="Price: {price:.2f}")
+        assert tpl.variables == {"price"}
+        assert tpl.render(price=1.2) == "Price: 1.20"
+
+    def test_render_conversion(self):
+        tpl = PromptTemplate(template="Name: {name!r}")
+        assert tpl.variables == {"name"}
+        assert tpl.render(name="Ada") == "Name: 'Ada'"
+
+    def test_render_attribute_lookup(self):
+        tpl = PromptTemplate(template="User: {user.name}")
+        assert tpl.variables == {"user"}
+        assert tpl.render(user=SimpleNamespace(name="Ada")) == "User: Ada"
+
+    def test_render_index_lookup(self):
+        tpl = PromptTemplate(template="First: {items[0]}")
+        assert tpl.variables == {"items"}
+        assert tpl.render(items=["cat", "dog"]) == "First: cat"
+
+    def test_render_mapping_lookup(self):
+        tpl = PromptTemplate(template="User: {user[name]}")
+        assert tpl.variables == {"user"}
+        assert tpl.render(user={"name": "Ada"}) == "User: Ada"
+
+    def test_render_placeholder_before_literal_closing_brace(self):
+        tpl = PromptTemplate(template='Return JSON {"count": {count}}')
+        assert tpl.variables == {"count"}
+        assert tpl.render(count=3) == 'Return JSON {"count": 3}'
+
+    def test_render_invalid_field_conversion_raises_value_error(self):
+        tpl = PromptTemplate(template="Name: {name!z}")
+        with pytest.raises(ValueError, match="Could not render template field"):
+            tpl.render(name="Ada")
+
+    def test_render_unclosed_field_raises_value_error(self):
+        tpl = PromptTemplate(template="Name: {name")
+        with pytest.raises(ValueError, match="Invalid template field"):
+            tpl.render(name="Ada")
 
     def test_serialization_roundtrip(self):
         tpl = PromptTemplate(template="A {animal} in {style} style")

--- a/libs/core/tests/unit/test_prompt_template.py
+++ b/libs/core/tests/unit/test_prompt_template.py
@@ -52,10 +52,25 @@ class TestPromptTemplate:
         assert tpl.render(x="hi") == "hi and hi"
         assert tpl.variables == {"x"}
 
-    def test_render_literal_braces(self):
-        """Literal braces use {{ }} per Python format_map convention."""
+    def test_render_escaped_literal_braces(self):
+        """Doubled braces preserve a literal placeholder-like string."""
         tpl = PromptTemplate(template="{{literal}} {var}")
         assert tpl.render(var="test") == "{literal} test"
+
+    def test_render_single_literal_braces(self):
+        tpl = PromptTemplate(template="cost is 5} dollars for {item}")
+        assert tpl.variables == {"item"}
+        assert tpl.render(item="x") == "cost is 5} dollars for x"
+
+    def test_render_json_template_with_variable(self):
+        tpl = PromptTemplate(template='Return JSON like {"name": "{subject}"}')
+        assert tpl.variables == {"subject"}
+        assert tpl.render(subject="cat") == 'Return JSON like {"name": "cat"}'
+
+    def test_render_missing_var_ignores_json_keys(self):
+        tpl = PromptTemplate(template='Return JSON like {"name": "{subject}"}')
+        with pytest.raises(ValueError, match="Missing template variables: subject"):
+            tpl.render()
 
     def test_serialization_roundtrip(self):
         tpl = PromptTemplate(template="A {animal} in {style} style")


### PR DESCRIPTION
## Summary
- Render `PromptTemplate` fields one-by-one so literal JSON/code/dict braces are left alone while top-level named fields still work.
- Keep safe top-level format specs and conversions such as `{price:.2f}` and `{name!r}` while rejecting attribute/item traversal like `{user.api_key}` and `{settings[voice]}`.
- Reject nested format specs and overlong malformed field-looking inputs with `ValueError` instead of recursive parsing failures.
- Clarify brace escaping and `str.format_map` migration docs, add a changelog security note, and add regression tests for JSON-shaped prompts, traversal rejection, nested specs, missing variables, and format-field compatibility.

## Linked issue
Closes #88

## Tests run
- `pytest libs/core/tests/unit/test_prompt_template.py -q`
- `mypy libs/core/genblaze_core/ --ignore-missing-imports`
- `make lint`
- `make test`

## Follow-up notes
- None.
