### PR TITLE
fix(core): supply sha256 for quickstart_local.py's demo asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`model_config = ConfigDict(extra="forbid")`) instead of silently discarding
   them — the same class of bug via direct model construction rather than
   `Pipeline.step()`. Provider-specific keys belong in `params={...}` (#133).
+- **Fixed** `examples/quickstart_local.py` printed `Verified: False` on a
+  clean `pip install genblaze-core` (#125). The 0.3.4 hardening of
+  `Manifest.verify()` (requires every output asset to declare a `sha256`)
+  wasn't reflected in the example's synthetic output asset. The example now
+  passes a `sha256` for its placeholder demo bytes, matching what a real
+  provider/`ObjectStorageSink` would populate.
 
 ### genblaze-openai
 

--- a/examples/quickstart_local.py
+++ b/examples/quickstart_local.py
@@ -9,6 +9,8 @@ Usage:
     python examples/quickstart_local.py
 """
 
+import hashlib
+
 from genblaze_core import (
     Manifest,
     Modality,
@@ -19,6 +21,12 @@ from genblaze_core import (
 
 
 def main() -> None:
+    # No network calls means no real video bytes to hash — stand in for what
+    # Sora would have returned. Manifest.verify() requires a sha256 on every
+    # output asset (hardened in genblaze-core 0.3.4), so a real pipeline run
+    # would pass the provider's actual bytes to hashlib.sha256() here instead.
+    video_bytes = b"placeholder bytes standing in for the generated video"
+
     # Build a step as if Sora generated a video
     step = (
         StepBuilder("openai", "sora-2")
@@ -27,7 +35,11 @@ def main() -> None:
         .params(size="1280x720", n_seconds=8)
         .seed(42)
         .status(StepStatus.SUCCEEDED)
-        .asset("file://output/demo.mp4", "video/mp4")
+        .asset(
+            "file://output/demo.mp4",
+            "video/mp4",
+            sha256=hashlib.sha256(video_bytes).hexdigest(),
+        )
         .build()
     )
 

--- a/libs/core/tests/unit/test_examples.py
+++ b/libs/core/tests/unit/test_examples.py
@@ -1,0 +1,42 @@
+"""Regression tests for the zero-dependency scripts under ``examples/``.
+
+``examples/quickstart_local.py`` is the first thing a new user runs (per its
+own docstring and the README quickstart link) — it must not print
+``Verified: False``, which reads as a broken install. See issue #125:
+`Manifest.verify()` was hardened in genblaze-core 0.3.4 to require a
+``sha256`` on every output asset, and the example wasn't updated to supply
+one for its synthetic (no real bytes) demo asset.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[4] / "examples"
+
+# Tolerates the label's column-alignment whitespace so a cosmetic reformat of
+# the print statement doesn't break this regression guard on unrelated grounds.
+_VERIFIED_TRUE = re.compile(r"Verified:\s*True")
+
+
+def test_quickstart_local_reports_verified_true() -> None:
+    """Running quickstart_local.py end-to-end must report a verified manifest.
+
+    Runs in a fresh subprocess (same interpreter, so the editable install
+    resolves) so this exercises exactly what a user copy-pasting the
+    README's `python examples/quickstart_local.py` command would see.
+    """
+    script = _EXAMPLES_DIR / "quickstart_local.py"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert _VERIFIED_TRUE.search(result.stdout), (
+        f"Expected a verified manifest from the zero-key quickstart.\nstdout: {result.stdout}"
+    )


### PR DESCRIPTION
## Summary

`examples/quickstart_local.py` — the zero-API-key quickstart, the first script a new user runs — printed `Verified: False` on a clean `pip install genblaze-core`, reading as a broken install.

**Root cause:** `Manifest.verify()` was hardened in genblaze-core 0.3.4 (#77) to require every output asset to declare a valid 64-char hex `sha256`. The example's `.asset("file://output/demo.mp4", "video/mp4")` call was never updated to supply one, so it failed the stricter contract even though the manifest hash itself was fine. A docs/example gap, not a library bug.

**Fix:** the example now hashes a labeled placeholder byte string (there is no real video in this offline demo) and passes it as `sha256=` to `.asset(...)`, mirroring what a real provider or `ObjectStorageSink` transfer would populate. A comment explains the placeholder and where a real pipeline would differ.

## Changes

- `examples/quickstart_local.py` — supply `sha256` for the synthetic demo asset
- `libs/core/tests/unit/test_examples.py` — new regression test: runs the script via subprocess and asserts a verified manifest is reported (matches `Verified:\s*True`)
- `CHANGELOG.md` — `[Unreleased]` / `genblaze-core` entry

## Verification

- `python3 examples/quickstart_local.py` now prints `Verified:  True`
- `pytest libs/core/tests/unit/test_examples.py -v` — 1 passed
- `ruff check` / `ruff format --check` on touched files — clean

Closes #125
