### PR TITLE
fix(security): always run ReDoS heuristic even when google-re2 is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Security** `pattern_safety.assert_safe()` no longer skips its
+  catastrophic-backtracking heuristic when `google-re2` is installed (#148).
+  A prior version (#80/#146) returned early once `re2.compile()` succeeded,
+  but `re2` accepts nested-quantifier shapes like `(a+)+$` because *its own*
+  engine matches them in linear time — `ModelFamily.matches()` always
+  matches with stdlib `re`, which still backtracks catastrophically on the
+  same input. Any environment with `re2` installed (CI, `[dev]`, `[re2]`)
+  was therefore strictly weaker than the pre-#146 heuristic-only guard for
+  exactly the shapes it targets. `re2` is now an additional gate rather
+  than a replacement; the heuristic always runs.
 - **Fixed** concurrent `stream()`/`astream()` calls on the same `Pipeline` or
   `AgentLoop` instance no longer cross-deliver events (#79, #84). The active
   emitter was a single mutable instance attribute, so a second concurrent

--- a/docs/exec-plans/active/redos-guard-heuristic-always-runs-148.md
+++ b/docs/exec-plans/active/redos-guard-heuristic-always-runs-148.md
@@ -32,6 +32,8 @@ Files touched:
   `(v\d+)+.*`) that monkeypatches `_HAS_RE2` (and a fake `_re2.compile`) to
   exercise both branches deterministically, independent of whether re2
   happens to be installed in the running environment.
+- `libs/core/tests/unit/test_model_family.py` — same `skipif(has_re2())`
+  bug baked into a construction-level smoke test; remove it the same way.
 
 No change needed in `family.py` — its matching code and docstring already
 describe the guard's intent correctly; the bug was entirely in

--- a/docs/exec-plans/active/redos-guard-heuristic-always-runs-148.md
+++ b/docs/exec-plans/active/redos-guard-heuristic-always-runs-148.md
@@ -1,0 +1,45 @@
+<!-- last_verified: 2026-07-15 -->
+# ReDoS guard regression: heuristic must always run regardless of re2 (#148)
+
+## Problem
+
+`pattern_safety.assert_safe()` (added by #146/#80) returns early after a
+successful `_re2.compile(src)` when `google-re2` is installed, skipping
+`_heuristic_unsafe()`. `re2.compile()` only confirms a pattern is
+*syntactically compatible* with re2 — it accepts nested-quantifier shapes
+like `(a+)+$` because re2's own engine matches them in linear time. But
+`ModelFamily.matches()` (`family.py:217`) always matches with a stdlib
+`re.Pattern`, which still backtracks catastrophically on the same input.
+Net effect: in any environment with `re2` installed (CI, `[dev]`, `[re2]`),
+the guard is strictly weaker than the pre-#146 heuristic-only behavior for
+exactly the shapes it was built to catch.
+
+## Fix
+
+Drop the early `return` in `assert_safe()` — `re2` becomes an *additional*
+gate (still rejects patterns re2 itself can't support, e.g. backreferences)
+rather than a replacement for the heuristic. `_heuristic_unsafe()` now runs
+unconditionally.
+
+Files touched:
+- `libs/core/genblaze_core/providers/pattern_safety.py` — remove the early
+  `return`; update the module/function docstrings that claimed re2 was a
+  standalone "authoritative" replacement.
+- `libs/core/tests/unit/test_pattern_safety.py` — remove the now-incorrect
+  `skipif(has_re2())` markers on the existing heuristic-shape rejection
+  tests (they should hold regardless of re2), and add a parametrized
+  regression test for the issue's exact repro shapes (`(a+)+`, `([a-z]+)+`,
+  `(v\d+)+.*`) that monkeypatches `_HAS_RE2` (and a fake `_re2.compile`) to
+  exercise both branches deterministically, independent of whether re2
+  happens to be installed in the running environment.
+
+No change needed in `family.py` — its matching code and docstring already
+describe the guard's intent correctly; the bug was entirely in
+`pattern_safety.py`'s branch logic.
+
+## Risk
+
+Low. Environments with `re2` installed now pay one extra heuristic scan per
+`ModelFamily` construction (import-time only, not a hot path) — negligible
+cost, and the existing perf gate (`tests/perf/test_registry_perf.py`)
+already budgets for the heuristic running.

--- a/docs/features/model-registry.md
+++ b/docs/features/model-registry.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-14 -->
+<!-- last_verified: 2026-07-15 -->
 # Model Registry
 
 Unified, declarative surface for per-model configuration across every
@@ -415,7 +415,7 @@ Existing `step.model="Seedream-5.0-Lite"` calls resolve to the new spec, a singl
 
 - `get(model_id)` (user-spec hit): ~80 ns (single dict lookup)
 - `match_family(model_id)` (32 families, miss): <50 µs (linear scan)
-- `match_family()` (adversarial input, 32 families): <100 µs (`pattern_safety` rejects unsafe patterns at construction; authoritative under `google-re2`, installed via the `re2`/`dev` extras — heuristic fallback otherwise). Enforced by `libs/core/tests/perf/test_registry_perf.py`.
+- `match_family()` (adversarial input, 32 families): <100 µs (`pattern_safety` rejects unsafe patterns at construction; the static heuristic always runs, plus an additional `google-re2` compile check when the `re2`/`dev` extras are installed — re2 is not a substitute for the heuristic, since runtime matching always uses stdlib `re`). Enforced by `libs/core/tests/perf/test_registry_perf.py`.
 - Full `prepare_payload` at 10 params: ~6 µs
 - `PricingContext` construction + strategy: <1 µs
 - `validate_model()` (no fetch, family-cached): <50 µs

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -9,15 +9,24 @@ DoS vector.
 
 This module guards against that at ``ModelFamily`` construction time —
 patterns that fail the safety check raise ``ValueError`` during connector
-import, before any user code runs. Two strategies, evaluated in order:
+import, before any user code runs. Runtime slug matching
+(``ModelFamily.matches()``, ``family.py``) always matches with a stdlib
+``re.Pattern``, never ``re2`` — so the static heuristic below always runs,
+regardless of whether ``re2`` is installed. Two gates are applied:
 
-* If ``google-re2`` is installed, every pattern is recompiled through it
-  to confirm linear-time matching. ``re2`` rejects unsupported constructs
-  outright, so the check is authoritative. Install it via the ``re2``
-  extra (``pip install "genblaze-core[re2]"``) or the ``dev`` extra, which
-  includes it — CI installs ``libs/core[dev]``, so this path is active
-  there by default.
-* Otherwise, fall back to a static heuristic that flags the most common
+* If ``google-re2`` is installed, every pattern is ALSO recompiled through
+  it as an additional gate: ``re2`` rejects constructs its own engine can't
+  support (e.g. backreferences) outright. This is *not* a substitute for
+  the heuristic — ``re2`` accepts nested-quantifier shapes like ``(a+)+``
+  because *its own* linear-time engine matches them fine, but stdlib
+  ``re`` (the engine actually used at match time) still backtracks
+  catastrophically on the same input. A prior version of this guard
+  returned early once the re2 compile succeeded, silently disabling the
+  heuristic for exactly these shapes whenever re2 was installed (#148).
+  Install re2 via the ``re2`` extra (``pip install "genblaze-core[re2]"``)
+  or the ``dev`` extra, which includes it — CI installs ``libs/core[dev]``,
+  so this path is active there by default.
+* The static heuristic always runs and flags the most common
   catastrophic-backtracking shapes: nested unbounded quantifiers (bare
   ``+``/``*`` or an open-ended ``{n,}`` brace quantifier, at any nesting
   depth), alternations of identical branches, runs of the same atom
@@ -177,14 +186,15 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
 
 
 def _heuristic_unsafe(src: str) -> bool:
-    """Static ReDoS heuristic used when ``re2`` isn't installed.
+    """Static ReDoS heuristic that always runs, whether or not ``re2`` is
+    installed.
 
-    Factored out of :func:`assert_safe` so it can be unit-tested directly.
-    ``assert_safe``'s branch selection depends on whether ``re2`` happens to
-    be importable in the current environment — testing only through
-    ``assert_safe`` would make these cases silently no-op wherever ``re2``
-    is installed (e.g. CI, once the authoritative check is wired in via the
-    ``dev`` extra).
+    Runtime slug matching (``ModelFamily.matches()``) always uses stdlib
+    ``re``, never ``re2`` — so ``re2`` accepting a pattern says nothing
+    about that pattern's safety under the engine actually used at match
+    time (#148). Factored out of :func:`assert_safe` so it can be
+    unit-tested directly regardless of whether ``re2`` happens to be
+    importable in the current environment.
     """
     return bool(
         _NESTED_QUANTIFIER.search(src)
@@ -200,6 +210,12 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
 
     Call from ``ModelFamily.__post_init__`` so connector imports fail fast
     when a pattern would put preflight at risk under adversarial input.
+
+    Two independent gates apply, both when ``re2`` is installed: the re2
+    compile check catches constructs re2 itself can't support, and the
+    heuristic below always runs regardless, because runtime matching
+    (``ModelFamily.matches()``) uses stdlib ``re``, which re2's acceptance
+    of a pattern says nothing about (#148).
     """
     src = pattern.pattern
 
@@ -211,7 +227,6 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
                 f"Pattern {src!r} rejected by google-re2 "
                 f"(linear-time guarantee unavailable): {exc}"
             ) from exc
-        return
 
     if _heuristic_unsafe(src):
         raise ValueError(
@@ -220,8 +235,9 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
             f"adjacent unbounded-quantified groups, and is rejected to "
             f"prevent catastrophic backtracking on adversarial input. "
             f"Rewrite the pattern (anchor it, use non-capturing groups, or "
-            f"make quantifiers possessive) or install google-re2 for an "
-            f"authoritative linear-time check."
+            f"make quantifiers possessive) — installing google-re2 does not "
+            f"bypass this check, since runtime matching always uses stdlib "
+            f"re, which this heuristic protects."
         )
 
 
@@ -229,6 +245,8 @@ def has_re2() -> bool:
     """Return ``True`` if ``google-re2`` is installed and active.
 
     Exposed for tests and observability — the registry doesn't change
-    behavior based on this; ``assert_safe`` already chose the strategy.
+    behavior based on this; ``assert_safe`` runs the heuristic gate
+    unconditionally and additionally runs the re2 gate when this is
+    ``True``.
     """
     return _HAS_RE2

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -57,13 +57,15 @@ audio = ["mutagen>=1.47,<1.49"]
 # already on httpx>=0.24 (nvidia, gmicloud, stability-audio, replicate).
 http = ["httpx>=0.24"]
 otel = ["opentelemetry-api>=1.20"]
-# Authoritative linear-time backstop for providers/pattern_safety.py's
-# ReDoS guard (issue #80). Guarded at the import site (try/except
-# ImportError) and absent by default — without it, assert_safe() falls back
-# to the static heuristic. google-re2 ships prebuilt wheels for macOS,
-# manylinux (x86_64/aarch64), and Windows across the Python versions this
-# repo supports, so declaring it here (and in `dev`, below) is low-risk and
-# is what actually activates the authoritative path in CI.
+# Additional linear-time gate for providers/pattern_safety.py's ReDoS guard
+# (issue #80), on top of the static heuristic that always runs regardless
+# (issue #148 — re2 accepting a pattern doesn't make it safe under the
+# stdlib `re` engine actually used at match time). Guarded at the import
+# site (try/except ImportError) and absent by default. google-re2 ships
+# prebuilt wheels for macOS, manylinux (x86_64/aarch64), and Windows across
+# the Python versions this repo supports, so declaring it here (and in
+# `dev`, below) is low-risk and is what actually activates this extra gate
+# in CI.
 re2 = ["google-re2>=1.0"]
 # genblaze_core.testing ships in the wheel and is a public, documented surface
 # (MockProvider/ProviderComplianceTests — see connector test suites and the

--- a/libs/core/tests/unit/test_model_family.py
+++ b/libs/core/tests/unit/test_model_family.py
@@ -65,14 +65,13 @@ class TestConstruction:
             )
 
     # `(a+)+` is rejected by the static heuristic (nested unbounded
-    # quantifier) but is exactly the shape `re2` guarantees linear-time
-    # matching for, so it's *accepted* — safely — once `re2` is active
-    # (e.g. the `dev`/`re2` extras, installed in CI as of #80). Branching on
-    # `has_re2()` keeps this construction-level smoke test meaningful under
-    # either strategy; `test_pattern_safety.py` covers each branch in depth.
-    @pytest.mark.skipif(
-        has_re2(), reason="re2 matches this pattern safely instead of rejecting it"
-    )
+    # quantifier). This used to skip when `re2` was active, on the mistaken
+    # assumption that `re2` accepting the pattern for its own linear-time
+    # engine made it safe overall — but `ModelFamily.matches()` always
+    # matches with stdlib `re`, which still backtracks catastrophically on
+    # this shape regardless of `re2`. That gap was itself issue #148; the
+    # heuristic now always runs, so construction must fail closed under
+    # either strategy. `test_pattern_safety.py` covers each branch in depth.
     def test_unsafe_pattern_rejected_at_construction(self) -> None:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             ModelFamily(

--- a/libs/core/tests/unit/test_model_family.py
+++ b/libs/core/tests/unit/test_model_family.py
@@ -81,7 +81,9 @@ class TestConstruction:
                 description="invalid",
             )
 
-    @pytest.mark.skipif(not has_re2(), reason="exercises the re2-authoritative construction path")
+    @pytest.mark.skipif(
+        not has_re2(), reason="exercises the additional re2-gate construction path"
+    )
     def test_re2_incompatible_pattern_rejected_at_construction(self) -> None:
         # Backreferences aren't supported by RE2's linear-time engine, so
         # this is unsafe-under-re2 the same way `(a+)+` is unsafe-under-the-

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -5,7 +5,22 @@ from __future__ import annotations
 import re
 
 import pytest
+from genblaze_core.providers import pattern_safety
 from genblaze_core.providers.pattern_safety import _heuristic_unsafe, assert_safe, has_re2
+
+
+class _FakeRe2:
+    """Stand-in for the ``re2`` module, used to force the ``_HAS_RE2 = True``
+    branch deterministically regardless of whether ``google-re2`` is
+    actually installed in the test environment. ``compile()`` mirrors re2's
+    real behavior for the nested-quantifier shapes this module cares about:
+    it happily accepts them (re2's own engine matches them in linear time),
+    which is exactly why the heuristic must run in addition to, not instead
+    of, the re2 check (#148)."""
+
+    @staticmethod
+    def compile(src: str) -> re.Pattern[str]:
+        return re.compile(src)
 
 
 class TestAssertSafe:
@@ -26,22 +41,24 @@ class TestAssertSafe:
     def test_empty_pattern_passes(self) -> None:
         assert_safe(re.compile(r""))
 
-    @pytest.mark.skipif(has_re2(), reason="re2 enforces its own checks")
+    # The four tests below used to skip whenever re2 was installed, because
+    # a prior version of assert_safe() returned early after a successful
+    # re2 compile, never reaching the heuristic — re2 itself accepts these
+    # shapes (see TestRedosGuardAlwaysRunsHeuristic below for why that's
+    # unsafe). The heuristic now always runs, so these hold unconditionally
+    # (#148).
     def test_nested_unbounded_plus_rejected(self) -> None:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(r"(a+)+"))
 
-    @pytest.mark.skipif(has_re2(), reason="re2 enforces its own checks")
     def test_nested_unbounded_star_rejected(self) -> None:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(r"(.+)+"))
 
-    @pytest.mark.skipif(has_re2(), reason="re2 enforces its own checks")
     def test_duplicate_alternation_rejected(self) -> None:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(r"(a|a)*"))
 
-    @pytest.mark.skipif(has_re2(), reason="re2 enforces its own checks")
     def test_realistic_evil_pattern_rejected(self) -> None:
         # The classic "(x+x+)+y" shape. Heuristic flags the nested quantifier;
         # that's enough to fail closed. Assembled at runtime (this fixture is only
@@ -51,13 +68,52 @@ class TestAssertSafe:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(evil))
 
-    @pytest.mark.skipif(not has_re2(), reason="requires re2 to exercise the authoritative branch")
+    @pytest.mark.skipif(not has_re2(), reason="requires re2 to exercise the additional re2 gate")
     def test_re2_rejects_backreference(self) -> None:
         # Backreferences aren't supported by RE2's linear-time engine — this
-        # exercises the authoritative branch itself (distinct from the
-        # heuristic-shape tests above, which are skipped once re2 is active).
+        # exercises the re2 gate itself (distinct from the heuristic-shape
+        # tests above, which now run regardless of whether re2 is active).
         with pytest.raises(ValueError, match="rejected by google-re2"):
             assert_safe(re.compile(r"(a)\1"))
+
+
+class TestRedosGuardAlwaysRunsHeuristic:
+    """Regression test for #148: ``assert_safe()`` must reject catastrophic
+    -backtracking patterns whether or not ``google-re2`` is installed.
+
+    ``re2.compile()`` only confirms a pattern is *syntactically compatible*
+    with re2 — it accepts nested-quantifier shapes like ``(a+)+$`` because
+    re2's own engine matches them in linear time. Runtime slug matching
+    (``ModelFamily.matches()``, ``family.py``) always uses stdlib ``re``,
+    which still backtracks catastrophically on the same input. A prior
+    version of ``assert_safe()`` returned early once ``_re2.compile()``
+    succeeded, so re2's acceptance silently disabled the heuristic for
+    exactly these shapes. Both branches are exercised via
+    ``monkeypatch.setattr`` so the test is deterministic regardless of
+    whether ``google-re2`` happens to be installed in the environment
+    actually running this suite.
+    """
+
+    @pytest.mark.parametrize(
+        "src",
+        [r"(a+)+$", r"([a-z]+)+$", r"(v\d+)+.*"],
+        ids=["nested-plus-anchored", "nested-charclass-anchored", "version-prefix-catastrophic"],
+    )
+    @pytest.mark.parametrize("has_re2_value", [True, False], ids=["re2-present", "re2-absent"])
+    def test_rejected_regardless_of_has_re2(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        src: str,
+        has_re2_value: bool,
+    ) -> None:
+        monkeypatch.setattr(pattern_safety, "_HAS_RE2", has_re2_value)
+        if has_re2_value:
+            # Force the re2 gate to "accept" the pattern (as real re2 does
+            # for these shapes) without depending on re2 actually being
+            # importable in this environment.
+            monkeypatch.setattr(pattern_safety, "_re2", _FakeRe2)
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(src))
 
 
 class TestHeuristicUnsafe:


### PR DESCRIPTION
## Summary

Closes #148

`pattern_safety.assert_safe()` returned early after a successful `_re2.compile()` when `google-re2` is installed, skipping `_heuristic_unsafe()` entirely. `re2.compile()` only confirms a pattern is syntactically compatible with re2's own linear-time engine — it accepts nested-quantifier shapes like `(a+)+$` because re2 itself matches them fine. But `ModelFamily.matches()` (`family.py:217`) always matches with a stdlib `re.Pattern`, which still backtracks catastrophically on the same input. Net effect: any environment with `re2` installed (CI, `[dev]`, `[re2]`) had a strictly weaker guard than the pre-#146 heuristic-only behavior for exactly the shapes it was designed to catch.

## Changes

- `libs/core/genblaze_core/providers/pattern_safety.py` — drop the early `return`; `re2` is now an additional gate (still catches constructs re2 itself can't support, e.g. backreferences) rather than a replacement for the heuristic, which now always runs. Updated module/function docstrings and the rejection error message to match the corrected behavior.
- `libs/core/tests/unit/test_pattern_safety.py` — removed `skipif(has_re2())` markers whose skip condition was itself the bug (the shape-rejection tests now hold regardless of re2); added `TestRedosGuardAlwaysRunsHeuristic`, a parametrized regression test for the issue's exact repro shapes (`(a+)+$`, `([a-z]+)+$`, `(v\d+)+.*`) that monkeypatches `_HAS_RE2` (and a `_FakeRe2` stand-in) to exercise both branches deterministically, independent of whether re2 happens to be installed.
- `libs/core/tests/unit/test_model_family.py` — same `skipif(has_re2())` bug was baked into a construction-level smoke test; removed with an accurate explanatory comment.
- `docs/features/model-registry.md`, `libs/core/pyproject.toml` — corrected stale comments that described re2 as an authoritative replacement for the heuristic (found in panel review; same wrong assumption the code bug embodied).
- `CHANGELOG.md` — `[Unreleased]` entry under `### genblaze-core`.
- `docs/exec-plans/active/redos-guard-heuristic-always-runs-148.md` — short plan.

No change needed in `family.py` — its matching code and docstring already describe the guard's intent correctly.

## Panel review

Three independent reviewers examined the committed diff (`git diff origin/main...HEAD`) before push, each with no knowledge of the others' findings:

- **Correctness/issue-coverage** — confirmed the fix resolves #148: with `google-re2` installed in this environment, all three repro patterns (`(a+)+$`, `([a-z]+)+$`, `(v\d+)+.*`) are now rejected by `assert_safe()`, and the new regression test genuinely fails pre-fix / passes post-fix in both `_HAS_RE2` branches. No blocking findings.
- **Adversarial security** — confirmed the three #148 repro patterns are correctly rejected with re2 active, and that deep nesting (`((((a+)+)+)+)$`) and non-adjacent quantified alternation (`(a+|b+)+$`) are still correctly caught. Found two **pre-existing** (not introduced by this diff) heuristic-completeness gaps unrelated to the re2-early-return bug: `(a|aa)+$` (non-identical overlapping alternation) and `(a+)-?(a+)-?(a+)-?(a+)$` (adjacent unbounded groups separated by an optional delimiter) both bypass `_heuristic_unsafe()` regardless of `_HAS_RE2`, with confirmed exponential/polynomial blowup under stdlib `re`. Flagged as a follow-up (out of scope for #148, which is specifically the re2-gate regression, not a full heuristic audit) — not filed as a new issue per this task's scope, surfacing here for a maintainer to triage.
- **Engineering quality** — found one P0 (now fixed): `docs/features/model-registry.md` still described re2 as an authoritative replacement, the exact wrong assumption #148 disproves. Also flagged (now fixed) an incomplete "files touched" list in the exec-plan and two stale "authoritative" references in `test_model_family.py`/`pyproject.toml` comments. No other blocking findings — confirmed minimal diff, DRY test double, and accurate docstrings/error message post-fix.

All fixes from panel review were applied and re-verified before push.

## Test plan

- [x] `make lint` passes (ruff check + format, deptry across all packages)
- [x] `pattern_safety`/`model_family`/registry-perf tests pass (51 passed)
- [x] Full `libs/core` suite passes except one pre-existing, unrelated `numpy`/`pyarrow` ABI failure in `test_pipeline_chain_integration.py::test_chain_pipeline_to_parquet_sink` (confirmed reproduces identically on unmodified `origin/main`)
- [x] All connector packages, `cli` (pre-existing unrelated failures also confirmed on `origin/main`), `meta`, and `tools` test suites pass/reproduce identically to `main`
- [x] Docs updated in the same PR

## Related

Refs #148, #80, #146