### PR TITLE
fix: handle Windows drive letters in file:// URLs across all four call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- Add new entries here. -->
+### genblaze-core
+
+- **Fixed** Windows `file://` URL handling across all call sites (#132).
+  On Windows, `urlparse("file:///C:/...").path` returns `/C:/...`, and
+  `Path("/C:/...").resolve()` produces a drive-relative path that always
+  fails the `is_relative_to(temp_root)` allowlist check. All affected sites
+  now use `urllib.request.url2pathname`, which strips the leading `/` before
+  a drive letter so `Path.resolve()` gets a properly anchored path.
+  On Unix `url2pathname` is an alias for `unquote` — no behaviour change.
+  Fixed in: `storage/transfer.py` (`ObjectStorageSink`), `providers/_ffmpeg_utils.py`
+  (compositor/transform), `providers/base.py` (`validate_chain_input_url`,
+  which also replaces `startswith("/")` with cross-platform `Path.is_absolute()`).
+
+### genblaze-openai
+
+- **Fixed** same Windows `file://` drive-letter bug in `dalle.py`
+  (`_resolve_local_file` — DALL-E image-edit local inputs) (#132).
 
 ## [0.4.0] - 2026-06-25
 

--- a/libs/connectors/openai/genblaze_openai/dalle.py
+++ b/libs/connectors/openai/genblaze_openai/dalle.py
@@ -41,7 +41,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import quote, urlparse
+from urllib.request import url2pathname
 
 from genblaze_core._utils import open_pinned_https_connection
 from genblaze_core.exceptions import ProviderError
@@ -299,7 +300,8 @@ _ALLOWED_FILE_ROOTS: tuple[Path, ...] = (Path(tempfile.gettempdir()).resolve(),)
 def _resolve_local_file(url: str, extra_root: Path | None) -> Path:
     """Resolve a file:// URL to a Path, checked against allowed roots."""
     parsed = urlparse(url)
-    resolved = Path(unquote(parsed.path)).resolve()
+    # url2pathname handles Windows drive letters: /C:/... → C:\... (no-op on Unix)
+    resolved = Path(url2pathname(parsed.path)).resolve()
     allowed = list(_ALLOWED_FILE_ROOTS)
     if extra_root is not None:
         allowed.append(extra_root.resolve())

--- a/libs/connectors/openai/tests/test_dalle_provider.py
+++ b/libs/connectors/openai/tests/test_dalle_provider.py
@@ -538,6 +538,35 @@ def test_edit_file_url_outside_allowed_roots_rejected(mock_b64_dalle):
         provider.generate(step)
 
 
+def test_edit_windows_drive_letter_file_url(mock_b64_dalle, tmp_path, monkeypatch):
+    """Regression for #132: url2pathname() strips the leading slash before a
+    Windows drive letter in _resolve_local_file. Simulates Windows url2pathname
+    behavior so the allowlist check receives the correct absolute path."""
+    provider, client, _ = mock_b64_dalle
+    from genblaze_core.models.asset import Asset as _Asset
+
+    # Create a real image file in tmp_path so resolved.is_file() passes
+    img = tmp_path / "input.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    real_path = str(img.resolve())
+
+    # Simulate what Windows url2pathname does for file:///C:/tmp/input.png
+    monkeypatch.setattr(
+        "genblaze_openai.dalle.url2pathname",
+        lambda _: real_path,
+    )
+
+    step = Step(
+        provider="openai-dalle",
+        model="gpt-image-2",
+        prompt="edit this",
+        inputs=[_Asset(url="file:///C:/tmp/input.png", media_type="image/png")],
+    )
+    # The provider resolves the file, calls images.edit; no ProviderError
+    provider.generate(step)
+    assert client.images.edit.called
+
+
 # --- Unknown model passthrough ---
 
 

--- a/libs/core/genblaze_core/providers/_ffmpeg_utils.py
+++ b/libs/core/genblaze_core/providers/_ffmpeg_utils.py
@@ -9,7 +9,8 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from genblaze_core._utils import ALLOWED_FILE_ROOTS as _ALLOWED_FILE_ROOTS
 from genblaze_core.exceptions import ProviderError
@@ -42,7 +43,8 @@ def resolve_input_path(url: str, *, extra_roots: list[Path] | None = None) -> st
     """
     parsed = urlparse(url)
     if parsed.scheme == "file":
-        raw_path = unquote(parsed.path)
+        # url2pathname handles Windows drive letters: /C:/... → C:\... (no-op on Unix)
+        raw_path = url2pathname(parsed.path)
         resolved = Path(raw_path).resolve()
         allowed = list(_ALLOWED_FILE_ROOTS)
         if extra_roots:

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -14,7 +14,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from genblaze_core._utils import new_id, sanitize_error, utc_now
 from genblaze_core.exceptions import ProviderError
@@ -283,9 +284,11 @@ def validate_chain_input_url(
 
     # Decode percent-encoded sequences BEFORE canonicalization so that
     # ``file:///valid/path/..%2Fetc%2Fpasswd`` collapses correctly.
-    decoded_path = unquote(parsed.path)
+    # url2pathname handles Windows drive letters (/C:/... → C:\...) and
+    # also does percent-decoding (no-op on Unix beyond the unquote call).
+    decoded_path = url2pathname(parsed.path)
 
-    if not decoded_path.startswith("/"):
+    if not Path(decoded_path).is_absolute():
         raise ProviderError(
             f"file:// URL requires an absolute path; got {decoded_path!r}",
             error_code=ProviderErrorCode.INVALID_INPUT,

--- a/libs/core/genblaze_core/storage/transfer.py
+++ b/libs/core/genblaze_core/storage/transfer.py
@@ -10,6 +10,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, BinaryIO, cast
 from urllib.parse import urljoin, urlparse
+from urllib.request import url2pathname
 
 import urllib3
 
@@ -283,9 +284,8 @@ def _read_local_file(
     to prevent arbitrary file reads. Resolves symlinks before checking.
     """
     parsed = urlparse(url)
-    from urllib.parse import unquote
-
-    path = unquote(parsed.path)
+    # url2pathname handles Windows drive letters: /C:/... → C:\... (no-op on Unix)
+    path = url2pathname(parsed.path)
     resolved = Path(path).resolve()
 
     # Allowlist: only temp dirs and explicitly provided roots

--- a/libs/core/tests/unit/test_ffmpeg_utils.py
+++ b/libs/core/tests/unit/test_ffmpeg_utils.py
@@ -65,6 +65,24 @@ class TestResolveInputPath:
         with pytest.raises(ProviderError, match="Unsupported URL scheme"):
             resolve_input_path("http://example.com/file.mp4")
 
+    def test_windows_drive_letter_file_url(self, tmp_path, monkeypatch):
+        """Regression for #132: url2pathname() strips the leading slash before a
+        Windows drive letter so Path.resolve() produces an absolute path that
+        passes the allowlist check. Simulates Windows url2pathname behavior."""
+        f = tmp_path / "clip.mp4"
+        f.write_bytes(b"fake")
+        real_path = str(f.resolve())
+        monkeypatch.setattr(
+            "genblaze_core.providers._ffmpeg_utils.url2pathname",
+            lambda _: real_path,
+        )
+        monkeypatch.setattr(
+            "genblaze_core.providers._ffmpeg_utils._ALLOWED_FILE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+        result = resolve_input_path("file:///C:/tmp/clip.mp4")
+        assert result == real_path
+
 
 class TestResolveFfmpeg:
     def test_raises_when_not_found(self):

--- a/libs/core/tests/unit/test_transfer.py
+++ b/libs/core/tests/unit/test_transfer.py
@@ -382,6 +382,34 @@ class TestReadLocalFile:
         with pytest.raises(StorageError, match="Failed to read"):
             _read_local_file(f"file://{missing}")
 
+    def test_windows_drive_letter_file_url(self, tmp_path, monkeypatch):
+        """Regression for #132: file:///C:/path yields /C:/path from urlparse.path.
+        The old unquote() kept the leading slash, causing Path.resolve() to produce
+        a drive-relative path on Windows that failed the allowlist check.
+        url2pathname() strips the leading slash before the drive letter.
+
+        Simulates Windows url2pathname behavior so the regression is catchable on
+        any platform — without the patch, the fake Windows URL's path would resolve
+        outside tmp_path and be rejected.
+        """
+        test_file = tmp_path / "asset.mp4"
+        test_file.write_bytes(b"video data")
+        real_path = str(test_file.resolve())
+
+        # Simulate what Windows url2pathname does: /C:/tmp/asset.mp4 → C:\tmp\asset.mp4
+        # On the fix branch url2pathname is a module-level name we can monkeypatch.
+        monkeypatch.setattr(
+            "genblaze_core.storage.transfer.url2pathname",
+            lambda _: real_path,
+        )
+        monkeypatch.setattr(
+            "genblaze_core.storage.transfer.ALLOWED_FILE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+
+        data, _ = _read_local_file("file:///C:/tmp/asset.mp4")
+        assert data == b"video data"
+
 
 class TestConnectionLifecycle:
     """release_conn() must fire on every transfer — success, failure, and

--- a/libs/core/tests/unit/test_validate_chain_input_url.py
+++ b/libs/core/tests/unit/test_validate_chain_input_url.py
@@ -214,3 +214,22 @@ def test_double_encoded_strict_mode_rejects(tmp_path: Path) -> None:
             "file:///valid/path/..%252Fsafe%252Foutput.mp4",
             file_root_allowlist=(tmp_path,),
         )
+
+
+def test_windows_drive_letter_file_url(tmp_path: Path, monkeypatch) -> None:
+    """Regression for #132: url2pathname() strips the leading slash before a
+    Windows drive letter so Path.is_absolute() passes and Path.resolve()
+    produces the correct canonical path. Simulates Windows url2pathname."""
+    asset = tmp_path / "asset.mp4"
+    real_path = str(asset.resolve())
+    monkeypatch.setattr(
+        "genblaze_core.providers.base.url2pathname",
+        lambda _: real_path,
+    )
+    # Should not raise — the path passes the is_absolute() check and
+    # (with allowlist) the containment check when url2pathname gives back
+    # the correct Windows-resolved path.
+    validate_chain_input_url(
+        "file:///C:/tmp/asset.mp4",
+        file_root_allowlist=(tmp_path,),
+    )


### PR DESCRIPTION
## Summary

Closes #132

On Windows, `urlparse("file:///C:/tmp/f.mp4").path` returns `/C:/tmp/f.mp4`. The old code called `unquote(parsed.path)`, leaving the leading `/` intact. `Path("/C:/tmp/f.mp4").resolve()` on Windows then produces a drive-relative path — the `is_relative_to(temp_root)` allowlist check always fails, rejecting files that are legitimately in the allowed temp directory.

**Fix:** replace `unquote(parsed.path)` with `url2pathname(parsed.path)` at all four `file://` URL parsing sites. On Unix it is a pure alias for `unquote` — no behaviour change.

**Sites fixed:**
- `storage/transfer.py` — `_read_local_file` (the reported site)
- `providers/_ffmpeg_utils.py` — `resolve_input_path`
- `providers/base.py` — `validate_chain_input_url` (also replaces `startswith("/")` with `Path.is_absolute()`)
- `connectors/openai/genblaze_openai/dalle.py` — `_resolve_local_file`

## Pre-PR triangulated review

- **Correctness/tests:** PASS
- **Security/invariants:** PASS — allowlist and symlink escape checks fully intact
- **Architecture/DRY:** Initial BLOCKING (three other sites had identical bug) — resolved by expanding the fix to all four sites

## Test plan

- [x] `make test` — 1800 passed, 1 pre-existing unrelated failure
- [x] `make lint` — clean
- [x] Windows regression tests added for all four fixed sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)