### PR TITLE
fix(openai): Sora image-to-video submit + download for openai SDK 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DalleProvider`'s existing file-input helpers) into an open file handle before
   upload. Also stringifies `seconds` (`4`/`8`/`12`), which the SDK types as
   `Literal["4", "8", "12"]`, not `int`.
+- **Fixed** `SoraProvider.fetch_output()` download against openai SDK 2.x (#127).
+  It called `videos.content()`, which the SDK renamed to `download_content()`;
+  every completed generation failed at the download step with `'Videos' object
+  has no attribute 'content'` — after the generation cost was already incurred.
+  The returned binary response still supports `write_to_file()`, so the method
+  rename is the only change needed.
 
 ### genblaze-google
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed** same Windows `file://` drive-letter bug in `dalle.py`
   (`_resolve_local_file` — DALL-E image-edit local inputs) (#132).
+- **Fixed** `SoraProvider` image-to-video chaining (#126). `submit()` forwarded
+  the routed image slot verbatim as `image=`, but `Videos.create()` has no such
+  kwarg — the openai SDK 2.x start frame goes in `input_reference`, which must
+  be an uploaded file, not a URL string. Chain inputs also arrive as local
+  `file://` temp paths (sink upload happens later), so the URL was unusable as-is
+  even with the right parameter name. `submit()` now materializes the routed
+  image (local `file://` resolve, or SSRF-pinned `https://` download — reusing
+  `DalleProvider`'s existing file-input helpers) into an open file handle before
+  upload. Also stringifies `seconds` (`4`/`8`/`12`), which the SDK types as
+  `Literal["4", "8", "12"]`, not `int`.
 
 ### genblaze-google
 

--- a/libs/connectors/openai/genblaze_openai/provider.py
+++ b/libs/connectors/openai/genblaze_openai/provider.py
@@ -370,8 +370,9 @@ class SoraProvider(BaseProvider):
                     error_code=ProviderErrorCode.UNKNOWN,
                 )
 
-            # Content endpoint requires the API key in the Authorization header
-            content = client.videos.content(prediction_id, variant="video")
+            # Content endpoint requires the API key in the Authorization header.
+            # openai SDK 2.x renamed videos.content → videos.download_content (#127).
+            content = client.videos.download_content(prediction_id, variant="video")
             if self._output_dir:
                 self._output_dir.mkdir(parents=True, exist_ok=True)
                 out_path = self._output_dir / f"{step.step_id}.mp4"

--- a/libs/connectors/openai/genblaze_openai/provider.py
+++ b/libs/connectors/openai/genblaze_openai/provider.py
@@ -18,13 +18,14 @@ Docs: https://platform.openai.com/docs/api-reference/videos
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, VideoMetadata
@@ -46,6 +47,12 @@ from genblaze_core.providers.retry import retry_after_from_response
 from genblaze_core.runnable.config import RunnableConfig
 
 from genblaze_openai._errors import map_openai_error
+
+# Reuse DalleProvider's file-input machinery (SSRF-pinned https download +
+# allowlisted file:// resolution) rather than duplicating it here — Sora's
+# image-to-video input has the exact same shape (chain output as a local
+# file:// temp path, or a user-supplied https:// URL).
+from genblaze_openai.dalle import _download_https_to_temp, _resolve_local_file
 
 logger = logging.getLogger("genblaze.openai.sora")
 
@@ -271,6 +278,8 @@ class SoraProvider(BaseProvider):
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
         """Create a video generation job via POST /v1/videos."""
         client = self._get_client()
+        open_file: Any = None
+        temp_to_clean: Path | None = None
         try:
             # Registry pipeline validates seconds/size, applies resolution+aspect
             # transformer, routes first image input, and SSRF-validates inputs.
@@ -280,9 +289,29 @@ class SoraProvider(BaseProvider):
                 "model": step.model,
                 "prompt": payload.get("prompt", step.prompt or ""),
             }
-            for key in ("seconds", "size", "image"):
+            for key in ("seconds", "size"):
                 if key in payload:
                     params[key] = payload[key]
+            if "seconds" in params:
+                # openai SDK's VideoSeconds is Literal["4", "8", "12"] — not int.
+                params["seconds"] = str(params["seconds"])
+
+            # route_images(slots=("image",)) hands back a plain asset URL, but
+            # Videos.create() has no `image` kwarg — the start frame goes in
+            # `input_reference` as an uploaded file. Chain inputs arrive as
+            # local file:// temp paths (sink upload happens later); direct
+            # inputs may be https:// URLs. Both are materialized to an open
+            # file handle before upload (see #126).
+            image_url = payload.get("image")
+            if image_url is not None:
+                parsed = urlparse(image_url)
+                if parsed.scheme == "file":
+                    local_path = _resolve_local_file(image_url, self._output_dir)
+                else:
+                    local_path = _download_https_to_temp(image_url, self._http_timeout)
+                    temp_to_clean = local_path
+                open_file = local_path.open("rb")
+                params["input_reference"] = open_file
 
             response = client.videos.create(**params)
             return response.id
@@ -294,6 +323,13 @@ class SoraProvider(BaseProvider):
                 error_code=map_openai_error(exc),
                 retry_after=retry_after_from_response(exc),
             ) from exc
+        finally:
+            if open_file is not None:
+                with contextlib.suppress(Exception):
+                    open_file.close()
+            if temp_to_clean is not None:
+                with contextlib.suppress(Exception):
+                    temp_to_clean.unlink(missing_ok=True)
 
     def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
         """Check video generation status via GET /v1/videos/{id}."""

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -11,10 +11,29 @@ from genblaze_core.models.enums import StepStatus
 from genblaze_core.models.step import Step
 from genblaze_core.testing import ProviderComplianceTests
 
+# SoraProvider reuses DalleProvider's SSRF-pinned https downloader for
+# image-to-video chain inputs (see genblaze_openai/provider.py:submit()).
+_SORA_CONN_PATCH = "genblaze_openai.dalle.open_pinned_https_connection"
+
+
+def _fake_pinned_conn(body: bytes) -> MagicMock:
+    """Minimal http.client-like connection that yields ``body`` once."""
+    conn = MagicMock()
+    resp = MagicMock()
+    resp.status = 200
+    resp.read.side_effect = [body, b""]
+    conn.getresponse.return_value = resp
+    return conn
+
 
 @pytest.fixture
-def mock_openai():
-    """Patch openai module with a mock client."""
+def mock_openai(tmp_path):
+    """Patch openai module with a mock client.
+
+    ``output_dir=tmp_path`` gives ``_resolve_local_file`` an allowed root for
+    the file:// image-input tests below (mirrors DalleProvider's
+    ``mock_b64_dalle`` fixture in test_dalle_provider.py).
+    """
     mock_client = MagicMock()
 
     # Mock videos.create → returns job with id
@@ -40,7 +59,7 @@ def mock_openai():
     with patch.dict("sys.modules", {"openai": MagicMock()}):
         from genblaze_openai import SoraProvider
 
-        provider = SoraProvider(api_key="test-key")
+        provider = SoraProvider(api_key="test-key", output_dir=str(tmp_path))
         provider._client = mock_client
         yield provider, mock_client
 
@@ -107,17 +126,70 @@ def test_invalid_size_raises(mock_openai):
         provider.submit(step)
 
 
-def test_submit_with_image_input(mock_openai):
-    """Image-to-video: image URL is forwarded to the API as 'image' param."""
+def test_submit_with_https_image_input(mock_openai):
+    """Image-to-video: a remote https:// image is downloaded and forwarded as
+    ``input_reference`` — ``videos.create`` has no ``image`` kwarg (#126)."""
     from genblaze_core.models.asset import Asset
 
     provider, client = mock_openai
     img = Asset(url="https://example.com/frame.png", media_type="image/png")
     step = Step(provider="openai-sora", model="sora-2", prompt="animate this", inputs=[img])
-    vid_id = provider.submit(step)
+
+    # The real SDK reads the file body synchronously during create(); capture
+    # it here too, since our own `finally` closes the handle once submit()
+    # returns (matches DalleProvider's file-handle-in-finally convention).
+    captured = {}
+
+    def _capture(**kwargs):
+        captured["bytes"] = kwargs["input_reference"].read()
+        return SimpleNamespace(id="vid-abc123")
+
+    client.videos.create.side_effect = _capture
+
+    with patch(_SORA_CONN_PATCH, return_value=_fake_pinned_conn(b"remote-png-bytes")):
+        vid_id = provider.submit(step)
+
     assert vid_id == "vid-abc123"
     call_kwargs = client.videos.create.call_args[1]
-    assert call_kwargs["image"] == "https://example.com/frame.png"
+    assert "image" not in call_kwargs
+    assert captured["bytes"] == b"remote-png-bytes"
+
+
+def test_submit_with_local_file_image_input(mock_openai, tmp_path):
+    """Chain image-to-video: a local file:// temp path (upstream step output,
+    pre-sink-upload) is read and uploaded via ``input_reference`` (#126)."""
+    from genblaze_core.models.asset import Asset
+
+    provider, client = mock_openai
+    img_path = tmp_path / "frame.png"
+    img_path.write_bytes(b"local-png-bytes")
+    img = Asset(url=f"file://{img_path}", media_type="image/png")
+    step = Step(provider="openai-sora", model="sora-2", prompt="animate this", inputs=[img])
+
+    captured = {}
+
+    def _capture(**kwargs):
+        captured["bytes"] = kwargs["input_reference"].read()
+        return SimpleNamespace(id="vid-abc123")
+
+    client.videos.create.side_effect = _capture
+
+    vid_id = provider.submit(step)
+
+    assert vid_id == "vid-abc123"
+    call_kwargs = client.videos.create.call_args[1]
+    assert "image" not in call_kwargs
+    assert captured["bytes"] == b"local-png-bytes"
+
+
+def test_submit_stringifies_seconds_for_sdk(mock_openai):
+    """openai SDK's VideoSeconds is Literal['4', '8', '12'] — must be str, not int (#126)."""
+    provider, client = mock_openai
+    step = Step(provider="openai-sora", model="sora-2", prompt="a sunset", params={"seconds": 8})
+    provider.submit(step)
+    call_kwargs = client.videos.create.call_args[1]
+    assert call_kwargs["seconds"] == "8"
+    assert isinstance(call_kwargs["seconds"], str)
 
 
 def test_submit_without_inputs_still_works(mock_openai):
@@ -128,6 +200,7 @@ def test_submit_without_inputs_still_works(mock_openai):
     assert vid_id == "vid-abc123"
     call_kwargs = client.videos.create.call_args[1]
     assert "image" not in call_kwargs
+    assert "input_reference" not in call_kwargs
 
 
 def test_submit_skips_non_image_inputs(mock_openai):

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -46,7 +46,10 @@ def mock_openai(tmp_path):
         model="sora-2",
     )
 
-    # Mock videos.content → returns writable response
+    # Mock videos.download_content → returns writable response.
+    # openai SDK 2.x renamed videos.content → videos.download_content; the old
+    # name is gone, so make any lingering .content call blow up like the real
+    # SDK would (a bare MagicMock would silently auto-create it) (#127).
     mock_content = MagicMock()
 
     def _write_video(path):
@@ -54,7 +57,10 @@ def mock_openai(tmp_path):
             f.write(b"video")
 
     mock_content.write_to_file = MagicMock(side_effect=_write_video)
-    mock_client.videos.content.return_value = mock_content
+    mock_client.videos.download_content.return_value = mock_content
+    mock_client.videos.content.side_effect = AttributeError(
+        "'Videos' object has no attribute 'content'"
+    )
 
     with patch.dict("sys.modules", {"openai": MagicMock()}):
         from genblaze_openai import SoraProvider
@@ -91,6 +97,16 @@ def test_fetch_output_attaches_asset(mock_openai):
     assert result.assets[0].media_type == "video/mp4"
     # Now saves locally as file:// URI instead of unauthenticated API URL
     assert result.assets[0].url.startswith("file://")
+
+
+def test_fetch_output_uses_download_content(mock_openai):
+    """Download must go through videos.download_content, not the removed
+    videos.content, and keep passing variant='video' (#127)."""
+    provider, client = mock_openai
+    step = Step(provider="openai-sora", model="sora-2", prompt="a sunset")
+    provider.fetch_output("vid-abc123", step)
+    client.videos.download_content.assert_called_once_with("vid-abc123", variant="video")
+    client.videos.content.assert_not_called()
 
 
 def test_fetch_output_failed_raises(mock_openai):
@@ -254,7 +270,7 @@ class TestSoraCompliance(ProviderComplianceTests):
         mock_client.videos.retrieve.return_value = SimpleNamespace(
             id="vid-abc123", status="completed", model="sora-2"
         )
-        mock_client.videos.content.return_value = mock_content
+        mock_client.videos.download_content.return_value = mock_content
         provider = SoraProvider(api_key="test-key")
         provider._client = mock_client
         return provider


### PR DESCRIPTION
## Summary

Bundles two related **openai SDK 2.x compatibility** fixes for `SoraProvider`.
Together, `genblaze-openai` 0.3.1 fails at both the submit and the download step
against the current openai SDK — and the generation cost is incurred before the
download failure surfaces.

Fixes #126 · Fixes #127

## #126 — image-to-video submit

`submit()` forwarded the routed image slot verbatim as `image=`, but
`client.videos.create()` has **no `image` kwarg** — the SDK expects the start
frame in `input_reference` as an **uploaded file**, not a URL string. Chain
inputs also arrive as local `file://` temp paths (sink upload happens later), so
the URL was unusable as-is even with the correct parameter name.

- `submit()` materializes the routed image into an open file handle before upload
  and passes it as `input_reference`:
  - `file://` inputs resolved via `_resolve_local_file`
  - `https://` inputs fetched via the SSRF-pinned `_download_https_to_temp`
  - both **reuse `DalleProvider`'s existing file-input helpers** rather than
    duplicating ~80 lines of security-sensitive logic
  - file handle + any downloaded temp file cleaned up in a `finally` block
- Stringifies `seconds` — the SDK types it as `Literal["4", "8", "12"]`, not `int`.

## #127 — download step

`fetch_output()` called `client.videos.content(...)`, which openai SDK 2.x
renamed to `download_content(...)`. Every completed generation failed with
`'Videos' object has no attribute 'content'`. The returned binary response still
supports `write_to_file()`, so the method rename is the only change needed.

The existing tests passed against the bug because a bare `MagicMock` auto-creates
any attribute (both `content` and `download_content` silently "existed"). The
fixture now mirrors the real 2.x surface — `content` raises `AttributeError` — so
these are genuine regression guards.

## Design note

The two `dalle.py` helpers are imported across sibling modules (underscore-prefixed)
rather than extracted to a shared module, because `test_dalle_provider.py` patches
them by exact module path — relocating them would silently defeat those existing
SSRF regression tests. A future `_file_inputs.py` extraction (migrating the Dalle
test patches too) is reasonable if a third caller ever needs the logic.

## Testing

- `libs/connectors/openai`: **154 passed, 7 skipped** (pre-existing skips)
- `make lint`: PASS · `mypy` on the connector: PASS
- `make test` full suite: 1836 passed, 3 skipped — 1 pre-existing failure
  (`test_chain_pipeline_to_parquet_sink`, a local numpy/pyarrow ABI mismatch;
  confirmed identical on unmodified `main`, unrelated to this change)