### PR TITLE
fix(gmicloud): add missing py.typed marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hash or "official, no version" — seeded from `validate_model()`'s existing
   probe, so a normal `Pipeline.run()` costs no extra round-trip.
 
+### genblaze-gmicloud
+
+- **Fixed** package now ships the `py.typed` marker its `Typing :: Typed`
+  classifier already promised (#44). The marker file was never added, so
+  downstream mypy/pyright silently treated every `genblaze_gmicloud` symbol
+  as `Any` despite the package being fully annotated. It ships the same way
+  as every other connector's marker — no `pyproject.toml` change needed,
+  since hatchling already includes all files under the declared
+  `[tool.hatch.build.targets.wheel] packages` directory.
+
 ### genblaze-cli
 
 - **Fixed** `extract`, `verify`, `index`, and `replay` accepted a directory


### PR DESCRIPTION
Closes #44

## Summary

`genblaze-gmicloud` declared the `Typing :: Typed` PEP 561 classifier but shipped no `py.typed` marker, so downstream mypy/pyright treated every symbol from the package as `Any`. It was the only one of 14 packages with this gap.

## Changes

- Add empty `libs/connectors/gmicloud/genblaze_gmicloud/py.typed`.
- No `pyproject.toml` change: gmicloud's `[tool.hatch.build.targets.wheel] packages = ["genblaze_gmicloud"]` is structurally identical to every other connector's; hatchling already bundles all files under a declared package directory, confirmed by rebuilding the wheel and inspecting its contents (see test plan).
- Add `[Unreleased]` CHANGELOG entry under a new `### genblaze-gmicloud` heading.

## Test plan

- [x] `make lint` passes
- [x] `python -m build --wheel` for `libs/connectors/gmicloud`, then `unzip -l` on the resulting wheel confirms `genblaze_gmicloud/py.typed` is present
- [x] Diffed gmicloud's `pyproject.toml` against openai/google/s3 — wheel-packaging section is identical; no connector uses a different include mechanism
- [x] Docs updated (CHANGELOG only; no other docs reference this)

## Related

Closes #44