### PR TITLE
fix(core): preserve input order in step_cache_key (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
+  Providers that consume inputs positionally (multi-image edit/compose,
+  multimodal chat) produce different output when input order changes, but the
+  sorted key made a reordered request incorrectly reuse an earlier run's
+  cached asset. The key now preserves input order, matching the
+  order-preserving manifest canonical hash. Existing cache entries for
+  multi-input steps whose inputs weren't already in sorted order miss once
+  and recompute (one-time repopulation, no data loss).
 - **Fixed** Windows `file://` URL handling across all call sites (#132).
   On Windows, `urlparse("file:///C:/...").path` returns `/C:/...`, and
   `Path("/C:/...").resolve()` produces a drive-relative path that always

--- a/libs/core/genblaze_core/pipeline/cache.py
+++ b/libs/core/genblaze_core/pipeline/cache.py
@@ -43,8 +43,11 @@ def step_cache_key(step: Step, tenant_id: str | None = None) -> str:
         "seed": step.seed,
         "modality": step.modality.value if step.modality else None,
         "step_type": step.step_type.value if step.step_type else None,
-        # Use content hash or URL for cache correctness — asset_id is random per execution
-        "input_ids": sorted(a.sha256 or a.url for a in step.inputs) if step.inputs else None,
+        # Use content hash or URL for cache correctness — asset_id is random per execution.
+        # Order is preserved (not sorted): providers that consume inputs positionally
+        # (multi-image edit/compose, multimodal chat) yield different output when input
+        # order changes, and this must match the order-preserving manifest canonical hash.
+        "input_ids": [a.sha256 or a.url for a in step.inputs] if step.inputs else None,
     }
     if tenant_id is not None:
         key_data["tenant_id"] = tenant_id

--- a/libs/core/tests/unit/test_pipeline.py
+++ b/libs/core/tests/unit/test_pipeline.py
@@ -204,6 +204,63 @@ def test_step_cache_key_tenant_isolation() -> None:
     assert step_cache_key(s, tenant_id="   ") == step_cache_key(s)
 
 
+def test_step_cache_key_input_order_sensitive() -> None:
+    """Issue #71: reversing step.inputs must change the cache key.
+
+    Providers that consume step.inputs positionally (multi-image edit/compose,
+    multimodal chat) produce different output when input order changes.
+    step_cache_key must preserve that order instead of sorting inputs, so a
+    reordered request can't wrongly hit an earlier run's cached asset — this
+    also keeps the cache key consistent with the order-preserving manifest
+    canonical hash.
+    """
+    from genblaze_core.pipeline.cache import step_cache_key
+
+    a1 = Asset(url="https://upload.test/first.png", media_type="image/png", sha256="1" * 64)
+    a2 = Asset(url="https://upload.test/second.png", media_type="image/png", sha256="2" * 64)
+
+    forward = Step(provider="p", model="m", prompt="same", inputs=[a1, a2])
+    backward = Step(provider="p", model="m", prompt="same", inputs=[a2, a1])
+    same_order = Step(provider="p", model="m", prompt="same", inputs=[a1, a2])
+
+    assert step_cache_key(forward) != step_cache_key(backward)
+    assert step_cache_key(forward) == step_cache_key(same_order)
+
+    # URL-fallback branch (sha256=None): #71 explicitly calls out URL-only
+    # inputs, and the `sha256 or url` fallback must stay order-sensitive too.
+    u1 = Asset(url="https://upload.test/first.png", media_type="image/png", sha256=None)
+    u2 = Asset(url="https://upload.test/second.png", media_type="image/png", sha256=None)
+    assert step_cache_key(
+        Step(provider="p", model="m", prompt="same", inputs=[u1, u2])
+    ) != step_cache_key(Step(provider="p", model="m", prompt="same", inputs=[u2, u1]))
+
+
+def test_pipeline_cache_input_order_sensitive(tmp_path: Path) -> None:
+    """Issue #71: a reordered-input request must MISS a shared cache, end to end.
+
+    Mirrors test_pipeline_cache_no_cross_tenant_hit (#68): drives the full
+    Pipeline().cache().run() path so the guarantee holds at the layer that
+    actually serves stale assets, not only at step_cache_key.
+    """
+    cache = StepCache(tmp_path / "cache")
+    a1 = Asset(url="https://upload.test/fg.png", media_type="image/png", sha256="1" * 64)
+    a2 = Asset(url="https://upload.test/bg.png", media_type="image/png", sha256="2" * 64)
+
+    p1 = CountingProvider()
+    Pipeline("c").cache(cache).step(p1, model="m", prompt="p", external_inputs=[a1, a2]).run()
+    assert p1.invoke_count == 1
+
+    # Same step, inputs reversed -> order-sensitive key -> MISS (no wrong-asset hit).
+    p2 = CountingProvider()
+    Pipeline("c").cache(cache).step(p2, model="m", prompt="p", external_inputs=[a2, a1]).run()
+    assert p2.invoke_count == 1
+
+    # Original order again -> cache HIT, provider not called.
+    p3 = CountingProvider()
+    Pipeline("c").cache(cache).step(p3, model="m", prompt="p", external_inputs=[a1, a2]).run()
+    assert p3.invoke_count == 0
+
+
 def test_pipeline_cache_no_cross_tenant_hit(tmp_path: Path) -> None:
     """Issue #68: a shared StepCache must not serve one tenant's result to another."""
     cache = StepCache(tmp_path / "cache")


### PR DESCRIPTION
## Summary

`step_cache_key` computed `sorted(a.sha256 or a.url for a in step.inputs)`, discarding input order. Providers that consume `step.inputs` positionally (multi-image edit/compose, multimodal chat) produce different output when input order changes, so a reordered request — e.g. `[foreground, background]` vs `[background, foreground]` — wrongly reused the earlier run's cached asset. The cache also disagreed with the manifest canonical hash, which preserves input order.

This drops `sorted()` and keys on the ordered list `[a.sha256 or a.url for a in step.inputs]`, keeping the per-element `sha256 or url` fallback. Cache key and manifest provenance now agree on input order.

## Changes

- `libs/core/genblaze_core/pipeline/cache.py` — hash inputs in order (no `sorted()`); comment explains why order matters.
- `libs/core/tests/unit/test_pipeline.py` — regression coverage:
  - `test_step_cache_key_input_order_sensitive` (pure key): reversed inputs differ, identical order matches; covers both the `sha256` and URL-fallback branches.
  - `test_pipeline_cache_input_order_sensitive` (end-to-end): drives `Pipeline().cache().run()` with reversed `external_inputs` and asserts the provider is re-invoked on the reordered request (miss), mirroring the `#68` tenant-isolation test.
- `CHANGELOG.md` — `[Unreleased] > genblaze-core` entry.

## Behavior note

This changes the cache key for multi-input steps whose inputs weren't already in sorted order. Those entries miss once and recompute — a one-time repopulation, no data loss, and no more wrong-asset hits. Single-input and zero-input steps are unaffected.

## Acceptance criteria

- [x] Reversing `step.inputs` produces a different cache key.
- [x] A regression test covers order-sensitive inputs (pure-function + end-to-end).

## Review

Fixed via the maintainer agent (TDD), then a three-perspective panel review (Engineering Manager, Scalability, Performance). The panel confirmed correctness and a strict micro-win on the hot path; its actionable findings — add an end-to-end integration test matching the `#68` pattern, and cover the URL-fallback branch — are incorporated above. Orphaned-cache-entry cleanup (no TTL/eviction) is a pre-existing property of `StepCache`, out of scope here.

## Verification

`pytest tests/unit/test_pipeline.py tests/unit/test_pipeline_step_inputs.py` → 150 passed. `ruff check` / `ruff format --check` clean on changed files.

Closes #71
