### PR TITLE
fix(core): stable canonical hash for identical fresh asset batches (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wasn't reflected in the example's synthetic output asset. The example now
   passes a `sha256` for its placeholder demo bytes, matching what a real
   provider/`ObjectStorageSink` would populate.
+- **Fixed** `Pipeline.ingest` sorted assets by the random `asset_id` before
+  hashing, so identical fresh asset batches (new `Asset()` instances with new
+  random ids, same content) could produce different `canonical_hash` values
+  even though `asset_id` is excluded from the hash payload (#76). Ingest now
+  sorts by `asset_provenance_key` — the same content fields that feed the
+  hash (`sha256`, `media_type`, `size_bytes`, dimensions, ...) — so the
+  determinism contract holds for fresh asset batches, not just permuted
+  reuses of the same objects.
 
 ### genblaze-openai
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hashing, so identical fresh asset batches (new `Asset()` instances with new
   random ids, same content) could produce different `canonical_hash` values
   even though `asset_id` is excluded from the hash payload (#76). Ingest now
-  sorts by `asset_provenance_key` — the same content fields that feed the
-  hash (`sha256`, `media_type`, `size_bytes`, dimensions, ...) — so the
-  determinism contract holds for fresh asset batches, not just permuted
-  reuses of the same objects.
+  sorts the finished steps by `asset_provenance_key` — the same content
+  fields that feed the hash (`sha256`, `media_type`, `size_bytes`,
+  dimensions, ...) — *after* `sink.put_asset` has populated each asset's
+  hash, since sorting beforehand ties on the shared placeholder content
+  every fresh batch starts with and falls back to caller input order. The
+  determinism contract now holds for fresh asset batches and sink-populated
+  hashes, not just permuted reuses of already-hashed objects.
 
 ### genblaze-openai
 

--- a/docs/exec-plans/active/ingest-sink-and-non-generative-pipelines-tranche.md
+++ b/docs/exec-plans/active/ingest-sink-and-non-generative-pipelines-tranche.md
@@ -87,7 +87,7 @@ You are an expert open-source SDK engineer with experience in DAM, archival, and
 | `Step.provider=None` weakens type guarantees | Validator restricts None to `step_type ∈ {INGEST, IMPORT}` only |
 | Subagent introduces parallel `IngestPipeline` class | Review gate forbids; must be a `Pipeline.ingest()` factory method |
 | Manifest size explodes for 1000+ asset ingest | `MAX_MANIFEST_BYTES` cap; documented; recommend per-batch ingest for large imports |
-| Canonical-hash determinism breaks across asset-order permutations | Test asserts hash equality for same asset set in different orders (sort by `asset_id` at canonicalization) |
+| Canonical-hash determinism breaks across asset-order permutations | Test asserts hash equality for same asset set in different orders (sort by content — `asset_provenance_key`, not `asset_id` — after the sink populates each asset's hash; see issue #76) |
 
 ## Out of scope
 

--- a/docs/features/ingest-workflows.md
+++ b/docs/features/ingest-workflows.md
@@ -190,16 +190,20 @@ index is opt-in and tenant-scoped.
 
 ## Manifest determinism
 
-`Pipeline.ingest` sorts the input assets by content — not `asset_id` — before
-building steps, using the same fields that feed the manifest hash (`sha256`,
-`media_type`, `size_bytes`, dimensions, ...; see `asset_provenance_key` in
+`Pipeline.ingest` sorts the finished steps by content — not `asset_id` — using
+the same fields that feed the manifest hash (`sha256`, `media_type`,
+`size_bytes`, dimensions, ...; see `asset_provenance_key` in
 `genblaze_core.models.manifest`). `asset_id` defaults to a random UUID and is
 excluded from the hash payload (schema 1.4+), so sorting by it would reshuffle
-same-content batches on every call. Sorting by content instead means the
-resulting manifest's `canonical_hash` is **invariant under permuted input
-order, and even across fresh `Asset` instances with new random ids** —
-calling `ingest(assets=[a, b, c])` and `ingest(assets=[c, a, b])` with the
-same asset content produces a byte-identical manifest hash (modulo
+same-content batches on every call. The sort runs *after* `sink.put_asset` has
+populated each asset's `sha256` / `size_bytes` — sorting before the sink runs
+would tie on the placeholder content every fresh batch shares (no hash yet)
+and silently fall back to caller input order, reintroducing the same
+non-determinism one layer deeper. Sorting by real content after the sink
+writes means the resulting manifest's `canonical_hash` is **invariant under
+permuted input order, and even across fresh `Asset` instances with new random
+ids** — calling `ingest(assets=[a, b, c])` and `ingest(assets=[c, a, b])` with
+the same asset content produces a byte-identical manifest hash (modulo
 `Run.name` and a few other deliberately-included caller-provenance fields):
 
 ```python

--- a/docs/features/ingest-workflows.md
+++ b/docs/features/ingest-workflows.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-30 -->
+<!-- last_verified: 2026-07-14 -->
 # Ingest workflows
 
 genblaze's pipeline surface is generation-shaped by default — you compose
@@ -190,12 +190,17 @@ index is opt-in and tenant-scoped.
 
 ## Manifest determinism
 
-`Pipeline.ingest` sorts the input assets by `asset_id` before building
-steps. The resulting manifest's `canonical_hash` is therefore **invariant
-under permuted input order** — calling `ingest(assets=[a, b, c])` and
-`ingest(assets=[c, a, b])` with the same asset set produces a
-byte-identical manifest hash (modulo `Run.name` and a few other
-deliberately-included caller-provenance fields):
+`Pipeline.ingest` sorts the input assets by content — not `asset_id` — before
+building steps, using the same fields that feed the manifest hash (`sha256`,
+`media_type`, `size_bytes`, dimensions, ...; see `asset_provenance_key` in
+`genblaze_core.models.manifest`). `asset_id` defaults to a random UUID and is
+excluded from the hash payload (schema 1.4+), so sorting by it would reshuffle
+same-content batches on every call. Sorting by content instead means the
+resulting manifest's `canonical_hash` is **invariant under permuted input
+order, and even across fresh `Asset` instances with new random ids** —
+calling `ingest(assets=[a, b, c])` and `ingest(assets=[c, a, b])` with the
+same asset content produces a byte-identical manifest hash (modulo
+`Run.name` and a few other deliberately-included caller-provenance fields):
 
 ```python
 import itertools
@@ -207,7 +212,8 @@ assert len(hashes) == 1  # invariant holds across all 6 permutations
 ```
 
 This matters for reproducibility: a DAM bulk-import that retries with a
-different scan order still produces the same provenance fingerprint.
+different scan order — or rebuilds fresh `Asset` objects for the same
+underlying files — still produces the same provenance fingerprint.
 
 ## INGEST vs IMPORT
 

--- a/libs/core/genblaze_core/models/manifest.py
+++ b/libs/core/genblaze_core/models/manifest.py
@@ -121,7 +121,7 @@ def _strip_asset_for_hash(asset: dict, *, mark_unhashed: bool) -> None:
         asset[_UNHASHED_ASSET_URL_FIELD] = strip_asset_url_credentials(url)
 
 
-def asset_provenance_key(asset: Asset) -> str:
+def asset_provenance_key(asset: Asset, *, schema_version: str = SCHEMA_VERSION) -> str:
     """Canonical, content-based sort key for an asset.
 
     Reuses ``_strip_asset_for_hash`` — the exact stripping applied before an
@@ -132,12 +132,15 @@ def asset_provenance_key(asset: Asset) -> str:
     payload). Two assets with identical provenance-relevant content always
     produce the same key regardless of their random ``asset_id``, so callers
     that need an input-order-independent ordering — e.g. ``Pipeline.ingest``
-    sorting assets before hashing — should sort on this instead of
-    ``asset_id``. ``mark_unhashed=False`` matches the currently-writable
-    schema policy (1.4/1.5); see ``_SCHEMA_HASH_POLICIES``.
+    sorting steps after hashing — should sort on this instead of
+    ``asset_id``. ``schema_version`` selects the hash policy (see
+    ``_SCHEMA_HASH_POLICIES``) so the key stays aligned with whichever
+    schema the caller is about to write, rather than hardcoding today's
+    default.
     """
     data = asset.model_dump(mode="python")
-    _strip_asset_for_hash(data, mark_unhashed=False)
+    mark_unhashed = _hash_policy(schema_version).mark_unhashed_assets
+    _strip_asset_for_hash(data, mark_unhashed=mark_unhashed)
     return canonical_json(data)
 
 

--- a/libs/core/genblaze_core/models/manifest.py
+++ b/libs/core/genblaze_core/models/manifest.py
@@ -121,7 +121,9 @@ def _strip_asset_for_hash(asset: dict, *, mark_unhashed: bool) -> None:
         asset[_UNHASHED_ASSET_URL_FIELD] = strip_asset_url_credentials(url)
 
 
-def asset_provenance_key(asset: Asset, *, schema_version: str = SCHEMA_VERSION) -> str:
+def asset_provenance_key(
+    asset: Asset, *, schema_version: str = SCHEMA_VERSION
+) -> tuple[str, int, str]:
     """Canonical, content-based sort key for an asset.
 
     Reuses ``_strip_asset_for_hash`` — the exact stripping applied before an
@@ -137,11 +139,23 @@ def asset_provenance_key(asset: Asset, *, schema_version: str = SCHEMA_VERSION) 
     ``_SCHEMA_HASH_POLICIES``) so the key stays aligned with whichever
     schema the caller is about to write, rather than hardcoding today's
     default.
+
+    The trailing canonical-JSON element is the authoritative content
+    identity: two assets tie iff their manifest hash contribution is
+    byte-identical. The leading ``sha256`` / ``size_bytes`` scalars are pure
+    comparison accelerators — in canonical (alphabetical) key order sha256
+    sorts behind any large shared ``metadata`` / media blocks, so front-
+    loading the cheap discriminators lets a big batch resolve ordering
+    without scanning those prefixes byte-by-byte. They are redundant with the
+    JSON tail and MUST NOT replace it: dropping the canonical JSON would let
+    assets that differ only in nested hashed fields tie in the sort and
+    reintroduce the input-order dependence this key exists to remove (#76).
     """
     data = asset.model_dump(mode="python")
     mark_unhashed = _hash_policy(schema_version).mark_unhashed_assets
     _strip_asset_for_hash(data, mark_unhashed=mark_unhashed)
-    return canonical_json(data)
+    size = asset.size_bytes if asset.size_bytes is not None else -1
+    return (asset.sha256 or "", size, canonical_json(data))
 
 
 def _unhashed_output_asset_ids(run: Run) -> list[str]:

--- a/libs/core/genblaze_core/models/manifest.py
+++ b/libs/core/genblaze_core/models/manifest.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from genblaze_core._asset_url import strip_asset_url_credentials
 from genblaze_core.canonical.json import canonical_hash, canonical_json
 from genblaze_core.exceptions import ManifestError, UnsupportedSchemaVersionError
-from genblaze_core.models.asset import is_valid_sha256
+from genblaze_core.models.asset import Asset, is_valid_sha256
 from genblaze_core.models.enums import PromptVisibility
 from genblaze_core.models.run import Run
 
@@ -119,6 +119,26 @@ def _strip_asset_for_hash(asset: dict, *, mark_unhashed: bool) -> None:
     if mark_unhashed and not has_sha256 and url is not None:
         asset["asset_integrity"] = _UNHASHED_ASSET_MARKER
         asset[_UNHASHED_ASSET_URL_FIELD] = strip_asset_url_credentials(url)
+
+
+def asset_provenance_key(asset: Asset) -> str:
+    """Canonical, content-based sort key for an asset.
+
+    Reuses ``_strip_asset_for_hash`` — the exact stripping applied before an
+    asset is folded into the manifest hash — so this key is built from
+    precisely the fields that make it into ``canonical_hash`` (``sha256``,
+    ``media_type``, ``size_bytes``, dimensions, ...), never ``asset_id``
+    (random UUID) or ``url`` (transport hint, both excluded from the hash
+    payload). Two assets with identical provenance-relevant content always
+    produce the same key regardless of their random ``asset_id``, so callers
+    that need an input-order-independent ordering — e.g. ``Pipeline.ingest``
+    sorting assets before hashing — should sort on this instead of
+    ``asset_id``. ``mark_unhashed=False`` matches the currently-writable
+    schema policy (1.4/1.5); see ``_SCHEMA_HASH_POLICIES``.
+    """
+    data = asset.model_dump(mode="python")
+    _strip_asset_for_hash(data, mark_unhashed=False)
+    return canonical_json(data)
 
 
 def _unhashed_output_asset_ids(run: Run) -> list[str]:

--- a/libs/core/genblaze_core/pipeline/ingest.py
+++ b/libs/core/genblaze_core/pipeline/ingest.py
@@ -20,8 +20,10 @@ The resulting :class:`PipelineResult` carries:
   ``sha256``, ``size_bytes`` populated by ``sink.put_asset``;
 * a canonical-hashable :class:`Manifest` whose hash is stable
   across permuted input orders — the ingest factory sorts the input
-  assets by ``asset_id`` before building steps so callers can pass
-  the same set in any order and get a byte-identical manifest.
+  assets by content (:func:`asset_provenance_key`, not the random
+  ``asset_id``) before building steps so callers can pass the same
+  set in any order — or as fresh ``Asset`` instances with new random
+  ids — and get a byte-identical manifest.
 """
 
 from __future__ import annotations
@@ -34,7 +36,7 @@ from genblaze_core._utils import normalize_tenant_id
 from genblaze_core.exceptions import GenblazeError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import Modality, RunStatus, StepStatus, StepType
-from genblaze_core.models.manifest import Manifest
+from genblaze_core.models.manifest import Manifest, asset_provenance_key
 from genblaze_core.models.run import Run
 from genblaze_core.models.step import Step
 from genblaze_core.pipeline.result import PipelineResult
@@ -124,10 +126,15 @@ def ingest_assets(
             "or skip the call entirely."
         )
 
-    # Sort by asset_id so the canonical hash is stable across permuted
-    # input orders. The plan's hash-determinism gate ("same asset set
-    # in different orders → byte-identical manifest") relies on this.
-    sorted_assets = sorted(asset_list, key=lambda a: a.asset_id)
+    # Sort by content — not asset_id — so the canonical hash is stable
+    # across permuted input orders. asset_id defaults to a random UUID and
+    # is excluded from the hash payload (schema 1.4+), so sorting by it
+    # would reshuffle same-content batches on every call. asset_provenance_key
+    # sorts on exactly the fields that feed the hash, so fresh Asset batches
+    # with identical content always converge on the same order. The plan's
+    # hash-determinism gate ("same asset set in different orders →
+    # byte-identical manifest") relies on this.
+    sorted_assets = sorted(asset_list, key=asset_provenance_key)
 
     metadata_template: dict[str, Any] = {"source": source}
     if source_metadata:

--- a/libs/core/genblaze_core/pipeline/ingest.py
+++ b/libs/core/genblaze_core/pipeline/ingest.py
@@ -18,12 +18,15 @@ The resulting :class:`PipelineResult` carries:
   source, **source_metadata}``;
 * the asset itself in ``step.assets`` with its durable URL,
   ``sha256``, ``size_bytes`` populated by ``sink.put_asset``;
-* a canonical-hashable :class:`Manifest` whose hash is stable
-  across permuted input orders — the ingest factory sorts the input
-  assets by content (:func:`asset_provenance_key`, not the random
-  ``asset_id``) before building steps so callers can pass the same
-  set in any order — or as fresh ``Asset`` instances with new random
-  ids — and get a byte-identical manifest.
+* a canonical-hashable :class:`Manifest` whose hash is stable across
+  permuted input orders — the ingest factory sorts the finished steps
+  by content (:func:`asset_provenance_key`, not the random
+  ``asset_id``) *after* ``sink.put_asset`` has populated ``sha256`` /
+  ``size_bytes``, so callers can pass the same set in any order — or
+  as fresh ``Asset`` instances with new random ids — and get a
+  byte-identical manifest. Sorting before the sink runs would tie on
+  the placeholder (pre-hash) content every batch shares and silently
+  fall back to caller input order.
 """
 
 from __future__ import annotations
@@ -126,16 +129,6 @@ def ingest_assets(
             "or skip the call entirely."
         )
 
-    # Sort by content — not asset_id — so the canonical hash is stable
-    # across permuted input orders. asset_id defaults to a random UUID and
-    # is excluded from the hash payload (schema 1.4+), so sorting by it
-    # would reshuffle same-content batches on every call. asset_provenance_key
-    # sorts on exactly the fields that feed the hash, so fresh Asset batches
-    # with identical content always converge on the same order. The plan's
-    # hash-determinism gate ("same asset set in different orders →
-    # byte-identical manifest") relies on this.
-    sorted_assets = sorted(asset_list, key=asset_provenance_key)
-
     metadata_template: dict[str, Any] = {"source": source}
     if source_metadata:
         # Caller's keys win on overlap with the source key — but we
@@ -144,11 +137,13 @@ def ingest_assets(
         metadata_template.update(source_metadata)
         metadata_template["source"] = source
 
-    # Build the run + steps WITHOUT touching the sink yet — gives us a
-    # complete in-memory shape so we can compute the manifest_uri (a
-    # function of run.run_id) before calling sink.put_asset.
+    # Build the run + steps in caller order, WITHOUT touching the sink yet
+    # — gives us a complete in-memory shape so we can compute the
+    # manifest_uri (a function of run.run_id) before calling sink.put_asset.
+    # Step order here is provisional; it's fixed to a content-based order
+    # below, after the sink has populated each asset's hash.
     steps: list[Step] = []
-    for asset in sorted_assets:
+    for asset in asset_list:
         step = Step(
             provider=None,
             model=source,
@@ -172,7 +167,9 @@ def ingest_assets(
     # Pre-compute the manifest_uri so put_asset can write the
     # asset_id → manifest_uri sidecar atomically with the asset
     # upload. ``manifest_key_for`` and ``get_durable_url`` exposed on
-    # storage sinks are pure functions of run config + run.run_id.
+    # storage sinks are pure functions of run config + run.run_id —
+    # unaffected by step order, so it's safe to derive this before the
+    # steps are put into their final content-sorted order below.
     manifest_uri = _derive_manifest_uri(sink, run)
 
     # Write asset bytes via the sink. Each call mutates the asset
@@ -180,7 +177,7 @@ def ingest_assets(
     # ``size_bytes`` populated.
     if sink is not None:
         indexed_manifest_uri = manifest_uri if run.tenant_id is not None else None
-        for asset in sorted_assets:
+        for asset in asset_list:
             try:
                 if indexed_manifest_uri is None:
                     sink.put_asset(asset)
@@ -200,6 +197,22 @@ def ingest_assets(
                     type(sink).__name__,
                     asset.asset_id,
                 )
+
+    # Sort steps by content — not asset_id, and not before the sink runs —
+    # so the canonical hash is stable across permuted input orders.
+    # asset_id defaults to a random UUID and is excluded from the hash
+    # payload (schema 1.4+), so sorting by it would reshuffle same-content
+    # batches on every call. Sorting *before* sink.put_asset would be just
+    # as unstable: fresh assets typically share identical placeholder
+    # content (no sha256 yet) until the sink hashes them, so an early sort
+    # ties completely and Python's stable sort falls back to caller input
+    # order. Doing this here — after sha256/size_bytes are finalized —
+    # means asset_provenance_key sorts on exactly the fields that feed the
+    # hash, so fresh Asset batches with identical content always converge
+    # on the same order regardless of call-site order. The plan's
+    # hash-determinism gate ("same asset set in different orders →
+    # byte-identical manifest") relies on this.
+    run.steps = sorted(run.steps, key=lambda step: asset_provenance_key(step.assets[0]))
 
     manifest = Manifest(run=run)
     manifest.compute_hash()

--- a/libs/core/genblaze_core/pipeline/ingest.py
+++ b/libs/core/genblaze_core/pipeline/ingest.py
@@ -198,20 +198,16 @@ def ingest_assets(
                     asset.asset_id,
                 )
 
-    # Sort steps by content — not asset_id, and not before the sink runs —
-    # so the canonical hash is stable across permuted input orders.
-    # asset_id defaults to a random UUID and is excluded from the hash
-    # payload (schema 1.4+), so sorting by it would reshuffle same-content
-    # batches on every call. Sorting *before* sink.put_asset would be just
-    # as unstable: fresh assets typically share identical placeholder
-    # content (no sha256 yet) until the sink hashes them, so an early sort
-    # ties completely and Python's stable sort falls back to caller input
-    # order. Doing this here — after sha256/size_bytes are finalized —
-    # means asset_provenance_key sorts on exactly the fields that feed the
-    # hash, so fresh Asset batches with identical content always converge
-    # on the same order regardless of call-site order. The plan's
-    # hash-determinism gate ("same asset set in different orders →
-    # byte-identical manifest") relies on this.
+    # Sort steps by content — via asset_provenance_key, NOT the random
+    # asset_id (excluded from the hash payload) — so the canonical hash is
+    # stable across permuted input orders and fresh Asset batches. This must
+    # run AFTER sink.put_asset populates sha256/size_bytes: sorting earlier
+    # ties on the placeholder content fresh assets share and falls back to
+    # caller order. See asset_provenance_key for the full rationale. Its
+    # schema_version must match the one compute_hash uses; both resolve to
+    # the SCHEMA_VERSION default via Manifest(run=run) below — thread the
+    # same value into both if this manifest is ever built at a non-default
+    # schema.
     run.steps = sorted(run.steps, key=lambda step: asset_provenance_key(step.assets[0]))
 
     manifest = Manifest(run=run)

--- a/libs/core/tests/unit/test_models.py
+++ b/libs/core/tests/unit/test_models.py
@@ -749,6 +749,24 @@ def test_equivalent_reruns_produce_same_hash():
     assert m1.canonical_hash == m2.canonical_hash
 
 
+def test_asset_provenance_key_ignores_asset_id_and_url():
+    """Regression for issue #76: the content-based sort key used by
+    Pipeline.ingest must tie for assets that differ only in asset_id/url —
+    the same fields _hash_payload excludes — and differ when actual
+    hash-relevant content (sha256) differs."""
+    from genblaze_core.models.manifest import asset_provenance_key
+
+    a1 = Asset(url="https://x/a.mp3", media_type="audio/mp3", sha256="a" * 64, size_bytes=1)
+    a2 = Asset(
+        url="https://x/different.mp3", media_type="audio/mp3", sha256="a" * 64, size_bytes=1
+    )
+    assert a1.asset_id != a2.asset_id
+    assert asset_provenance_key(a1) == asset_provenance_key(a2)
+
+    b = Asset(url="https://x/b.mp3", media_type="audio/mp3", sha256="b" * 64, size_bytes=1)
+    assert asset_provenance_key(a1) != asset_provenance_key(b)
+
+
 def test_old_v1_3_manifest_still_verifies():
     """Manifests created under v1.3 (IDs included in hash) still verify."""
     from genblaze_core.models.manifest import parse_manifest

--- a/libs/core/tests/unit/test_pipeline_ingest.py
+++ b/libs/core/tests/unit/test_pipeline_ingest.py
@@ -14,6 +14,7 @@ Coverage by use case (matches the plan's spec):
 
 from __future__ import annotations
 
+import hashlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -46,6 +47,27 @@ def _stub_sink_that_records_calls() -> MagicMock:
     def _put_asset(asset: Asset, **kwargs) -> Asset:
         asset.sha256 = "0" * 64
         asset.size_bytes = 1
+        return asset
+
+    sink = MagicMock()
+    sink.put_asset = MagicMock(side_effect=_put_asset)
+    sink.write_run = MagicMock()
+    sink.manifest_url_for = MagicMock(return_value="https://mem/run/manifest.json")
+    return sink
+
+
+def _stub_sink_that_assigns_content_derived_hashes() -> MagicMock:
+    """A sink mock that assigns a DISTINCT sha256 per asset, derived from
+    its (pre-upload) source URL — unlike ``_stub_sink_that_records_calls``,
+    which hardcodes the same sha256 for every asset and therefore can't
+    distinguish assets by content. Mimics a real content-addressed sink
+    that only learns each asset's hash once it fetches/uploads the bytes,
+    i.e. after the assets have already been queued for ingest — the
+    scenario the sort-by-content fix must handle."""
+
+    def _put_asset(asset: Asset, **kwargs) -> Asset:
+        asset.sha256 = hashlib.sha256(asset.url.encode()).hexdigest()
+        asset.size_bytes = len(asset.url)
         return asset
 
     sink = MagicMock()
@@ -273,8 +295,10 @@ class TestIngestAssets:
 
 class TestCanonicalHashDeterminism:
     """Plan correctness gate: same asset set in different orders →
-    byte-identical manifest hash. The ingest factory sorts by
-    asset_id before building steps; permuted callers converge."""
+    byte-identical manifest hash. The ingest factory sorts steps by
+    content (``asset_provenance_key``) after the sink has populated
+    each asset's hash — not by ``asset_id``, and not before hashing —
+    so permuted callers always converge."""
 
     def test_hash_invariant_across_permuted_input_order(self):
         a = _ingestable_asset(asset_id="01-aaaa", url="https://x/a.mp3")
@@ -296,6 +320,44 @@ class TestCanonicalHashDeterminism:
 
         # Hash equality across all permutations.
         hashes = {r.manifest.canonical_hash for r in runs}
+        assert len(hashes) == 1, f"hashes diverged across permutations: {hashes}"
+
+    def test_hash_invariant_across_permuted_order_with_sink_assigned_hashes(self):
+        """Regression for issue #76 (sink-populated-hash path).
+
+        Assets typically have no ``sha256`` yet when passed to
+        ``Pipeline.ingest`` — the sink assigns it during ``put_asset``,
+        *after* the caller's input order is already fixed. Sorting before
+        the sink runs would tie on the shared pre-hash placeholder content
+        and silently fall back to caller input order, reproducing the bug
+        one layer deeper. The fix sorts steps by content after the sink has
+        populated real, distinct hashes, so permuted input orders must
+        still converge on one canonical hash.
+
+        Each permutation gets FRESH ``Asset`` instances (not the same
+        mutated objects reused across calls) — ``put_asset`` mutates in
+        place, so reusing objects across iterations would carry over
+        already-populated hashes from a prior call and mask exactly the
+        bug this test targets.
+        """
+
+        def _fresh_batch() -> list[Asset]:
+            return [
+                _ingestable_asset(url="https://x/a.mp3"),
+                _ingestable_asset(url="https://x/b.mp3"),
+                _ingestable_asset(url="https://x/c.mp3"),
+            ]
+
+        hashes = set()
+        for perm in ([0, 1, 2], [2, 1, 0], [1, 0, 2]):
+            batch = _fresh_batch()
+            result = Pipeline.ingest(
+                assets=[batch[i] for i in perm],
+                source="t",
+                name="ingest",
+                sink=_stub_sink_that_assigns_content_derived_hashes(),
+            )
+            hashes.add(result.manifest.canonical_hash)
         assert len(hashes) == 1, f"hashes diverged across permutations: {hashes}"
 
     def test_hash_changes_when_asset_set_changes(self):

--- a/libs/core/tests/unit/test_pipeline_ingest.py
+++ b/libs/core/tests/unit/test_pipeline_ingest.py
@@ -307,6 +307,41 @@ class TestCanonicalHashDeterminism:
         r2 = Pipeline.ingest(assets=[a, b], source="t")
         assert r1.manifest.canonical_hash != r2.manifest.canonical_hash
 
+    def test_hash_stable_across_fresh_asset_batches_with_same_content(self):
+        """Regression for issue #76.
+
+        ``asset_id`` defaults to a random UUID and is excluded from the hash
+        payload (schema 1.4+), so sorting ingested assets by ``asset_id``
+        reshuffles same-content batches on every call and produces different
+        canonical hashes. Rebuilding fresh ``Asset`` instances (new random
+        asset_id each call, same url/media_type/sha256/size_bytes) must
+        converge on ONE canonical_hash across repeated ingests.
+        """
+
+        def _fresh_batch() -> list[Asset]:
+            # Distinct content per asset (different sha256/size) so a
+            # content-based sort actually orders them — unlike the
+            # permutation test above, ties here would mask the bug.
+            return [
+                Asset(
+                    url="https://x/a.mp3", media_type="audio/mp3", sha256="a" * 64, size_bytes=100
+                ),
+                Asset(
+                    url="https://x/b.mp3", media_type="audio/mp3", sha256="b" * 64, size_bytes=200
+                ),
+                Asset(
+                    url="https://x/c.mp3", media_type="audio/mp3", sha256="c" * 64, size_bytes=300
+                ),
+            ]
+
+        hashes = {
+            Pipeline.ingest(
+                assets=_fresh_batch(), source="t", name="ingest"
+            ).manifest.canonical_hash
+            for _ in range(10)
+        }
+        assert len(hashes) == 1, f"hash unstable across fresh asset_id batches: {hashes}"
+
 
 # ---------------------------------------------------------------------------
 # Edge cases + error handling


### PR DESCRIPTION
## Summary

Fixes #76. `Pipeline.ingest` documents and tests that the same asset **set** produces a stable `canonical_hash` regardless of caller input order, but it sorted assets by `Asset.asset_id` — a random UUID that is **excluded** from the manifest hash payload (schema 1.4+). So two logically identical *fresh* asset batches (new `Asset()` instances, same `url`/`media_type`/`sha256`/`size_bytes`) could be ordered differently before hashing and produce **different** canonical hashes, undermining reproducibility, dedup, and audit checks. The existing test missed this because it reused assets with fixed `asset_id` values.

## Root cause & fix

The determinism contract must be enforced with an ordering derived from the fields that actually feed the hash — never `asset_id`.

- **New `asset_provenance_key(asset, *, schema_version=SCHEMA_VERSION)`** in `genblaze_core/models/manifest.py`. It reuses the exact `_strip_asset_for_hash` machinery applied before hashing, so the key is built from precisely the hashed fields (`sha256`, `media_type`, `size_bytes`, dimensions, …) and never `asset_id`/`url`.
- **Sort steps by content *after* the sink runs.** The sort moved to `run.steps = sorted(run.steps, key=lambda step: asset_provenance_key(step.assets[0]))`, executed **after** `sink.put_asset` populates each asset's real `sha256`/`size_bytes`. Sorting *before* the sink would tie on the placeholder (pre-hash) content every fresh batch shares, and Python's stable sort would silently fall back to caller input order — reproducing the bug one layer deeper for the common sink-assigns-the-hash case.
- Docs (`docs/features/ingest-workflows.md` "Manifest determinism"), `CHANGELOG.md`, and a stale exec-plan risk-register line updated to match.

## Panel review (3 independent reviewers)

The fix was reviewed by an Engineering Manager, a Scalability Engineer, and a Performance Engineer. All three confirmed correctness: the `run.steps` reassignment is safe (`Run` has no `validate_assignment`), tie-safety holds (equal key ⟹ byte-identical hash contribution, so the tie→input-order fallback is harmless — including the `sink=None` / `ParquetSink` `NotImplementedError` paths), and the new tests genuinely reproduce the bug (they fail on the old `asset_id` sort). Two low-risk improvements were triangulated and applied:

- **Front-loaded sort key** (Scalability, Medium). `asset_provenance_key` now returns `(sha256, size_bytes, canonical_json)`. In canonical (alphabetical) key order `sha256` sorts behind any large shared `metadata`/media blocks, so on bulk-import batches each comparison scanned the shared prefix byte-by-byte. Leading with the cheap scalar discriminators resolves ordering without that scan; the canonical JSON stays as the **authoritative tiebreaker**, so determinism is unchanged.
- **Schema-alignment invariant documented** (EM + Scalability, Low). The sort key and `compute_hash` agree only because both default to `SCHEMA_VERSION`; a comment now records that they must use the same schema policy, with guidance for any future non-default-schema manifest build.

Non-blocking follow-ups reviewers noted (out of scope for this bug fix): per-asset double serialization (bounded, dominated by upload I/O — all three said leave as-is); `pipeline/cache.py::step_cache_key` implements a deliberately narrower content-identity proxy (intentional, should not be unified).

## Acceptance criteria

- [x] Rebuilding fresh `Asset` objects with the same content produces one `canonical_hash` across repeated `Pipeline.ingest(...)` calls.
- [x] Existing "permuted input order" tests still pass.
- [x] A regression test uses fresh `Asset(...)` instances rather than reusing fixed-ID objects.

## Verification

- `libs/core` — `test_pipeline_ingest.py` + `test_models.py`: **100 passed**; broader ingest/manifest/canonical/hash sweep: **270 passed**.
- Full `libs/core` suite green except one pre-existing, unrelated `test_parquet.py` numpy/pyarrow ABI flake (confirmed identical on `origin/main`).
- `ruff check`, `ruff format --check`, `mypy` on the changed files: clean.

## New / updated tests

- `test_hash_stable_across_fresh_asset_batches_with_same_content` — 10 fresh batches, distinct `sha256` per asset, asserts a single `canonical_hash`.
- `test_hash_invariant_across_permuted_order_with_sink_assigned_hashes` — fresh instances + a sink mock that assigns distinct content-derived hashes during `put_asset` (the sink-populates-the-hash path).
- `test_asset_provenance_key_ignores_asset_id_and_url` — the key ties on `asset_id`/`url` differences and diverges on real content.
