### PR TITLE
fix(core): cap JPEG/WebP extract() reads at MAX_FILE_BYTES (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Fixed** `JpegHandler.extract()` and `WebpHandler.extract()` no longer buffer
+  an unbounded amount of the source file into memory (#82). Both now read via
+  the bounded `read_media_bytes()` helper (500 MB `MAX_FILE_BYTES` cap) already
+  used by PNG/WAV, so a container over the cap raises `EmbeddingError` instead
+  of being fully materialized in RAM. Since the CLI content-sniffs the handler
+  from magic bytes rather than file extension, an oversized file with JPEG/WebP
+  magic previously bypassed the cap that PNG/WAV/MP4 already enforced.
 - **Fixed** Windows `file://` URL handling across all call sites (#132).
   On Windows, `urlparse("file:///C:/...").path` returns `/C:/...`, and
   `Path("/C:/...").resolve()` produces a drive-relative path that always

--- a/docs/features/media-embedding.md
+++ b/docs/features/media-embedding.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-20 -->
+<!-- last_verified: 2026-07-14 -->
 # Feature: Media Embedding
 
 ## Purpose
@@ -45,6 +45,7 @@ Embed provenance manifests directly into media files (PNG, JPEG, WebP, MP4, MP3,
 ## Edge Cases
 - Unsupported format → sidecar fallback
 - JPEG/WebP manifest > 60KB → sidecar fallback
+- PNG/JPEG/WebP/WAV container > 500 MB → `EmbeddingError` on `extract()` (bounded in-memory read; applies uniformly since content-sniffed handlers can't rely on file extension)
 - MP4 files 500 MB–2 GB → seek-based streaming embed (avoids loading full file into RAM)
 - MP4 files > 2 GB → `EmbeddingError` (use sidecar fallback)
 - MP3/WAV/AAC/M4A/FLAC without mutagen installed → `EmbeddingError` with install instructions

--- a/libs/core/genblaze_core/media/jpeg.py
+++ b/libs/core/genblaze_core/media/jpeg.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from PIL import Image
 
 from genblaze_core.exceptions import EmbeddingError
-from genblaze_core.media.base import BaseMediaHandler, MediaCapability, atomic_write
+from genblaze_core.media.base import (
+    BaseMediaHandler,
+    MediaCapability,
+    atomic_write,
+    read_media_bytes,
+)
 from genblaze_core.models.manifest import Manifest, parse_manifest
 
 XMP_NS = "genblaze"
@@ -123,8 +128,7 @@ class JpegHandler(BaseMediaHandler):
 
     def extract(self, source: Path) -> Manifest:
         try:
-            with open(source, "rb") as f:
-                data = f.read()
+            data = read_media_bytes(source)
             manifest_json = _scan_xmp_for_manifest(data, source)
             return parse_manifest(json.loads(manifest_json))
         except EmbeddingError:

--- a/libs/core/genblaze_core/media/webp.py
+++ b/libs/core/genblaze_core/media/webp.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from PIL import Image
 
 from genblaze_core.exceptions import EmbeddingError
-from genblaze_core.media.base import BaseMediaHandler, MediaCapability, atomic_write
+from genblaze_core.media.base import (
+    BaseMediaHandler,
+    MediaCapability,
+    atomic_write,
+    read_media_bytes,
+)
 from genblaze_core.media.jpeg import MAX_XMP_BYTES, _build_xmp, _scan_xmp_for_manifest
 from genblaze_core.models.manifest import Manifest, parse_manifest
 
@@ -86,8 +91,7 @@ class WebpHandler(BaseMediaHandler):
 
     def extract(self, source: Path) -> Manifest:
         try:
-            with open(source, "rb") as f:
-                data = f.read()
+            data = read_media_bytes(source)
             manifest_json = _scan_xmp_for_manifest(data, source)
             return parse_manifest(json.loads(manifest_json))
         except EmbeddingError:

--- a/libs/core/tests/unit/test_jpeg.py
+++ b/libs/core/tests/unit/test_jpeg.py
@@ -45,6 +45,26 @@ def test_jpeg_capabilities() -> None:
     assert JpegHandler.capabilities() == ["image/jpeg"]
 
 
+def test_jpeg_extract_rejects_oversized_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """extract() must refuse a container over MAX_FILE_BYTES via read_media_bytes,
+    not buffer it with a raw read() — the CLI content-sniffs handlers from magic
+    bytes, so an oversized JPEG-magic file must be capped like PNG/WAV are.
+
+    Patches the cap low so the test file stays a few bytes (no 500MB+ alloc).
+    """
+    from genblaze_core.media import base as media_base
+
+    monkeypatch.setattr(media_base, "MAX_FILE_BYTES", 10)
+
+    src = tmp_path / "oversized.jpg"
+    src.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 64)  # JPEG magic, > patched cap
+
+    with pytest.raises(EmbeddingError, match="too large"):
+        JpegHandler().extract(src)
+
+
 def test_jpeg_extract_walks_past_foreign_xmp(tmp_path: Path, sample_manifest: Manifest) -> None:
     """A JPEG carrying a leading non-genblaze XMP packet (e.g. Photoshop)
     must still surface the genblaze manifest from a later packet."""

--- a/libs/core/tests/unit/test_webp.py
+++ b/libs/core/tests/unit/test_webp.py
@@ -45,6 +45,26 @@ def test_webp_capabilities() -> None:
     assert WebpHandler.capabilities() == ["image/webp"]
 
 
+def test_webp_extract_rejects_oversized_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """extract() must refuse a container over MAX_FILE_BYTES via read_media_bytes,
+    not buffer it with a raw read() — the CLI content-sniffs handlers from magic
+    bytes, so an oversized WebP-magic file must be capped like PNG/WAV are.
+
+    Patches the cap low so the test file stays a few bytes (no 500MB+ alloc).
+    """
+    from genblaze_core.media import base as media_base
+
+    monkeypatch.setattr(media_base, "MAX_FILE_BYTES", 10)
+
+    src = tmp_path / "oversized.webp"
+    src.write_bytes(b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 64)  # WebP magic, > patched cap
+
+    with pytest.raises(EmbeddingError, match="too large"):
+        WebpHandler().extract(src)
+
+
 def test_webp_embed_preserves_pixels(tmp_path: Path, sample_manifest: Manifest) -> None:
     """Embedding with lossless=True should preserve exact pixel data."""
     np = pytest.importorskip("numpy")


### PR DESCRIPTION
## Summary

`JpegHandler.extract()` and `WebpHandler.extract()` did a raw, uncapped `with open(source, "rb") as f: data = f.read()`, while `PngHandler`/`WavHandler` already read through the bounded `read_media_bytes()` helper (500 MB `MAX_FILE_BYTES` cap). Because the CLI content-sniffs the handler from magic bytes rather than file extension, an attacker-supplied multi-GB file with JPEG or WebP magic was fully materialized into RAM, where an equivalently-sized PNG would be refused up front — an OOM vector on memory-constrained hosts.

Both `extract()` methods now call `read_media_bytes(source)`, so oversized JPEG/WebP containers are refused identically to PNG/WAV. The existing `except EmbeddingError: raise` clause propagates the "File too large…" error un-wrapped.

Closes #82.

## Changes

- `libs/core/genblaze_core/media/jpeg.py` — `extract()` reads via `read_media_bytes()`; import added.
- `libs/core/genblaze_core/media/webp.py` — same change.
- `libs/core/tests/unit/test_jpeg.py`, `test_webp.py` — regression tests that patch `MAX_FILE_BYTES` down to 10 bytes and assert `EmbeddingError` ("too large") on an oversized-magic file, so test files stay tiny (no large allocations). Verified red→green.
- `docs/features/media-embedding.md`, `CHANGELOG.md` — documented the now-uniform 500 MB container cap.

## Verification

- `pytest libs/core/tests/unit/test_jpeg.py tests/unit/test_webp.py` — 21 passed.
- Full `libs/core` suite: 1839 passed, 3 skipped; 1 pre-existing failure (`test_chain_pipeline_to_parquet_sink`, a pyarrow/numpy ABI mismatch in this environment) that also fails on unmodified `main` and is unrelated to this change.
- `ruff check` / `ruff format --check` / `mypy` on changed files — clean.

## Review

Reviewed by a three-perspective panel (Engineering Manager, Scalability Engineer, Performance Engineer). Consensus: clean, correctly-scoped, net memory-safety improvement; **no blocking findings**. The fix reuses the shared helper (DRY) and makes JPEG/WebP structurally identical to PNG/WAV.

### Recommended fast-follow (out of scope for #82)

The panel surfaced one pre-existing, non-blocking consistency gap on the same extract path, worth tracking separately: unlike PNG/WAV/MP4/AAC/FLAC/sidecar (which all enforce the tighter 16 MB `MAX_MANIFEST_BYTES` on the payload before decoding), the JPEG/WebP XMP scanner (`_scan_xmp_for_manifest`/`_extract_from_xmp`) applies no manifest-level cap on extract — it only guards `MAX_XMP_BYTES` on the *embed* side. So a ~500 MB container with a giant embedded XMP `<mf:manifest>` still decodes to `str` + `html.unescape()` uncapped (~1.5–2.5× peak). This is not introduced by this PR and does not affect its acceptance criteria; a small guard in `_scan_xmp_for_manifest` (mirroring `png.py:137`) would close it in a focused follow-up.
