### PR TITLE
fix(provenance): validate manifests on load & harden provenance CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Fixed** `parse_manifest()` leaked a raw `AttributeError:
+  'list' object has no attribute 'get'` when given valid JSON whose
+  top-level value isn't an object (e.g. a JSON array) (#64). Both the
+  `index` and `replay` CLI commands call `parse_manifest()`, so both leaked
+  the same internal error; it now raises a `ManifestError` naming the
+  actual type, giving both commands the same clean error message.
 - **Fixed** `Asset` accepted physically impossible provenance metadata —
   negative `size_bytes`, negative/zero `width`/`height`, negative or
   non-finite `duration`, and malformed `media_type` — which then became
@@ -136,6 +142,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-cli
 
+- **Fixed** `extract`, `verify`, `index`, and `replay` accepted a directory
+  argument and failed downstream with a confusing error (e.g. `EmbeddingError:
+  No sidecar file found at <dir>.genblaze.json` or `[Errno 21] Is a
+  directory`) instead of a clear "expected a file" message (#64). All four
+  file arguments now set `dir_okay=False`.
 - **Fixed** six latent `str | None` flow bugs in `replay.py` (#43). A
   provider-less step (only valid for `INGEST`/`IMPORT`, per `Step`'s own
   validator) flowed `None` into `sorted()`, `list.append`, a `dict[str, ...]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Fixed** `Asset` accepted physically impossible provenance metadata —
+  negative `size_bytes`, negative/zero `width`/`height`, negative or
+  non-finite `duration`, and malformed `media_type` — which then became
+  canonical hashed data (#78). Construction now rejects these via Pydantic
+  field constraints, along with the equivalent fields on `VideoMetadata`
+  (`frame_rate`, `bitrate`), `AudioMetadata` (`sample_rate`, `channels`,
+  `bitrate`), and `WordTiming` (non-negative `start`/`end` with `end >=
+  start`, `confidence` in `[0, 1]`). `sha256` is intentionally left
+  format-tolerant at construction — see #100, which already made a
+  malformed `sha256` fail `Manifest.verify()`; enforcing hash *shape* there
+  instead of at construction keeps `parse_manifest()` from crashing on
+  older or foreign-authored manifests. `Asset.set_hash()` is unaffected —
+  it only ever produces valid hashes and non-negative sizes.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Added** unit tests for the previously-untested canonical-hash
+  normalization branches (#50): NaN/Inf floats, `Enum.value` extraction, a
+  naive datetime raising `TypeError`, and aware-datetime timezone
+  canonicalization (`+00:00` → `Z`, non-UTC offsets preserved and stable).
+  `genblaze_core/canonical/_normalize.py` coverage rises from 71% to 89%.
 - **Fixed** `parse_manifest()` leaked a raw `AttributeError:
   'list' object has no attribute 'get'` when given valid JSON whose
   top-level value isn't an object (e.g. a JSON array) (#64). Both the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,27 +22,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actual type, giving both commands the same clean error message.
 - **Fixed** `Asset` accepted physically impossible provenance metadata —
   negative `size_bytes`, negative/zero `width`/`height`, negative or
-  non-finite `duration`, and malformed `media_type` — which then became
+  non-finite `duration`, malformed `media_type` — which then became
   canonical hashed data (#78). Construction now rejects these via Pydantic
-  field constraints, along with the equivalent fields on `VideoMetadata`
-  (`frame_rate`, `bitrate`), `AudioMetadata` (`sample_rate`, `channels`,
-  `bitrate`), and `WordTiming` (non-negative `start`/`end` with `end >=
-  start`, `confidence` in `[0, 1]`). `sha256` is intentionally left
-  format-tolerant at construction — see #100, which already made a
-  malformed `sha256` fail `Manifest.verify()`; enforcing hash *shape* there
-  instead of at construction keeps `parse_manifest()` from crashing on
-  older or foreign-authored manifests. `Asset.set_hash()` is unaffected —
-  it only ever produces valid hashes and non-negative sizes.
-- **Fixed** `ParquetSink` double-counted a `run_id` when its content changed
-  between sinks — e.g. a resume that completes more steps (#72). The
-  idempotency sentinel path (`runs/{partition}/{run_id}.parquet`) is derived
-  from run content (step modality/provider set), so a same-partition
-  existence check missed a sentinel written earlier under a *different*
-  partition, letting a second `runs` row and duplicate `steps`/`assets` rows
-  accumulate for one `run_id`. `write_run()` now probes every partition for
-  an existing sentinel: an exact-path match stays a no-op, and a match
-  elsewhere removes the stale partition's files first so the freshest write
-  wins and the run collapses to exactly one location.
+  field constraints, plus the equivalent fields on `VideoMetadata`,
+  `AudioMetadata`, and `WordTiming` (`end >= start`, `confidence` in
+  `[0, 1]`). `sha256` stays format-tolerant at construction by design (see
+  #100, which already makes a malformed hash fail `Manifest.verify()`) so
+  `parse_manifest()` keeps loading older/foreign manifests without
+  crashing; `Asset.set_hash()` is unaffected.
+- **Fixed** `ParquetSink` double-counted a `run_id` when its content
+  changed between sinks — e.g. a resume completing more steps (#72). The
+  idempotency sentinel's partition path is content-derived, so a
+  same-partition check alone missed a sentinel written earlier under a
+  different partition, letting duplicate `runs`/`steps`/`assets` rows
+  accumulate. `write_run()` now falls back to probing every partition only
+  when the fast path misses, and removes a stale partition's files
+  (`steps`/`assets` before `runs`, so an interrupted cleanup is safely
+  retryable) before writing the fresh ones.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the
@@ -152,13 +148,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   No sidecar file found at <dir>.genblaze.json` or `[Errno 21] Is a
   directory`) instead of a clear "expected a file" message (#64). All four
   file arguments now set `dir_okay=False`.
-- **Fixed** six latent `str | None` flow bugs in `replay.py` (#43). A
-  provider-less step (only valid for `INGEST`/`IMPORT`, per `Step`'s own
-  validator) flowed `None` into `sorted()`, `list.append`, a `dict[str, ...]`
-  key, and `_load_provider(name: str)`, raising a confusing `TypeError`
-  instead of a clean CLI error. The provider-confirmation prompt now skips
-  provider-less steps (they invoke no provider), and the execution loop
-  raises a clear `ClickException` naming the offending step instead of
+- **Fixed** six mypy `str | None` errors in `replay.py` (#43), all stemming
+  from `step.provider` not being narrowed after a provider-less step (only
+  valid for `INGEST`/`IMPORT`, per `Step`'s own validator): `sorted()`, the
+  provider-confirmation list, two `dict[str, ...]` key sites, and
+  `_load_provider`'s/`Pipeline.step`'s argument types. A manifest with such
+  a step could reach some of these with an actual `None` and raise a
+  confusing `TypeError` instead of a clean CLI error. The
+  provider-confirmation prompt now skips provider-less steps (they invoke
+  no provider), and the execution loop raises a clear `ClickException`
+  naming the offending step instead of
   reaching those call sites with `None`. `mypy cli/genblaze_cli/
   --ignore-missing-imports` is now clean.
 - **Fixed** 0.3.2 → 0.3.3: `extract` now supports the `-o/--output` option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of at construction keeps `parse_manifest()` from crashing on
   older or foreign-authored manifests. `Asset.set_hash()` is unaffected —
   it only ever produces valid hashes and non-negative sizes.
+- **Fixed** `ParquetSink` double-counted a `run_id` when its content changed
+  between sinks — e.g. a resume that completes more steps (#72). The
+  idempotency sentinel path (`runs/{partition}/{run_id}.parquet`) is derived
+  from run content (step modality/provider set), so a same-partition
+  existence check missed a sentinel written earlier under a *different*
+  partition, letting a second `runs` row and duplicate `steps`/`assets` rows
+  accumulate for one `run_id`. `write_run()` now probes every partition for
+  an existing sentinel: an exact-path match stays a no-op, and a match
+  elsewhere removes the stale partition's files first so the freshest write
+  wins and the run collapses to exactly one location.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-cli
 
+- **Fixed** six latent `str | None` flow bugs in `replay.py` (#43). A
+  provider-less step (only valid for `INGEST`/`IMPORT`, per `Step`'s own
+  validator) flowed `None` into `sorted()`, `list.append`, a `dict[str, ...]`
+  key, and `_load_provider(name: str)`, raising a confusing `TypeError`
+  instead of a clean CLI error. The provider-confirmation prompt now skips
+  provider-less steps (they invoke no provider), and the execution loop
+  raises a clear `ClickException` naming the offending step instead of
+  reaching those call sites with `None`. `mypy cli/genblaze_cli/
+  --ignore-missing-imports` is now clean.
 - **Fixed** 0.3.2 → 0.3.3: `extract` now supports the `-o/--output` option
   to write the manifest JSON to a file, matching the documented usage.
 - **Changed** `--version` now reports `genblaze-cli` rather than `genblaze`,

--- a/cli/genblaze_cli/commands/extract.py
+++ b/cli/genblaze_cli/commands/extract.py
@@ -20,7 +20,7 @@ def _manifest_json_for_display(manifest: Manifest) -> str:
 
 
 @click.command()
-@click.argument("file", type=click.Path(exists=True, path_type=Path))
+@click.argument("file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--format", "fmt", type=click.Choice(["json", "summary"]), default="json")
 @click.option(
     "-o",

--- a/cli/genblaze_cli/commands/index.py
+++ b/cli/genblaze_cli/commands/index.py
@@ -7,7 +7,7 @@ import click
 
 
 @click.command()
-@click.argument("manifest_file", type=click.Path(exists=True, path_type=Path))
+@click.argument("manifest_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option(
     "--output",
     "-o",

--- a/cli/genblaze_cli/commands/replay.py
+++ b/cli/genblaze_cli/commands/replay.py
@@ -2,12 +2,16 @@
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from genblaze_core.models.enums import PromptVisibility, RunStatus
 
+if TYPE_CHECKING:
+    from genblaze_core.providers.base import BaseProvider
 
-def _load_provider(provider_name: str, allowed: tuple[str, ...] | None):
+
+def _load_provider(provider_name: str, allowed: tuple[str, ...] | None) -> "BaseProvider":
     """Load a provider by name using entry point discovery.
 
     If allowed is set, reject providers not in the allowlist.
@@ -142,9 +146,13 @@ def replay(
 
     # Safety: when no allowlist is provided, confirm each unique provider.
     # A hostile manifest could reference any installed provider and execute
-    # paid API calls on the user's credentials without consent.
+    # paid API calls on the user's credentials without consent. Steps with no
+    # provider (INGEST/IMPORT, see the loop below) don't invoke one, so they're
+    # excluded here rather than flowing `None` into sorted() (issue #43).
     if allowed is None:
-        unique_providers = sorted({step.provider for step in run.steps})
+        unique_providers = sorted(
+            {step.provider for step in run.steps if step.provider is not None}
+        )
         click.echo(
             "No --allow-provider allowlist set. Confirm each provider before execution:",
             err=True,
@@ -165,7 +173,7 @@ def replay(
     # Cache providers by name to avoid re-instantiating
     from genblaze_core.pipeline import Pipeline
 
-    providers: dict[str, object] = {}
+    providers: dict[str, BaseProvider] = {}
     pipe = Pipeline(
         run.name,
         tenant_id=run.tenant_id,
@@ -177,6 +185,17 @@ def replay(
     _reserved = {"model", "prompt", "modality", "step_type", "seed", "negative_prompt"}
 
     for step_idx, step in enumerate(run.steps):
+        # A None provider (only valid for INGEST/IMPORT steps, see Step's
+        # own validator) has no upstream service to re-invoke here — replay
+        # only supports Pipeline.step()-shaped generative steps. Without this
+        # guard, None flowed into a dict[str, ...] key and _load_provider's
+        # str parameter, raising a confusing TypeError instead (issue #43).
+        if step.provider is None:
+            raise click.ClickException(
+                f"Step {step_idx + 1} (step_type={step.step_type}) has no provider; "
+                "replay does not support re-executing provider-less steps "
+                "(e.g. INGEST/IMPORT)."
+            )
         if step.provider not in providers:
             providers[step.provider] = _load_provider(step.provider, allowed)
 

--- a/cli/genblaze_cli/commands/replay.py
+++ b/cli/genblaze_cli/commands/replay.py
@@ -81,7 +81,7 @@ _UNREPLAYABLE_FIELDS = [
 
 
 @click.command()
-@click.argument("manifest_file", type=click.Path(exists=True, path_type=Path))
+@click.argument("manifest_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--dry-run/--no-dry-run", default=True, help="Preview without executing.")
 @click.option(
     "--allow-provider",

--- a/cli/genblaze_cli/commands/verify.py
+++ b/cli/genblaze_cli/commands/verify.py
@@ -8,7 +8,7 @@ from genblaze_cli.manifest_io import extract_manifest
 
 
 @click.command()
-@click.argument("file", type=click.Path(exists=True, path_type=Path))
+@click.argument("file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option(
     "--hash-only",
     is_flag=True,

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -13,8 +13,10 @@ from genblaze_core.builders import RunBuilder, StepBuilder
 from genblaze_core.canonical.json import canonical_json
 from genblaze_core.media.png import PngHandler
 from genblaze_core.models.asset import Asset
-from genblaze_core.models.enums import Modality, ProviderErrorCode, StepStatus
+from genblaze_core.models.enums import Modality, ProviderErrorCode, StepStatus, StepType
 from genblaze_core.models.manifest import Manifest
+from genblaze_core.models.run import Run
+from genblaze_core.models.step import Step
 from genblaze_core.testing import MockProvider
 from PIL import Image
 
@@ -429,6 +431,30 @@ def test_replay_aborts_when_no_allowlist_and_declined(tmp_path: Path) -> None:
     result = runner.invoke(cli, ["replay", str(manifest_path), "--no-dry-run"], input="n\n")
     assert result.exit_code != 0
     assert "Aborted" in result.output or "Execute with provider" in result.output
+
+
+def test_replay_reports_clear_error_for_providerless_step(tmp_path: Path) -> None:
+    """A provider-less step (INGEST/IMPORT, valid per Step's own model) must
+    produce a clear ClickException on replay --no-dry-run, not a TypeError
+    from None flowing into sorted()/dict keys/_load_provider (issue #43)."""
+    step = Step(
+        provider=None,
+        model="rss",
+        step_type=StepType.INGEST,
+        status=StepStatus.SUCCEEDED,
+        assets=[Asset(url="https://example.com/a.png", media_type="image/png")],
+    )
+    run = Run(name="ingest-test", steps=[step])
+    manifest = Manifest.from_run(run)
+    manifest_path = tmp_path / "ingest.json"
+    manifest_path.write_text(manifest.to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["replay", str(manifest_path), "--no-dry-run"])
+
+    assert result.exit_code != 0
+    assert "TypeError" not in result.output
+    assert "no provider" in result.output.lower()
 
 
 def test_replay_no_dry_run_exits_nonzero_when_run_fails(tmp_path: Path, monkeypatch) -> None:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -6,6 +6,7 @@ import json
 import tomllib
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from genblaze_cli.main import cli
 from genblaze_core._utils import MAX_MANIFEST_BYTES
@@ -497,6 +498,40 @@ def test_index(tmp_path: Path) -> None:
     result = runner.invoke(cli, ["index", str(manifest_path), "-o", str(out_dir)])
     assert result.exit_code == 0
     assert "Indexed" in result.output
+
+
+# --- Issue #64: directories rejected with a clear error; non-object JSON is
+# handled consistently across index/replay ---
+
+
+@pytest.mark.parametrize("command", ["extract", "verify", "index", "replay"])
+def test_commands_reject_directory_with_clear_error(tmp_path: Path, command: str) -> None:
+    """A directory argument must fail with click's own actionable error
+    instead of leaking a confusing downstream error (e.g. EmbeddingError or
+    [Errno 21] Is a directory)."""
+    runner = CliRunner()
+    result = runner.invoke(cli, [command, str(tmp_path)])
+    assert result.exit_code != 0
+    assert "is a directory" in result.output.lower()
+
+
+@pytest.mark.parametrize("command", ["index", "replay"])
+def test_non_object_manifest_json_gives_consistent_clean_error(
+    tmp_path: Path, command: str
+) -> None:
+    """A top-level JSON array (valid JSON, invalid manifest shape) must fail
+    with the same clean error for both index and replay, not an internal
+    AttributeError leaked from parse_manifest's dict-only .get() call."""
+    array_path = tmp_path / "not-a-manifest.json"
+    array_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [command, str(array_path)])
+
+    assert result.exit_code != 0
+    assert "must be a JSON object" in result.output
+    assert "AttributeError" not in result.output
+    assert "'list' object has no attribute 'get'" not in result.output
 
 
 # --- Fix B: extract -o / --output ---

--- a/docs/exec-plans/completed/provenance-manifest-integrity.md
+++ b/docs/exec-plans/completed/provenance-manifest-integrity.md
@@ -1,0 +1,52 @@
+<!-- completed: 2026-07-14 -->
+# Provenance & Manifest Integrity Batch
+
+## Summary
+
+Batch fix for six provenance/manifest-integrity issues: validate manifests
+consistently on load, reject impossible `Asset` metadata, make `ParquetSink`
+idempotent across content changes, and harden `replay`'s CLI error handling.
+
+## Scope
+
+- **#78** — Add Pydantic field constraints to `Asset`, `VideoMetadata`,
+  `AudioMetadata`, `WordTiming` rejecting negative/impossible numeric
+  provenance fields and malformed `media_type` at construction. `sha256`
+  stays construction-tolerant by design (#100); `Manifest.verify()` is the
+  enforcement boundary for hash shape.
+- **#72** — Make `ParquetSink.write_run()` idempotent when a run's content
+  (and therefore its derived partition) changes between sinks: check the
+  current partition first, fall back to a full-tree probe only on a miss,
+  and remove a stale partition's `steps`/`assets` files before its `runs`
+  sentinel so an interrupted cleanup is retryable.
+- **#43** — Fix six `str | None` flow bugs in `cli/genblaze_cli/commands/replay.py`
+  by narrowing `step.provider` before use; provider-less steps now raise a
+  clear `ClickException` instead of a `TypeError`.
+- **#64** — Add `dir_okay=False` to all four CLI file arguments; guard
+  `parse_manifest()` against non-dict top-level JSON.
+- **#50** — Add unit tests for the untested canonical-hash normalization
+  branches (NaN/Inf, `Enum.value`, naive-datetime rejection, timezone
+  canonicalization).
+- **#73** — Investigated; already fixed on `main` since v0.2.2 (`d73c577`)
+  with existing regression tests. No change made.
+
+## Review
+
+Three independent reviewers (correctness/tests, architecture/DRY,
+data-integrity) examined the diff before push. Two follow-up fixes came out
+of that pass: `ParquetSink`'s idempotency check was reordered to avoid a
+full-tree scan on every write (the common case), and stale-partition
+deletes were reordered (`steps`/`assets` before `runs`) so an interrupted
+cleanup can't orphan files with no sentinel pointing at them.
+
+## Verification
+
+- `libs/core`: `pytest tests/ -q` (1869 passed; one pre-existing,
+  environment-only numpy/pyarrow ABI failure unrelated to this batch)
+- `cli`: `pytest tests/ -q` (31 passed, 7 new; pre-existing Click/pytest
+  `CliRunner` version-mismatch failures unrelated to this batch)
+- `mypy cli/genblaze_cli/ --ignore-missing-imports` — clean
+- All 13 connector suites + `libs/meta` + `tools/tests` — all pass
+- `ruff check` / `ruff format --check` — clean
+
+PR: https://github.com/backblaze-labs/genblaze/pull/145

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -50,6 +50,10 @@ Command-line tools to extract, verify, replay, and index manifests from media fi
 - Unknown provider in manifest → error with list of known providers
 - Provider-less step (`INGEST`/`IMPORT`, `provider=None`) → replay
   `--no-dry-run` raises a clear error naming the step; not yet supported
+- Directory passed where a file is expected (`extract`/`verify`/`index`/`replay`)
+  → clear "is a directory" error, not a downstream crash
+- Manifest JSON whose top-level value isn't an object (e.g. a JSON array)
+  → same clean `ManifestError` from `index` and `replay`
 
 ## Verification
 - Test files: `cli/tests/test_cli.py`

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-03-06 -->
+<!-- last_verified: 2026-07-14 -->
 # Feature: CLI
 
 ## Purpose
@@ -48,6 +48,8 @@ Command-line tools to extract, verify, replay, and index manifests from media fi
 - Replay dry-run (default) → no API calls made
 - Replay `--no-dry-run` → requires provider package installed (e.g., `genblaze-replicate`)
 - Unknown provider in manifest → error with list of known providers
+- Provider-less step (`INGEST`/`IMPORT`, `provider=None`) → replay
+  `--no-dry-run` raises a clear error naming the step; not yet supported
 
 ## Verification
 - Test files: `cli/tests/test_cli.py`

--- a/docs/features/parquet-sink.md
+++ b/docs/features/parquet-sink.md
@@ -32,10 +32,14 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
 - Idempotent by `run_id`: the partition is derived from run content
   (step modality/provider set), so it can move between sinks of the same
   `run_id` (e.g. a resume that completes more steps). A same-partition
-  match is a no-op; a match under a *different* partition means content
-  changed since the last sink — the stale partition's `runs`/`steps`/`assets`
-  files are removed before writing the fresh ones, so exactly one row set
-  exists per `run_id` at all times (#72)
+  match is a no-op (checked first, cheaply); otherwise every partition is
+  probed for a stale sentinel, whose `steps`/`assets`/`runs` files are
+  removed (in that order) before writing the fresh ones, so a completed
+  write leaves exactly one row set per `run_id` (#72). This is not a
+  cross-file transaction: a crash between removing the stale sentinel and
+  writing the new one leaves the run temporarily un-sinked until the next
+  `write_run()` call, the same accepted trade-off as the original
+  first-write completion sentinel
 
 ## Edge Cases
 - Duplicate `run_id`, same content → write skipped (idempotent)

--- a/docs/features/parquet-sink.md
+++ b/docs/features/parquet-sink.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-03-06 -->
+<!-- last_verified: 2026-07-14 -->
 # Feature: Parquet Sink
 
 ## Purpose
@@ -29,10 +29,18 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
 - `write_run()` flattens run/steps/assets into tabular rows
 - When `policy` is set, redacts prompt/params/seed per `EmbedPolicy` rules before writing step rows
 - Writes to partitioned Parquet using pyarrow
-- Idempotent: skips if `{run_id}.parquet` already exists
+- Idempotent by `run_id`: the partition is derived from run content
+  (step modality/provider set), so it can move between sinks of the same
+  `run_id` (e.g. a resume that completes more steps). A same-partition
+  match is a no-op; a match under a *different* partition means content
+  changed since the last sink — the stale partition's `runs`/`steps`/`assets`
+  files are removed before writing the fresh ones, so exactly one row set
+  exists per `run_id` at all times (#72)
 
 ## Edge Cases
-- Duplicate `run_id` → write skipped (idempotent)
+- Duplicate `run_id`, same content → write skipped (idempotent)
+- Duplicate `run_id`, changed content (moved partition) → stale partition's
+  files are replaced by the new write, not duplicated
 - Missing pyarrow → `ImportError` at sink creation (optional dependency)
 - Concurrent writes → thread-safe via internal lock
 - `EmbedPolicy` with `prompt_visibility=PRIVATE` → prompts written as empty strings

--- a/libs/core/genblaze_core/models/asset.py
+++ b/libs/core/genblaze_core/models/asset.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from genblaze_core._utils import compute_sha256, new_id
 
 _SHA256_HEX_CHARS = frozenset("0123456789abcdef")
+
+# Loose MIME "type/subtype" shape (e.g. "image/png", "application/octet-stream").
+# Intentionally permissive on subtype characters (RFC 6838 allows '+', '-', '.')
+# since this is a sanity check against garbage, not a full MIME validator.
+_MEDIA_TYPE_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.+-]*$")
 
 
 def is_valid_sha256(value: str | None) -> bool:
@@ -24,17 +30,27 @@ class WordTiming(BaseModel):
     """A single word with its time boundaries in the audio."""
 
     word: str = Field(description="The spoken word or token.")
-    start: float = Field(description="Start time in seconds.")
-    end: float = Field(description="End time in seconds.")
-    confidence: float | None = Field(default=None, description="Recognition confidence 0-1.")
+    start: float = Field(ge=0, allow_inf_nan=False, description="Start time in seconds.")
+    end: float = Field(ge=0, allow_inf_nan=False, description="End time in seconds.")
+    confidence: float | None = Field(
+        default=None, ge=0, le=1, allow_inf_nan=False, description="Recognition confidence 0-1."
+    )
+
+    @model_validator(mode="after")
+    def _validate_end_after_start(self) -> WordTiming:
+        if self.end < self.start:
+            raise ValueError(f"WordTiming.end ({self.end}) must be >= start ({self.start})")
+        return self
 
 
 class VideoMetadata(BaseModel):
     """Technical metadata for video assets (codec, frame rate, etc.)."""
 
-    frame_rate: float | None = Field(default=None, description="Frames per second.")
+    frame_rate: float | None = Field(
+        default=None, ge=0, allow_inf_nan=False, description="Frames per second."
+    )
     codec: str | None = Field(default=None, description="Video codec (e.g. 'h264', 'vp9').")
-    bitrate: int | None = Field(default=None, description="Bitrate in bits per second.")
+    bitrate: int | None = Field(default=None, gt=0, description="Bitrate in bits per second.")
     color_space: str | None = Field(default=None, description="Color space (e.g. 'bt709').")
     has_audio: bool | None = Field(
         default=None, description="Whether the video contains an audio track."
@@ -47,12 +63,14 @@ class VideoMetadata(BaseModel):
 class AudioMetadata(BaseModel):
     """Technical metadata for audio assets (sample rate, codec, etc.)."""
 
-    sample_rate: int | None = Field(default=None, description="Sample rate in Hz (e.g. 44100).")
+    sample_rate: int | None = Field(
+        default=None, gt=0, description="Sample rate in Hz (e.g. 44100)."
+    )
     channels: int | None = Field(
-        default=None, description="Number of channels (1=mono, 2=stereo)."
+        default=None, gt=0, description="Number of channels (1=mono, 2=stereo)."
     )
     codec: str | None = Field(default=None, description="Audio codec (e.g. 'mp3', 'aac', 'pcm').")
-    bitrate: int | None = Field(default=None, description="Bitrate in bits per second.")
+    bitrate: int | None = Field(default=None, gt=0, description="Bitrate in bits per second.")
     word_timings: list[WordTiming] | None = Field(
         default=None, description="Word-level timing data [{word, start, end}, ...]."
     )
@@ -96,10 +114,12 @@ class Asset(BaseModel):
     )
     media_type: str = Field(description="MIME type (e.g. 'image/png').")
     sha256: str | None = Field(default=None, description="SHA-256 hash of asset content.")
-    size_bytes: int | None = Field(default=None, description="File size in bytes.")
-    width: int | None = Field(default=None, description="Image/video width in pixels.")
-    height: int | None = Field(default=None, description="Image/video height in pixels.")
-    duration: float | None = Field(default=None, description="Audio/video duration in seconds.")
+    size_bytes: int | None = Field(default=None, ge=0, description="File size in bytes.")
+    width: int | None = Field(default=None, gt=0, description="Image/video width in pixels.")
+    height: int | None = Field(default=None, gt=0, description="Image/video height in pixels.")
+    duration: float | None = Field(
+        default=None, ge=0, allow_inf_nan=False, description="Audio/video duration in seconds."
+    )
     video: VideoMetadata | None = Field(
         default=None, description="Video-specific technical metadata."
     )
@@ -110,6 +130,23 @@ class Asset(BaseModel):
         default=None, description="Media tracks in this container asset."
     )
     metadata: dict[str, Any] = Field(default_factory=dict, description="Arbitrary metadata.")
+
+    # NOTE: sha256 is intentionally NOT format-validated here. Asset must tolerate
+    # a malformed/legacy sha256 on construction and load (see #100 and
+    # test_asset_tolerates_malformed_sha256_on_load) so that parse_manifest() /
+    # extract_manifest() never crash on old or foreign-authored manifests.
+    # Rejection happens at the verification boundary instead — see
+    # is_valid_sha256() + Manifest.output_asset_ids_missing_sha256() /
+    # ManifestVerification, which already make a malformed sha256 fail
+    # manifest.verify() (confirmed: it no longer returns True as #78 originally
+    # reported — that was fixed by #100's verification hardening).
+
+    @field_validator("media_type")
+    @classmethod
+    def _validate_media_type(cls, value: str) -> str:
+        if not _MEDIA_TYPE_RE.match(value):
+            raise ValueError(f"media_type must look like 'type/subtype', got {value!r}")
+        return value
 
     def set_hash(self, data: bytes) -> None:
         """Compute and set sha256 + size_bytes from raw asset bytes."""

--- a/libs/core/genblaze_core/models/manifest.py
+++ b/libs/core/genblaze_core/models/manifest.py
@@ -434,6 +434,11 @@ def parse_manifest(data: dict) -> Manifest:
     read paths report a deliberate upgrade-required condition rather than a
     generic validation failure.
     """
+    if not isinstance(data, dict):
+        raise ManifestError(
+            f"manifest must be a JSON object, got {type(data).__name__} — "
+            "check that the file contains a single manifest, not a list or scalar"
+        )
     version = data.get("schema_version") or "1.0"
     data["schema_version"] = version
     if version not in SUPPORTED_SCHEMA_VERSIONS:

--- a/libs/core/genblaze_core/sinks/parquet.py
+++ b/libs/core/genblaze_core/sinks/parquet.py
@@ -96,10 +96,27 @@ class ParquetSink(BaseSink):
         partition = self._partition_path(run)
 
         # Idempotency: runs table is written last as a completion sentinel.
-        # If it exists, all tables are already written.
+        # The partition is derived from run *content* (step modality/provider
+        # set), which can change between sinks of the same run_id — e.g. a
+        # resume that completes more steps, or a CLI replay re-indexing a
+        # richer manifest. A same-path check alone would then miss the prior
+        # sentinel (it now lives under a different partition), letting a
+        # second `runs` row and duplicate `steps`/`assets` rows accumulate
+        # for one run_id (#72). Probe every partition for an existing
+        # sentinel instead: an exact-path match is a pure no-op re-write;
+        # a match elsewhere means content changed since the last sink, so
+        # remove the stale partition's files first — the run_id, not the
+        # partition, is the identity, and the freshest write should win.
         runs_path = self.base_dir / "runs" / partition / f"{run.run_id}.parquet"
-        if runs_path.exists():
+        existing_sentinels = list((self.base_dir / "runs").glob(f"**/{run.run_id}.parquet"))
+        if runs_path in existing_sentinels:
             return
+        for stale_runs_path in existing_sentinels:
+            stale_partition = stale_runs_path.relative_to(self.base_dir / "runs").parent
+            for table in ("runs", "steps", "assets"):
+                (self.base_dir / table / stale_partition / f"{run.run_id}.parquet").unlink(
+                    missing_ok=True
+                )
 
         # --- steps table (written before runs) ---
         step_rows = []

--- a/libs/core/genblaze_core/sinks/parquet.py
+++ b/libs/core/genblaze_core/sinks/parquet.py
@@ -96,24 +96,38 @@ class ParquetSink(BaseSink):
         partition = self._partition_path(run)
 
         # Idempotency: runs table is written last as a completion sentinel.
+        # Fast path first: an exact-path match (unchanged content, including
+        # every ordinary first-time write) is a pure no-op re-write and the
+        # overwhelmingly common case, so check it with a single stat() before
+        # paying for anything more expensive.
+        runs_path = self.base_dir / "runs" / partition / f"{run.run_id}.parquet"
+        if runs_path.exists():
+            return
+
         # The partition is derived from run *content* (step modality/provider
         # set), which can change between sinks of the same run_id — e.g. a
         # resume that completes more steps, or a CLI replay re-indexing a
-        # richer manifest. A same-path check alone would then miss the prior
-        # sentinel (it now lives under a different partition), letting a
-        # second `runs` row and duplicate `steps`/`assets` rows accumulate
-        # for one run_id (#72). Probe every partition for an existing
-        # sentinel instead: an exact-path match is a pure no-op re-write;
-        # a match elsewhere means content changed since the last sink, so
-        # remove the stale partition's files first — the run_id, not the
-        # partition, is the identity, and the freshest write should win.
-        runs_path = self.base_dir / "runs" / partition / f"{run.run_id}.parquet"
-        existing_sentinels = list((self.base_dir / "runs").glob(f"**/{run.run_id}.parquet"))
-        if runs_path in existing_sentinels:
-            return
-        for stale_runs_path in existing_sentinels:
+        # richer manifest. The fast-path check above only covers the current
+        # partition, so it misses a sentinel written earlier under a
+        # *different* partition, letting a second `runs` row and duplicate
+        # `steps`/`assets` rows accumulate for one run_id (#72). Only pay for
+        # a full-tree probe once the fast path misses (new run_id or a moved
+        # partition): find any prior sentinel and remove its partition's
+        # files first — the run_id, not the partition, is the identity, and
+        # the freshest write should win.
+        # Materialize before deleting — mutating the tree mid-walk while a
+        # generator is still traversing it is unsafe.
+        stale_sentinels = list((self.base_dir / "runs").glob(f"**/{run.run_id}.parquet"))
+        for stale_runs_path in stale_sentinels:
             stale_partition = stale_runs_path.relative_to(self.base_dir / "runs").parent
-            for table in ("runs", "steps", "assets"):
+            # Delete steps/assets before the runs sentinel itself (mirroring
+            # "runs is written last" on the write side) so an interrupted
+            # cleanup is safely retryable: if a crash lands mid-cleanup, the
+            # stale runs sentinel is still present, a retry's probe finds it
+            # again, and the whole stale partition is cleaned from scratch —
+            # never leaving orphaned steps/assets with no sentinel pointing
+            # at them.
+            for table in ("steps", "assets", "runs"):
                 (self.base_dir / table / stale_partition / f"{run.run_id}.parquet").unlink(
                     missing_ok=True
                 )

--- a/libs/core/tests/unit/test_canonical.py
+++ b/libs/core/tests/unit/test_canonical.py
@@ -1,7 +1,10 @@
 """Tests for canonical JSON and hashing."""
 
 import math
+from datetime import UTC, datetime, timedelta, timezone
+from enum import Enum
 
+import pytest
 from genblaze_core.canonical._normalize import normalize
 from genblaze_core.canonical.json import canonical_hash, canonical_json
 
@@ -15,6 +18,48 @@ def test_float_normalization():
     assert normalize(1.00000000001) == 1.0
     assert normalize(math.nan) is None
     assert normalize(math.inf) is None
+    assert normalize(-math.inf) is None
+
+
+# --- Issue #50: cover the normalization branches left untested — these feed
+# canonical_hash()/to_canonical_json(), so a regression here silently changes
+# (or fails to change) a manifest's provenance hash. ---
+
+
+def test_enum_normalization():
+    """Enum values normalize to .value, not their name or repr."""
+
+    class Color(Enum):
+        RED = "red"
+
+    assert normalize(Color.RED) == "red"
+    assert canonical_json({"color": Color.RED}) == '{"color":"red"}'
+
+
+def test_naive_datetime_raises_type_error():
+    """A timezone-naive datetime is rejected outright — canonical hashing
+    requires an explicit offset so the same instant always normalizes
+    identically regardless of the caller's local timezone."""
+    naive = datetime(2026, 1, 1, 12, 0, 0)
+    with pytest.raises(TypeError, match="naive datetime"):
+        normalize(naive)
+
+
+def test_aware_utc_datetime_serializes_with_z_suffix():
+    """A +00:00 offset canonicalizes to the RFC 3339 'Z' shorthand."""
+    dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    assert normalize(dt) == "2026-01-01T12:00:00Z"
+
+
+def test_aware_non_utc_datetime_round_trips_stably():
+    """A non-UTC offset is preserved (not forced to Z or shifted to UTC) and
+    is stable across repeated normalization calls — the hash must not depend
+    on incidental timezone-conversion behavior."""
+    dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+    result = normalize(dt)
+    assert result == dt.isoformat()
+    assert not result.endswith("Z")
+    assert normalize(dt) == result
 
 
 def test_nested_sort():

--- a/libs/core/tests/unit/test_models.py
+++ b/libs/core/tests/unit/test_models.py
@@ -57,6 +57,117 @@ def test_asset_tolerates_malformed_sha256_assignment():
     assert asset.sha256 == "not-a-sha"
 
 
+# --- Issue #78: reject impossible numeric/media-type metadata on construction ---
+# NOTE: sha256 is intentionally excluded (see test_asset_tolerates_malformed_sha256_*
+# above and the comment on Asset in asset.py) — that field stays tolerant at
+# construction by design; verify() is the enforcement boundary.
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"size_bytes": -1},
+        {"width": -640},
+        {"width": 0},
+        {"height": 0},
+        {"height": -480},
+        {"duration": -3.5},
+        {"duration": float("nan")},
+        {"duration": float("inf")},
+    ],
+)
+def test_asset_rejects_impossible_numeric_fields(kwargs):
+    with pytest.raises(ValidationError):
+        Asset(url="https://example.com/a.png", media_type="image/png", **kwargs)
+
+
+def test_asset_accepts_valid_numeric_fields():
+    asset = Asset(
+        url="https://example.com/a.png",
+        media_type="image/png",
+        size_bytes=1024,
+        width=640,
+        height=480,
+        duration=3.5,
+    )
+    assert asset.size_bytes == 1024
+    assert asset.width == 640
+    assert asset.height == 480
+    assert asset.duration == 3.5
+
+
+@pytest.mark.parametrize("media_type", ["not-a-mime", "image", "/png", "image/", ""])
+def test_asset_rejects_malformed_media_type(media_type):
+    with pytest.raises(ValidationError, match="media_type"):
+        Asset(url="https://example.com/a.png", media_type=media_type)
+
+
+def test_asset_set_hash_still_works_without_caller_changes():
+    """Asset.set_hash() must keep working — it always produces valid sha256/size_bytes."""
+    asset = Asset(url="https://example.com/a.png", media_type="image/png")
+    asset.set_hash(b"some bytes")
+    assert asset.sha256 is not None
+    from genblaze_core.models.asset import is_valid_sha256
+
+    assert is_valid_sha256(asset.sha256)
+    assert asset.size_bytes == len(b"some bytes")
+
+
+def test_word_timing_rejects_end_before_start():
+    with pytest.raises(ValidationError, match="end"):
+        WordTiming(word="hi", start=2.0, end=1.0)
+
+
+def test_word_timing_rejects_negative_start():
+    with pytest.raises(ValidationError):
+        WordTiming(word="hi", start=-1.0, end=1.0)
+
+
+def test_word_timing_rejects_out_of_range_confidence():
+    with pytest.raises(ValidationError):
+        WordTiming(word="hi", start=0.0, end=1.0, confidence=1.5)
+
+
+def test_word_timing_accepts_valid_bounds():
+    wt = WordTiming(word="hi", start=0.0, end=1.0, confidence=0.9)
+    assert wt.start == 0.0
+    assert wt.end == 1.0
+
+
+def test_video_metadata_rejects_impossible_values():
+    from genblaze_core.models.asset import VideoMetadata
+
+    with pytest.raises(ValidationError):
+        VideoMetadata(frame_rate=-30.0)
+    with pytest.raises(ValidationError):
+        VideoMetadata(bitrate=0)
+
+
+def test_audio_metadata_rejects_impossible_values():
+    from genblaze_core.models.asset import AudioMetadata
+
+    with pytest.raises(ValidationError):
+        AudioMetadata(sample_rate=0)
+    with pytest.raises(ValidationError):
+        AudioMetadata(channels=-1)
+    with pytest.raises(ValidationError):
+        AudioMetadata(bitrate=-128000)
+
+
+def test_asset_with_impossible_metadata_no_longer_reaches_manifest():
+    """Regression test for the issue #78 repro — construction now fails fast
+    instead of letting impossible metadata become canonical provenance data."""
+    with pytest.raises(ValidationError):
+        Asset(
+            url="https://example.com/a.png",
+            media_type="image/png",
+            size_bytes=-1,
+            width=-640,
+            height=0,
+            duration=-3.5,
+        )
+
+
 def test_step_defaults():
     s = Step(provider="replicate", model="flux-schnell")
     assert s.step_id

--- a/libs/core/tests/unit/test_parquet.py
+++ b/libs/core/tests/unit/test_parquet.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import pyarrow.parquet as pq
-from genblaze_core.models import EmbedPolicy, Manifest, PromptVisibility, Run, Step
+from genblaze_core.models import EmbedPolicy, Manifest, Modality, PromptVisibility, Run, Step
 from genblaze_core.models.asset import Asset
 from genblaze_core.sinks.parquet import ParquetSink
 
@@ -99,6 +99,56 @@ def test_idempotent_write(tmp_path: Path):
 
     parquet_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
     assert len(parquet_files) == 1
+
+
+def test_idempotent_write_when_content_changes_moves_partition(tmp_path: Path):
+    """Re-sinking a run_id whose content changed (moving the content-derived
+    partition) must not create duplicate runs/steps/assets rows (#72).
+
+    This is the normal resume/CLI-replay shape: a first partial sink, then a
+    later sink once more steps complete. The partition is derived from the
+    step modality/provider set, so it moves between the two writes even
+    though run_id — the documented idempotency key — is unchanged.
+    """
+    step1 = Step(provider="replicate", model="m", modality=Modality.IMAGE)
+    step1.assets.append(Asset(url="https://example.com/out.png", media_type="image/png"))
+    run = Run(steps=[step1])
+    manifest = Manifest(run=run)
+    manifest.compute_hash()
+
+    sink = ParquetSink(tmp_path / "out")
+    sink.write_run(run, manifest)
+    stale_runs_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
+    assert len(stale_runs_files) == 1
+
+    # Same run_id gains a second step with a different modality/provider —
+    # the content-derived partition path for this run_id now differs.
+    step2 = Step(provider="elevenlabs", model="m2", modality=Modality.AUDIO)
+    step2.assets.append(Asset(url="https://example.com/out.mp3", media_type="audio/mp3"))
+    run.steps.append(step2)
+    manifest2 = Manifest(run=run)
+    manifest2.compute_hash()
+    sink.write_run(run, manifest2)
+
+    runs_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
+    steps_files = list((tmp_path / "out" / "steps").rglob("*.parquet"))
+    assets_files = list((tmp_path / "out" / "assets").rglob("*.parquet"))
+
+    # Exactly one runs sentinel for this run_id — the stale one under the
+    # old partition was removed, not left alongside a new duplicate.
+    assert len(runs_files) == 1
+    assert runs_files != stale_runs_files
+    run_table = pq.ParquetFile(runs_files[0]).read()
+    assert run_table.num_rows == 1
+    assert run_table.column("run_id")[0].as_py() == run.run_id
+    assert run_table.column("step_count")[0].as_py() == 2
+
+    # steps/assets tables reflect the latest write only — no duplicates
+    # accumulated from the first (now-stale) partial write.
+    assert len(steps_files) == 1
+    assert pq.ParquetFile(steps_files[0]).read().num_rows == 2
+    assert len(assets_files) == 1
+    assert pq.ParquetFile(assets_files[0]).read().num_rows == 2
 
 
 def test_write_run_applies_embed_policy_redaction(tmp_path: Path):


### PR DESCRIPTION
## Summary

Resolves the provenance & manifest-integrity batch:

- **#78** — `Asset` accepted physically impossible provenance metadata (negative `size_bytes`, negative/zero `width`/`height`, negative or non-finite `duration`, malformed `media_type`). Added Pydantic field constraints on `Asset`, `VideoMetadata`, `AudioMetadata`, and `WordTiming` to reject these at construction. `sha256` is intentionally left format-tolerant at construction (see #100 — `Manifest.verify()` already fails a malformed hash there; construction-time rejection would break loading older/foreign manifests, and existing tests assert that tolerance). Closes #78.
- **#72** — `ParquetSink` double-counted a `run_id` when its content changed between sinks (e.g. a resume completing more steps), because the content-derived partition path moved and a same-partition check missed the prior sentinel. `write_run()` now checks the current partition first (cheap, the common case), then falls back to probing every partition only when that misses, removing a stale partition's `steps`/`assets` files before its `runs` sentinel so an interrupted cleanup stays safely retryable. Closes #72.
- **#43** — `replay.py` had six latent `str | None` flow bugs (`mypy cli/genblaze_cli/ --ignore-missing-imports` now clean) stemming from a provider-less step's `None` reaching `sorted()`, a dict key, and `_load_provider`. A provider-less step now raises a clear `ClickException` naming the step instead of a `TypeError`. Closes #43.
- **#64** — `extract`/`verify`/`index`/`replay` accepted a directory and failed with a confusing downstream error; a non-object manifest JSON (e.g. a JSON array) leaked a raw `AttributeError` from `parse_manifest()`. All four commands now set `dir_okay=False`, and `parse_manifest()` raises a clean `ManifestError` for non-dict input. Closes #64.
- **#50** — Added targeted unit tests for the untested canonical-hash normalization branches (NaN/Inf, `Enum.value`, naive-datetime rejection, aware-datetime timezone canonicalization). `_normalize.py` coverage: 71% → 89%. Closes #50.
- **#73** — investigated, already fixed on `main` (commit `d73c577`, v0.2.2, predates this PR) with existing regression tests. No change needed; left out of this diff. Not part of this PR's Closes list.

## Pre-PR review

Per the maintainer workflow, three independent reviewers examined `git diff origin/main...HEAD` before push:

- **Correctness & tests** — all 5 fixed issues + #73 verified FULLY RESOLVED against their original repros/acceptance criteria; no P0/P1.
- **Security/architecture & DRY** — no duplicated logic, `is_valid_sha256` reused not reimplemented, CLI patterns consistent across commands; flagged a P1 (full-tree glob on every `ParquetSink.write_run()`, including the common case) and CHANGELOG wording imprecision — both fixed in a follow-up commit.
- **Data integrity** — confirmed schema-version, Asset-validation, and replay-CLI logic hold; flagged a P1 (crash between deleting a stale Parquet partition's sentinel and its steps/assets could orphan files) — fixed by reordering deletes (steps/assets before the sentinel) so an interrupted cleanup self-heals on retry.

## Test plan

- [x] `make lint` — `ruff check`/`ruff format --check` clean on `libs/`, `cli/`, `examples/`
- [x] `mypy cli/genblaze_cli/ --ignore-missing-imports` — clean (issue #43's acceptance bar)
- [x] `mypy libs/core/genblaze_core/ --ignore-missing-imports` — 1 pre-existing, unrelated error (`media/aac.py:58`), confirmed present on unmodified `origin/main`
- [x] `libs/core`: 1869 passed, 3 skipped, coverage 88.44% (gate: 70%). One pre-existing environment-only failure (`test_pipeline_chain_integration.py::test_chain_pipeline_to_parquet_sink`, a numpy/pyarrow ABI mismatch reproducing on unmodified `origin/main` and even on a bare `import pandas` in this env) — not a regression.
- [x] `cli`: 31 passed (7 new). 9 pre-existing failures reproduce identically on unmodified `origin/main` (a Click/pytest `CliRunner` version mismatch — `stderr not separately captured` — plus the same Parquet ABI issue) — not regressions.
- [x] All 13 connector test suites (openai, google, runway, luma, decart, replicate, elevenlabs, stability-audio, lmnt, hume, gmicloud, langsmith, nvidia, assemblyai) + `libs/meta` + `tools/tests` — all pass, confirming the `Asset` validation changes don't reject any real construction site.
- [x] Docs updated in the same PR: `docs/features/cli.md`, `docs/features/parquet-sink.md`, `CHANGELOG.md`.

Related: `docs/exec-plans/completed/provenance-manifest-integrity.md` (implementation notes).