### PR TITLE
fix(core): merge Pipeline.step() params={} dict with top-level kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pytest-free `genblaze_core.mocks` module (still re-exported from
   `genblaze_core.testing` for backward compatibility), so
   `from genblaze_core import MockVideoProvider` works in a runtime-only install.
+- **Fixed** `Pipeline.step(..., params={...})` no longer nests the dict under a
+  literal `"params"` key in `Step.params` (#133). The catch-all kwargs collector
+  was itself named `params`, so a caller passing `params={"image": ..., "length":
+  ...}` (the natural spelling, mirroring the `Step.params` field) got
+  `step.params == {"params": {...}}` instead of the flattened dict, with no error
+  or warning. `.step()` now accepts an explicit `params={}` dict alongside
+  top-level kwargs; both populate `Step.params`, and a top-level kwarg wins on
+  key collision.
+- **Fixed** `Step(...)` now rejects unrecognized constructor kwargs
+  (`model_config = ConfigDict(extra="forbid")`) instead of silently discarding
+  them — the same class of bug via direct model construction rather than
+  `Pipeline.step()`. Provider-specific keys belong in `params={...}` (#133).
 
 ### genblaze-openai
 

--- a/docs/features/pipeline.md
+++ b/docs/features/pipeline.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-20 -->
+<!-- last_verified: 2026-07-14 -->
 # Feature: Pipeline
 
 ## Purpose
@@ -29,7 +29,8 @@ Fluent API for building and executing multi-step generative media workflows with
 - `tenant_id`: str — Tenant identifier
 - `max_concurrency`: int | None — Global concurrency limit for async steps
 - `provider`: BaseProvider — Provider adapter for each step
-- `model`, `prompt`, `step_type`, `**params`: Step configuration
+- `model`, `prompt`, `step_type`: Step configuration
+- Provider-specific parameters: pass as top-level kwargs (`.step(..., duration=10)`) or as a `params={}` dict (`.step(..., params={"duration": 10})`) — both populate `Step.params`. If a key appears in both, the top-level kwarg wins.
 - `fallback_models`: list[str] | None — Models to try on `MODEL_ERROR` failure
 - `sink`: optional BaseSink — Output destination on `.run()`
 - `pipeline_timeout`: float | None — End-to-end timeout in seconds for the entire pipeline (checked before each step)

--- a/libs/core/genblaze_core/models/step.py
+++ b/libs/core/genblaze_core/models/step.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from genblaze_core._utils import new_id
 from genblaze_core.models.asset import Asset
@@ -30,6 +30,11 @@ UPSTREAM_ID_KEY = "upstream_id"
 
 class Step(BaseModel):
     """A single generation step within a run."""
+
+    # Reject unrecognized constructor kwargs instead of silently discarding
+    # them (Pydantic v2 default is extra="ignore"). Provider-specific keys
+    # belong in ``params={...}``, not top-level — see issue #133.
+    model_config = ConfigDict(extra="forbid")
 
     step_id: str = Field(default_factory=new_id, description="Unique step identifier (UUID).")
     run_id: str | None = Field(default=None, description="Parent run ID. Set by RunBuilder.")

--- a/libs/core/genblaze_core/pipeline/pipeline.py
+++ b/libs/core/genblaze_core/pipeline/pipeline.py
@@ -531,7 +531,8 @@ class Pipeline(Runnable[None, PipelineResult]):
         input_from: list[int] | int | None = None,
         external_inputs: list[Asset] | None = None,
         expected_duration_sec: float | None = None,
-        **params,
+        params: dict[str, Any] | None = None,
+        **extra_params: Any,
     ) -> Pipeline:
         """Add a step to the pipeline.
 
@@ -549,15 +550,27 @@ class Pipeline(Runnable[None, PipelineResult]):
                 UIs. The SDK does not synthesize this — supply your own median
                 from observed runs. Stale values produce worse UX than
                 omitting the field; treat as informational.
+            params: Provider-specific parameters as a dict. Equivalent to
+                passing the same keys as top-level kwargs — use whichever
+                reads better at the call site. If a key appears in both,
+                the top-level kwarg wins (issue #133).
+            **extra_params: Provider-specific parameters as top-level kwargs
+                (e.g. ``duration=10``). Merged with ``params=`` above.
         """
-        # Reject reserved param names that would silently land in **params.
+        # Explicit params= dict and **extra_params kwargs both feed
+        # Step.params; kwargs win on key collision since they're the more
+        # specific, call-site-local override.
+        merged_params: dict[str, Any] = dict(params) if params else {}
+        merged_params.update(extra_params)
+
+        # Reject reserved param names that would silently land in Step.params.
         # `inputs=` / `input=` is the natural-but-wrong name a user trying to
         # seed Step.inputs would reach for; without this guard they get
-        # swallowed by **params, normalized as a model param, and either
+        # swallowed into params, normalized as a model param, and either
         # rejected by the upstream provider or — worse — embedded in the
         # manifest as part of Step.params, drifting the canonical hash.
         for reserved in ("inputs", "input"):
-            if reserved in params:
+            if reserved in merged_params:
                 raise GenblazeError(
                     f"'{reserved}=' is not a valid step() kwarg — did you mean "
                     f"'external_inputs=' (a list of caller-held Assets)? See "
@@ -600,7 +613,7 @@ class Pipeline(Runnable[None, PipelineResult]):
                 provider=provider,
                 model=model,
                 prompt=prompt,
-                params=params,
+                params=merged_params,
                 modality=modality,
                 step_type=step_type,
                 fallback_models=fallback_models or [],

--- a/libs/core/tests/unit/test_models.py
+++ b/libs/core/tests/unit/test_models.py
@@ -65,6 +65,19 @@ def test_step_defaults():
     assert s.assets == []
 
 
+def test_step_rejects_unknown_kwargs():
+    """Unrecognized constructor kwargs must raise, not vanish silently (issue #133).
+
+    Pydantic v2's default ``extra="ignore"`` behavior let callers pass
+    provider-specific keys (e.g. ``duration=10``) directly to ``Step(...)``
+    and have them disappear with no error and no warning — the same class of
+    silent data loss as the ``.step(params={...})`` nesting bug. Unknown keys
+    belong in ``params={...}``.
+    """
+    with pytest.raises(ValidationError, match="duration"):
+        Step(provider="replicate", model="flux-schnell", duration=10)
+
+
 def test_run_with_steps():
     s1 = Step(provider="replicate", model="flux-schnell", prompt="a cat")
     s2 = Step(provider="replicate", model="flux-pro", prompt="enhance")

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -2003,6 +2003,52 @@ def test_pipeline_allows_normal_params() -> None:
     assert result.run.status == RunStatus.COMPLETED
 
 
+def test_step_params_dict_flattens_to_top_level() -> None:
+    """params={...} passed to .step() must land as top-level Step.params keys,
+    not nested under a literal 'params' key (issue #133).
+
+    Before the fix, ``**params`` was both the name of the catch-all kwargs
+    dict and the name a caller naturally reaches for (mirroring the
+    documented ``Step.params`` field), so ``step(..., params={"image": ...})``
+    silently nested the whole dict one level too deep: ``{"params": {"image":
+    ...}}`` instead of ``{"image": ...}``. Providers reading ``step.params["image"]``
+    directly (rather than reimplementing genblaze's own allowlist machinery)
+    never saw the key.
+    """
+    p = MockProvider()
+    result = (
+        Pipeline("params-dict-test")
+        .step(
+            p,
+            model="m",
+            prompt="p",
+            params={"image": "http://example.com/ref.png", "length": 20.0},
+        )
+        .run()
+    )
+    step = result.run.steps[0]
+    assert step.params == {"image": "http://example.com/ref.png", "length": 20.0}
+
+
+def test_step_params_kwargs_win_over_params_dict_on_collision() -> None:
+    """Top-level kwargs override a colliding key in params={} — the more
+    specific, call-site-local form wins."""
+    p = MockProvider()
+    result = (
+        Pipeline("params-collision-test")
+        .step(
+            p,
+            model="m",
+            prompt="p",
+            params={"quality": "sd", "size": "512x512"},
+            quality="hd",
+        )
+        .run()
+    )
+    step = result.run.steps[0]
+    assert step.params == {"quality": "hd", "size": "512x512"}
+
+
 # -----------------------------------------------------------------------------
 # F2 — on_step_complete sink hook: fires per-step, survives sink errors.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes silent data loss when calling `Pipeline.step(..., params={...})`.

The catch-all kwargs collector in `Pipeline.step()` was itself named `params`,
so passing a `params={...}` dict (the natural mental model, mirroring the public
`Step.params` field) nested the dict one level too deep — under a literal
`"params"` key — instead of populating `Step.params`. Provider code then looked
up `step.params["image"]`, missed it, and silently fell back to template
defaults. No filtering/allow-list was involved (contrary to the issue title);
the values were simply nested wrong.

## Changes

- **`step()` signature**: added an explicit `params: dict | None = None` keyword,
  renamed the catch-all to `**extra_params`, and merged them with **kwargs
  winning on collision** (`{**params, **extra_params}`). Reserved-name guard now
  scans the merged dict.
- **`Step` model hardening**: set `ConfigDict(extra="forbid")` so direct
  `Step(...)` construction with unrecognized kwargs raises instead of silently
  dropping them (Pydantic v2's prior default was `extra="ignore"`). Audited all
  first-party `Step(...)` call sites — none affected.
- **Tests**: `test_step_params_dict_flattens_to_top_level`,
  `test_step_params_kwargs_win_over_params_dict_on_collision` (test_pipeline.py),
  and `test_step_rejects_unknown_kwargs` (test_models.py). All fail before the
  fix, pass after.
- **Docs/changelog**: `docs/features/pipeline.md` documents both calling
  conventions and the collision precedence; `CHANGELOG.md [Unreleased]/Fixed`
  entries added.

## Verification

- `libs/core`: full suite passes (one pre-existing parquet numpy/pyarrow ABI
  failure in this env, confirmed identical on `main`).
- `make lint`: clean.

Closes #133
