### PR TITLE
fix(provenance): tolerant Asset load + ParquetSink write correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maintains a persisted `run_id -> partition` index (one small file per
   `run_id`, so concurrent writers sinking different `run_id`s never race on
   a shared file) and only touches the file for that specific `run_id`
-  instead of walking the tree; an existing `runs/` tree without an index
-  yet is backfilled once, at the first `ParquetSink` construction, not on
-  every write.
+  instead of walking the tree. An existing `runs/` tree without an index
+  yet is backfilled once, atomically (built in a temp directory and
+  `os.replace`d into place so a crash mid-backfill can never leave a
+  partially-populated index that a later `ParquetSink` mistakes for
+  complete), at the first `ParquetSink` construction, not on every write.
 - **Fixed** the #72 idempotency fix still silently dropped a same-partition
   re-sink whose content changed — e.g. a resume that completes more steps
   without changing the modality/provider set, so the partition path (and
@@ -140,7 +142,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compares the existing sentinel's `canonical_hash` against the new
   manifest's before short-circuiting; only a byte-for-byte repeat is a
   no-op, and a genuine content change rewrites the `runs`/`steps`/`assets`
-  rows in place.
+  rows in place. The no-op path also refreshes the run's index entry, so a
+  prior write that crashed between writing its sentinel and persisting its
+  index entry self-heals on the next call for that `run_id` instead of
+  only on a future rewrite.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `output_asset_ids_with_invalid_metadata()` is the new verification
   boundary that surfaces out-of-spec metadata on loaded data, mirroring
   `output_asset_ids_missing_sha256()`.
+- **Fixed** `ParquetSink.write_run()` globbed the entire `runs/` tree on
+  every write for a brand-new `run_id`, not just the idempotent-rewrite
+  case the #72 fix targeted — an O(number of partitions) cost paid on every
+  single write over a long-lived dataset (#150). `write_run()` now
+  maintains a persisted `run_id -> partition` index (one small file per
+  `run_id`, so concurrent writers sinking different `run_id`s never race on
+  a shared file) and only touches the file for that specific `run_id`
+  instead of walking the tree; an existing `runs/` tree without an index
+  yet is backfilled once, at the first `ParquetSink` construction, not on
+  every write.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the fast path misses, and removes a stale partition's files
   (`steps`/`assets` before `runs`, so an interrupted cleanup is safely
   retryable) before writing the fresh ones.
+- **Fixed** the numeric/`media_type` field constraints added for #78
+  (`width`/`height`/`bitrate`/`sample_rate`/`channels` `gt=0`,
+  `duration`/`frame_rate` finite, `media_type` shape) were enforced on the
+  manifest **load** path too, so an older or foreign-authored manifest
+  carrying a previously-valid value (e.g. `width=0` as an "unknown
+  dimensions" placeholder, or a non-MIME `media_type`) raised
+  `ValidationError` from `parse_manifest()`, breaking `verify`/`index`/
+  `replay` on files that used to load fine (#149). These fields now follow
+  the same tolerant-load pattern already established for `sha256`:
+  constraints still reject impossible values on ordinary construction, but
+  `parse_manifest()` validates with `context={"tolerant_load": True}` so a
+  tolerant load never crashes. `Manifest.verify()` /
+  `output_asset_ids_with_invalid_metadata()` is the new verification
+  boundary that surfaces out-of-spec metadata on loaded data, mirroring
+  `output_asset_ids_missing_sha256()`.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of walking the tree; an existing `runs/` tree without an index
   yet is backfilled once, at the first `ParquetSink` construction, not on
   every write.
+- **Fixed** the #72 idempotency fix still silently dropped a same-partition
+  re-sink whose content changed — e.g. a resume that completes more steps
+  without changing the modality/provider set, so the partition path (and
+  therefore the fast-path check) is unchanged (#152). `write_run()` now
+  compares the existing sentinel's `canonical_hash` against the new
+  manifest's before short-circuiting; only a byte-for-byte repeat is a
+  no-op, and a genuine content change rewrites the `runs`/`steps`/`assets`
+  rows in place.
 - **Fixed** `step_cache_key` no longer sorts `step.inputs` before hashing (#71).
   Providers that consume inputs positionally (multi-image edit/compose,
   multimodal chat) produce different output when input order changes, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to write the manifest JSON to a file, matching the documented usage.
 - **Changed** `--version` now reports `genblaze-cli` rather than `genblaze`,
   so the CLI's version is no longer mistaken for the umbrella package version.
+- **Fixed** `verify` reported `OK` (exit 0) for a manifest whose asset
+  metadata is out of spec (e.g. a `width=0` value a tolerant load accepts)
+  even though `Manifest.verify()` rejects it — the command checked only
+  `hash_ok` and sha256, never the new `invalid_metadata_ids` boundary (#149).
+  `verify` now fails such a manifest with a clear message, and `extract
+  --format summary` gains an `Output metadata:` line so a `Verified: False`
+  verdict always shows its reason.
 
 ### genblaze (umbrella)
 

--- a/cli/genblaze_cli/commands/extract.py
+++ b/cli/genblaze_cli/commands/extract.py
@@ -46,6 +46,9 @@ def extract(file: Path, fmt: str, output: Path | None) -> None:
             click.echo(f"Hash:      {manifest.canonical_hash}")
             click.echo(f"Hash OK:   {report.hash_ok}")
             click.echo(f"Output sha256: {len(report.unverified_sha256_ids)} missing or malformed")
+            # Itemize metadata too, so a False `Verified:` line always has a
+            # visible reason (report.ok folds in invalid_metadata_ids, #149).
+            click.echo(f"Output metadata: {len(report.invalid_metadata_ids)} out of spec")
             click.echo(f"Verified:  {report.ok} (asset bytes were not fetched or compared)")
     except Exception as exc:
         raise click.ClickException(f"{type(exc).__name__}: {exc}") from exc

--- a/cli/genblaze_cli/commands/verify.py
+++ b/cli/genblaze_cli/commands/verify.py
@@ -12,7 +12,7 @@ from genblaze_cli.manifest_io import extract_manifest
 @click.option(
     "--hash-only",
     is_flag=True,
-    help="Only verify canonical_hash; do not require output sha256 declarations.",
+    help="Only verify canonical_hash; skip output sha256 and asset-metadata checks.",
 )
 def verify(file: Path, hash_only: bool) -> None:
     """Verify an embedded, sidecar, or standalone genblaze manifest."""
@@ -32,9 +32,21 @@ def verify(file: Path, hash_only: bool) -> None:
                 err=True,
             )
             raise click.exceptions.Exit(1)
+        # Out-of-spec numeric/media_type metadata (e.g. width=0) is tolerated on
+        # load by parse_manifest() but fails verify() (#149); surface it here so
+        # the CLI verdict matches Manifest.verify()/report.ok instead of a stale
+        # "OK" that only checked sha256.
+        if report.invalid_metadata_ids:
+            click.echo(
+                f"FAIL: {len(report.invalid_metadata_ids)} output asset(s) "
+                "carry out-of-spec numeric/media_type metadata "
+                "(e.g. width=0, or a malformed media_type).",
+                err=True,
+            )
+            raise click.exceptions.Exit(1)
         click.echo(
-            "OK: manifest hash verified; all output assets declare sha256. "
-            "Asset bytes were not fetched or compared."
+            "OK: manifest hash verified; all output assets declare sha256 and "
+            "carry in-spec metadata. Asset bytes were not fetched or compared."
         )
     except click.exceptions.Exit:
         raise

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -58,6 +58,28 @@ def _create_url_only_manifest(*, schema_version: str | None = None) -> Manifest:
     return manifest
 
 
+def _url_only_manifest_with_bad_metadata() -> Manifest:
+    """A hash-valid, sha256-valid manifest whose sole output asset carries an
+    out-of-spec dimension (width=0) — the shape parse_manifest() tolerates on
+    load but verify() must reject (#149). Injected via object.__setattr__ to
+    bypass construction validation, mirroring a foreign-authored manifest."""
+    manifest = _create_url_only_manifest()
+    asset = manifest.run.steps[0].assets[0]
+    object.__setattr__(asset, "sha256", "a" * 64)  # valid, so only metadata fails
+    object.__setattr__(asset, "width", 0)
+    manifest.compute_hash()
+    return manifest
+
+
+def _combined_output(result) -> str:
+    """CLI stdout+stderr, robust across Click versions. Click >=8.2 captures
+    stderr separately; 8.1.x mixes it into output and raises on ``.stderr``."""
+    try:
+        return result.output + result.stderr
+    except ValueError:
+        return result.output
+
+
 def test_extract_json(tmp_path: Path) -> None:
     png = _create_embedded_png(tmp_path)
     runner = CliRunner()
@@ -94,6 +116,7 @@ def test_extract_summary(tmp_path: Path) -> None:
     assert "Run ID:" in result.output
     assert "Hash OK:" in result.output
     assert "Output sha256:" in result.output
+    assert "Output metadata:" in result.output
     assert "Verified:" in result.output
 
 
@@ -242,6 +265,75 @@ def test_verify_rejects_malformed_output_sha256(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "1 output asset(s) missing or malformed sha256" in combined
+
+
+def test_verify_rejects_out_of_spec_asset_metadata(tmp_path: Path) -> None:
+    """#149/#155: a manifest with a valid hash and valid sha256 but out-of-spec
+    asset metadata (e.g. width=0, which parse_manifest() tolerates on load) must
+    fail `verify`, so the CLI verdict agrees with Manifest.verify()/report.ok
+    rather than reporting OK because only sha256 was checked."""
+    manifest = _url_only_manifest_with_bad_metadata()
+    # Assert the model layer first so this pins the boundary even in a Click
+    # build where CLI output parsing behaves differently.
+    assert not manifest.verify()
+
+    png_path = tmp_path / "bad-metadata.png"
+    Image.new("RGBA", (1, 1), (255, 0, 0, 255)).save(png_path)
+    png_path.with_suffix(png_path.suffix + ".genblaze.json").write_text(
+        manifest.to_canonical_json(),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", str(png_path)])
+    combined = _combined_output(result)
+
+    assert result.exit_code != 0
+    assert "out-of-spec" in combined
+    # Prove it's the metadata boundary, not a sha256 or hash failure.
+    assert "missing or malformed sha256" not in combined
+    assert "hash mismatch" not in combined
+
+
+def test_verify_hash_only_skips_metadata_check(tmp_path: Path) -> None:
+    """--hash-only must short-circuit before the metadata check: an out-of-spec
+    manifest whose hash still matches exits 0 (metadata lives inside the hash
+    payload, so hash-only stays an honest integrity-only claim). Pins the check
+    order so a refactor can't move the metadata guard ahead of the early return."""
+    manifest = _url_only_manifest_with_bad_metadata()
+    png_path = tmp_path / "bad-metadata-hash-only.png"
+    Image.new("RGBA", (1, 1), (255, 0, 0, 255)).save(png_path)
+    png_path.with_suffix(png_path.suffix + ".genblaze.json").write_text(
+        manifest.to_canonical_json(),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--hash-only", str(png_path)])
+
+    assert result.exit_code == 0
+    assert "manifest hash verified" in result.output
+
+
+def test_extract_summary_surfaces_out_of_spec_metadata(tmp_path: Path) -> None:
+    """#149/#155: `extract --format summary` itemizes invalid metadata so a
+    `Verified: False` verdict always has a visible reason and agrees with
+    `verify` (mirrors the sha256 parity test)."""
+    manifest = _url_only_manifest_with_bad_metadata()
+    png_path = tmp_path / "bad-metadata-extract.png"
+    Image.new("RGBA", (1, 1), (255, 0, 0, 255)).save(png_path)
+    png_path.with_suffix(png_path.suffix + ".genblaze.json").write_text(
+        manifest.to_canonical_json(),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "--format", "summary", str(png_path)])
+
+    assert result.exit_code == 0
+    assert "Output sha256: 0 missing or malformed" in result.output
+    assert "Output metadata: 1 out of spec" in result.output
+    assert "Verified:  False" in result.output
 
 
 def test_verify_reports_legacy_unverified_assets(tmp_path: Path) -> None:

--- a/docs/features/manifest-provenance.md
+++ b/docs/features/manifest-provenance.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-20 -->
+<!-- last_verified: 2026-07-15 -->
 # Feature: Manifest Provenance
 
 ## Purpose
@@ -10,7 +10,7 @@ Produce hash-verified, canonical JSON manifests that capture full provenance of 
 
 ## Core Functions
 - `Manifest.from_run(run)` — Construct manifest from run and compute hash
-- `Manifest.verify()` — Validate canonical_hash matches content and every output asset declares a valid lowercase `sha256`
+- `Manifest.verify()` — Validate canonical_hash matches content, every output asset declares a valid lowercase `sha256`, and every output asset's numeric/`media_type` metadata is in spec
 - `Manifest.verify_hash()` — Validate only that canonical_hash matches the canonical payload
 - `canonical_json()` — Deterministic serialization (sorted keys, normalized floats, NFC unicode)
 - `Manifest.to_embed_json()` — Policy-filtered JSON for embedding
@@ -34,12 +34,16 @@ Produce hash-verified, canonical JSON manifests that capture full provenance of 
 - SHA-256 hash computed over canonical bytes
 - Hash stored as `canonical_hash`
 - `verify_hash()` re-serializes and compares the canonical hash
-- `verify()` calls `verify_hash()` and returns `False` when any output asset lacks a valid lowercase `sha256`
+- `verify()` calls `verify_hash()` and returns `False` when any output asset lacks a valid lowercase `sha256` or carries out-of-spec numeric/`media_type` metadata (`output_asset_ids_with_invalid_metadata()`, #149)
 
 ## Edge Cases
 - Float precision differences → normalization ensures consistency
 - Unicode variants → NFC normalization before hashing
 - Empty run (no steps) → valid manifest with empty steps list
+- Older/foreign manifest with an out-of-spec asset field (`width=0`, a
+  non-MIME `media_type`, ...) → `parse_manifest()` loads it tolerantly
+  (`Asset` still rejects these on ordinary construction); `verify()` is the
+  boundary that surfaces the problem instead of a load-time crash (#149)
 
 ## Hash payload vs canonical JSON
 
@@ -68,7 +72,7 @@ authoritative reference.
 ### Self-verification flow
 1. Read the embedded / sidecar manifest JSON (full canonical form).
 2. Parse with `parse_manifest(json.loads(text))` so schema migrations and manifest invariants are enforced.
-3. Call `manifest.verify_hash()` to check only canonical payload integrity, or `manifest.verify()` to also reject URL-only output assets and malformed sha256 declarations.
+3. Call `manifest.verify_hash()` to check only canonical payload integrity, or `manifest.verify()` to also reject URL-only output assets, malformed sha256 declarations, and out-of-spec asset metadata.
 4. If you will fetch asset URLs, hash those fetched bytes separately and compare them with `asset.sha256`; manifest verification does not perform network reads.
 
 ### Trust modes

--- a/docs/features/parquet-sink.md
+++ b/docs/features/parquet-sink.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-14 -->
+<!-- last_verified: 2026-07-15 -->
 # Feature: Parquet Sink
 
 ## Purpose
@@ -23,30 +23,42 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
 ## Outputs
 - Three Parquet table directories: `runs/`, `steps/`, `assets/`
 - Partition scheme: `dt=YYYY-MM-DD/tenant_id={tenant}/modality={modality}/provider={provider}`
+- `_run_index/`: internal `run_id -> partition` bookkeeping (one small file
+  per `run_id`); not a data table, ignored by Hive-style dataset readers
+  scanning `runs/`/`steps`/`assets`
 
 ## Flow
-- `ParquetSink(output_dir, policy=None)` initializes with target directory and optional `EmbedPolicy`
+- `ParquetSink(output_dir, policy=None)` initializes with target directory
+  and optional `EmbedPolicy`. If `output_dir` already has a `runs/` tree but
+  no `_run_index/` yet (e.g. first use after upgrading), the index is
+  backfilled once from that tree.
 - `write_run()` flattens run/steps/assets into tabular rows
 - When `policy` is set, redacts prompt/params/seed per `EmbedPolicy` rules before writing step rows
 - Writes to partitioned Parquet using pyarrow
 - Idempotent by `run_id`: the partition is derived from run content
   (step modality/provider set), so it can move between sinks of the same
   `run_id` (e.g. a resume that completes more steps). A same-partition
-  match is a no-op (checked first, cheaply); otherwise every partition is
-  probed for a stale sentinel, whose `steps`/`assets`/`runs` files are
-  removed (in that order) before writing the fresh ones, so a completed
-  write leaves exactly one row set per `run_id` (#72). This is not a
-  cross-file transaction: a crash between removing the stale sentinel and
-  writing the new one leaves the run temporarily un-sinked until the next
-  `write_run()` call, the same accepted trade-off as the original
-  first-write completion sentinel
+  match is a no-op (checked first, cheaply); otherwise the `run_id ->
+  partition` index (`_run_index/`) is consulted — an O(1) lookup, not a
+  scan of the whole `runs/` tree (#150) — to find and remove a stale
+  partition's `steps`/`assets`/`runs` files (in that order) before writing
+  the fresh ones, so a completed write leaves exactly one row set per
+  `run_id` (#72). This is not a cross-file transaction: a crash between
+  removing the stale sentinel and writing the new one leaves the run
+  temporarily un-sinked until the next `write_run()` call, the same
+  accepted trade-off as the original first-write completion sentinel
 
 ## Edge Cases
 - Duplicate `run_id`, same content → write skipped (idempotent)
 - Duplicate `run_id`, changed content (moved partition) → stale partition's
-  files are replaced by the new write, not duplicated
+  files are replaced by the new write, not duplicated (#72)
+- New `run_id` in a dataset with many existing partitions → resolved via the
+  `_run_index/` file for that `run_id`, never a full-tree scan (#150)
 - Missing pyarrow → `ImportError` at sink creation (optional dependency)
-- Concurrent writes → thread-safe via internal lock
+- Concurrent writes to the *same* `ParquetSink` instance → thread-safe via internal lock
+- Concurrent writes to *different* `run_id`s from separate `ParquetSink`
+  instances (e.g. parallel `genblaze index` invocations into one output
+  dir) → each `run_id`'s index entry is its own file, so they don't race
 - `EmbedPolicy` with `prompt_visibility=PRIVATE` → prompts written as empty strings
 - `EmbedPolicy` with `include_params=False` → params written as `{}`
 - `EmbedPolicy` with `include_seed=False` → seed written as null

--- a/docs/features/parquet-sink.md
+++ b/docs/features/parquet-sink.md
@@ -40,22 +40,30 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
   (e.g. a resume that completes more steps).
   - Same partition as the last sink: compares the new manifest's
     `canonical_hash` against the sentinel already on disk. Identical content
-    is a no-op; changed content (e.g. a resume that added steps without
-    changing modality/provider) rewrites the `runs`/`steps`/`assets` rows in
-    place instead of silently dropping the new data (#152).
+    is a no-op — but the `run_id -> partition` index entry is refreshed even
+    on this path, so a prior crash that wrote the sentinel but never
+    persisted its index entry self-heals on the next call rather than only
+    a future rewrite. Changed content (e.g. a resume that added steps
+    without changing modality/provider) rewrites the `runs`/`steps`/`assets`
+    rows in place instead of silently dropping the new data (#152).
   - Different partition than the last sink: the `run_id -> partition` index
     (`_run_index/`) is consulted — an O(1) lookup, not a scan of the whole
     `runs/` tree (#150) — to find and remove the stale partition's
     `steps`/`assets`/`runs` files (in that order) before writing the fresh
     ones, so a completed write leaves exactly one row set per `run_id` (#72).
+    The index itself is backfilled once, atomically (temp directory +
+    `os.replace`), from any pre-existing `runs/` tree that predates it.
   - This is not a cross-file transaction: a crash between removing the stale
-    sentinel/index entry and writing the new one leaves the run temporarily
-    un-sinked, or the index entry briefly stale, until the next `write_run()`
-    call for that `run_id` — the same accepted trade-off as the original
-    first-write completion sentinel.
+    sentinel and writing the new one leaves the run temporarily un-sinked
+    until the next `write_run()` call for that `run_id`, the same accepted
+    trade-off as the original first-write completion sentinel. A crash
+    between writing the new sentinel and persisting its index entry is
+    self-healed by that same next call (including a no-op one, per above);
+    only a crash there immediately followed by a *second* partition move
+    before any intervening call remains an accepted, narrow residual risk.
 
 ## Edge Cases
-- Duplicate `run_id`, same content → write skipped (idempotent)
+- Duplicate `run_id`, same content → write skipped (idempotent), index entry refreshed
 - Duplicate `run_id`, changed content, same partition → rewritten in place (#152)
 - Duplicate `run_id`, changed content, moved partition → stale partition's
   files are replaced by the new write, not duplicated (#72)
@@ -69,6 +77,11 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
 - `EmbedPolicy` with `prompt_visibility=PRIVATE` → prompts written as empty strings
 - `EmbedPolicy` with `include_params=False` → params written as `{}`
 - `EmbedPolicy` with `include_seed=False` → seed written as null
+- Re-sinking a run under a *changed* `EmbedPolicy` only (run content
+  otherwise identical) → still a no-op: `canonical_hash` reflects
+  provenance content, not policy, so already-sunk rows keep their original
+  redaction. Re-sink under a policy change is not currently a supported way
+  to purge already-written prompt/params/seed values.
 
 ## Verification
 - Test files: `libs/core/tests/unit/test_parquet.py`

--- a/docs/features/parquet-sink.md
+++ b/docs/features/parquet-sink.md
@@ -35,22 +35,29 @@ Write structured run/step/asset data to partitioned Parquet files for analytics 
 - `write_run()` flattens run/steps/assets into tabular rows
 - When `policy` is set, redacts prompt/params/seed per `EmbedPolicy` rules before writing step rows
 - Writes to partitioned Parquet using pyarrow
-- Idempotent by `run_id`: the partition is derived from run content
-  (step modality/provider set), so it can move between sinks of the same
-  `run_id` (e.g. a resume that completes more steps). A same-partition
-  match is a no-op (checked first, cheaply); otherwise the `run_id ->
-  partition` index (`_run_index/`) is consulted — an O(1) lookup, not a
-  scan of the whole `runs/` tree (#150) — to find and remove a stale
-  partition's `steps`/`assets`/`runs` files (in that order) before writing
-  the fresh ones, so a completed write leaves exactly one row set per
-  `run_id` (#72). This is not a cross-file transaction: a crash between
-  removing the stale sentinel and writing the new one leaves the run
-  temporarily un-sinked until the next `write_run()` call, the same
-  accepted trade-off as the original first-write completion sentinel
+- Idempotent by `run_id`: the partition is derived from run content (step
+  modality/provider set), so it can move between sinks of the same `run_id`
+  (e.g. a resume that completes more steps).
+  - Same partition as the last sink: compares the new manifest's
+    `canonical_hash` against the sentinel already on disk. Identical content
+    is a no-op; changed content (e.g. a resume that added steps without
+    changing modality/provider) rewrites the `runs`/`steps`/`assets` rows in
+    place instead of silently dropping the new data (#152).
+  - Different partition than the last sink: the `run_id -> partition` index
+    (`_run_index/`) is consulted — an O(1) lookup, not a scan of the whole
+    `runs/` tree (#150) — to find and remove the stale partition's
+    `steps`/`assets`/`runs` files (in that order) before writing the fresh
+    ones, so a completed write leaves exactly one row set per `run_id` (#72).
+  - This is not a cross-file transaction: a crash between removing the stale
+    sentinel/index entry and writing the new one leaves the run temporarily
+    un-sinked, or the index entry briefly stale, until the next `write_run()`
+    call for that `run_id` — the same accepted trade-off as the original
+    first-write completion sentinel.
 
 ## Edge Cases
 - Duplicate `run_id`, same content → write skipped (idempotent)
-- Duplicate `run_id`, changed content (moved partition) → stale partition's
+- Duplicate `run_id`, changed content, same partition → rewritten in place (#152)
+- Duplicate `run_id`, changed content, moved partition → stale partition's
   files are replaced by the new write, not duplicated (#72)
 - New `run_id` in a dataset with many existing partitions → resolved via the
   `_run_index/` file for that `run_id`, never a full-tree scan (#150)

--- a/libs/core/genblaze_core/models/asset.py
+++ b/libs/core/genblaze_core/models/asset.py
@@ -179,6 +179,11 @@ class Asset(BaseModel):
     )
     media_type: str = Field(description="MIME type (e.g. 'image/png').")
     sha256: str | None = Field(default=None, description="SHA-256 hash of asset content.")
+    # NOTE: size_bytes keeps its plain Field(ge=0) — unlike width/height/duration
+    # below, it was not part of #149's reported failure scenarios (foreign
+    # manifests carrying it negative is not a known real-world case), so it
+    # stays strict on load too rather than adding tolerant-load plumbing with
+    # no reported need. Revisit if a real load-time failure surfaces.
     size_bytes: int | None = Field(default=None, ge=0, description="File size in bytes.")
     width: int | None = Field(default=None, description="Image/video width in pixels.")
     height: int | None = Field(default=None, description="Image/video height in pixels.")

--- a/libs/core/genblaze_core/models/asset.py
+++ b/libs/core/genblaze_core/models/asset.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import math
 import re
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from genblaze_core._utils import compute_sha256, new_id
 
@@ -24,6 +25,30 @@ def is_valid_sha256(value: str | None) -> bool:
         and len(value) == 64
         and all(char in _SHA256_HEX_CHARS for char in value)
     )
+
+
+def _tolerant_load(info: ValidationInfo) -> bool:
+    """True when validating a manifest read via ``parse_manifest()``.
+
+    ``parse_manifest()`` passes ``context={"tolerant_load": True}`` to
+    ``Manifest.model_validate()`` (which propagates to every nested model,
+    including ``Asset``/``VideoMetadata``/``AudioMetadata``) so an older or
+    foreign-authored manifest with out-of-spec numeric/``media_type`` values
+    still loads. See the NOTE below and ``is_valid_asset_metadata()`` for the
+    verification-boundary enforcement this defers to (#149).
+    """
+    return bool(info.context and info.context.get("tolerant_load"))
+
+
+def _is_positive(value: float | None) -> bool:
+    """True if None or > 0 — the invariant behind the former `gt=0` Field constraint."""
+    return value is None or value > 0
+
+
+def _is_finite_nonnegative(value: float | None) -> bool:
+    """True if None or a finite value >= 0 — the invariant behind the former
+    `ge=0, allow_inf_nan=False` Field constraint."""
+    return value is None or (math.isfinite(value) and value >= 0)
 
 
 class WordTiming(BaseModel):
@@ -46,11 +71,9 @@ class WordTiming(BaseModel):
 class VideoMetadata(BaseModel):
     """Technical metadata for video assets (codec, frame rate, etc.)."""
 
-    frame_rate: float | None = Field(
-        default=None, ge=0, allow_inf_nan=False, description="Frames per second."
-    )
+    frame_rate: float | None = Field(default=None, description="Frames per second.")
     codec: str | None = Field(default=None, description="Video codec (e.g. 'h264', 'vp9').")
-    bitrate: int | None = Field(default=None, gt=0, description="Bitrate in bits per second.")
+    bitrate: int | None = Field(default=None, description="Bitrate in bits per second.")
     color_space: str | None = Field(default=None, description="Color space (e.g. 'bt709').")
     has_audio: bool | None = Field(
         default=None, description="Whether the video contains an audio track."
@@ -59,21 +82,42 @@ class VideoMetadata(BaseModel):
         default=None, description="Resolution label (e.g. '1080p', '4k')."
     )
 
+    # NOTE: frame_rate/bitrate constraints are enforced by field_validator below
+    # rather than Field(...) so they can be relaxed for tolerant manifest loads
+    # (context={"tolerant_load": True}) — see _tolerant_load() and the Asset
+    # NOTE for the full rationale (#149).
+
+    @field_validator("frame_rate", mode="after")
+    @classmethod
+    def _validate_frame_rate(cls, value: float | None, info: ValidationInfo) -> float | None:
+        if not _is_finite_nonnegative(value) and not _tolerant_load(info):
+            raise ValueError(f"frame_rate must be a finite value >= 0, got {value}")
+        return value
+
+    @field_validator("bitrate", mode="after")
+    @classmethod
+    def _validate_bitrate(cls, value: int | None, info: ValidationInfo) -> int | None:
+        if not _is_positive(value) and not _tolerant_load(info):
+            raise ValueError(f"bitrate must be greater than 0, got {value}")
+        return value
+
 
 class AudioMetadata(BaseModel):
     """Technical metadata for audio assets (sample rate, codec, etc.)."""
 
-    sample_rate: int | None = Field(
-        default=None, gt=0, description="Sample rate in Hz (e.g. 44100)."
-    )
+    sample_rate: int | None = Field(default=None, description="Sample rate in Hz (e.g. 44100).")
     channels: int | None = Field(
-        default=None, gt=0, description="Number of channels (1=mono, 2=stereo)."
+        default=None, description="Number of channels (1=mono, 2=stereo)."
     )
     codec: str | None = Field(default=None, description="Audio codec (e.g. 'mp3', 'aac', 'pcm').")
-    bitrate: int | None = Field(default=None, gt=0, description="Bitrate in bits per second.")
+    bitrate: int | None = Field(default=None, description="Bitrate in bits per second.")
     word_timings: list[WordTiming] | None = Field(
         default=None, description="Word-level timing data [{word, start, end}, ...]."
     )
+
+    # NOTE: sample_rate/channels/bitrate constraints are enforced by
+    # field_validator below rather than Field(...) — see VideoMetadata NOTE
+    # above and the Asset NOTE for the tolerant-load rationale (#149).
 
     @model_validator(mode="before")
     @classmethod
@@ -86,6 +130,27 @@ class AudioMetadata(BaseModel):
                     item if isinstance(item, WordTiming) else WordTiming(**item) for item in wt
                 ]
         return data
+
+    @field_validator("sample_rate", mode="after")
+    @classmethod
+    def _validate_sample_rate(cls, value: int | None, info: ValidationInfo) -> int | None:
+        if not _is_positive(value) and not _tolerant_load(info):
+            raise ValueError(f"sample_rate must be greater than 0, got {value}")
+        return value
+
+    @field_validator("channels", mode="after")
+    @classmethod
+    def _validate_channels(cls, value: int | None, info: ValidationInfo) -> int | None:
+        if not _is_positive(value) and not _tolerant_load(info):
+            raise ValueError(f"channels must be greater than 0, got {value}")
+        return value
+
+    @field_validator("bitrate", mode="after")
+    @classmethod
+    def _validate_bitrate(cls, value: int | None, info: ValidationInfo) -> int | None:
+        if not _is_positive(value) and not _tolerant_load(info):
+            raise ValueError(f"bitrate must be greater than 0, got {value}")
+        return value
 
 
 class Track(BaseModel):
@@ -115,11 +180,9 @@ class Asset(BaseModel):
     media_type: str = Field(description="MIME type (e.g. 'image/png').")
     sha256: str | None = Field(default=None, description="SHA-256 hash of asset content.")
     size_bytes: int | None = Field(default=None, ge=0, description="File size in bytes.")
-    width: int | None = Field(default=None, gt=0, description="Image/video width in pixels.")
-    height: int | None = Field(default=None, gt=0, description="Image/video height in pixels.")
-    duration: float | None = Field(
-        default=None, ge=0, allow_inf_nan=False, description="Audio/video duration in seconds."
-    )
+    width: int | None = Field(default=None, description="Image/video width in pixels.")
+    height: int | None = Field(default=None, description="Image/video height in pixels.")
+    duration: float | None = Field(default=None, description="Audio/video duration in seconds.")
     video: VideoMetadata | None = Field(
         default=None, description="Video-specific technical metadata."
     )
@@ -140,11 +203,35 @@ class Asset(BaseModel):
     # ManifestVerification, which already make a malformed sha256 fail
     # manifest.verify() (confirmed: it no longer returns True as #78 originally
     # reported — that was fixed by #100's verification hardening).
+    #
+    # width/height/duration/media_type (and VideoMetadata.frame_rate/bitrate,
+    # AudioMetadata.sample_rate/channels/bitrate) follow the same pattern as of
+    # #149: constraints still reject impossible values on ordinary construction
+    # (e.g. width=0), but parse_manifest() validates with
+    # context={"tolerant_load": True} so an older/foreign manifest carrying
+    # such values (a common "unknown dimensions" placeholder, or a
+    # nonstandard media_type) still loads instead of raising ValidationError.
+    # is_valid_asset_metadata() + Manifest.verification_report() is the
+    # verification boundary that surfaces the problem on loaded data.
 
-    @field_validator("media_type")
+    @field_validator("width", "height", mode="after")
     @classmethod
-    def _validate_media_type(cls, value: str) -> str:
-        if not _MEDIA_TYPE_RE.match(value):
+    def _validate_dimension(cls, value: int | None, info: ValidationInfo) -> int | None:
+        if not _is_positive(value) and not _tolerant_load(info):
+            raise ValueError(f"{info.field_name} must be greater than 0, got {value}")
+        return value
+
+    @field_validator("duration", mode="after")
+    @classmethod
+    def _validate_duration(cls, value: float | None, info: ValidationInfo) -> float | None:
+        if not _is_finite_nonnegative(value) and not _tolerant_load(info):
+            raise ValueError(f"duration must be a finite value >= 0, got {value}")
+        return value
+
+    @field_validator("media_type", mode="after")
+    @classmethod
+    def _validate_media_type(cls, value: str, info: ValidationInfo) -> str:
+        if not _MEDIA_TYPE_RE.match(value) and not _tolerant_load(info):
             raise ValueError(f"media_type must look like 'type/subtype', got {value!r}")
         return value
 
@@ -155,3 +242,32 @@ class Asset(BaseModel):
 
     def __repr__(self) -> str:
         return f"Asset(id={self.asset_id[:8]}..., url={self.url!r}, type={self.media_type})"
+
+
+def is_valid_asset_metadata(asset: Asset) -> bool:
+    """Return True when an asset's numeric/media_type fields satisfy the
+    construction-time invariants (see the field_validators above).
+
+    A manifest loaded via ``parse_manifest()`` tolerates violations (e.g.
+    ``width=0``, ``media_type='unknown'``) so the file still parses; this is
+    the verification-boundary check that surfaces them, mirroring
+    ``is_valid_sha256()`` (#149). Used by
+    ``Manifest.verification_report()``/``Manifest.verify()``.
+    """
+    if not _is_positive(asset.width) or not _is_positive(asset.height):
+        return False
+    if not _is_finite_nonnegative(asset.duration):
+        return False
+    if not _MEDIA_TYPE_RE.match(asset.media_type):
+        return False
+    if asset.video is not None and (
+        not _is_finite_nonnegative(asset.video.frame_rate) or not _is_positive(asset.video.bitrate)
+    ):
+        return False
+    if asset.audio is not None and (
+        not _is_positive(asset.audio.sample_rate)
+        or not _is_positive(asset.audio.channels)
+        or not _is_positive(asset.audio.bitrate)
+    ):
+        return False
+    return True

--- a/libs/core/genblaze_core/models/manifest.py
+++ b/libs/core/genblaze_core/models/manifest.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from genblaze_core._asset_url import strip_asset_url_credentials
 from genblaze_core.canonical.json import canonical_hash, canonical_json
 from genblaze_core.exceptions import ManifestError, UnsupportedSchemaVersionError
-from genblaze_core.models.asset import Asset, is_valid_sha256
+from genblaze_core.models.asset import Asset, is_valid_asset_metadata, is_valid_sha256
 from genblaze_core.models.enums import PromptVisibility
 from genblaze_core.models.run import Run
 
@@ -168,6 +168,21 @@ def _unhashed_output_asset_ids(run: Run) -> list[str]:
     ]
 
 
+def _invalid_metadata_output_asset_ids(run: Run) -> list[str]:
+    """Return output asset IDs whose numeric/media_type metadata is out of spec.
+
+    parse_manifest() tolerates such values on load (see the Asset NOTE in
+    asset.py, #149) so this is the verification-boundary check that surfaces
+    them — mirroring _unhashed_output_asset_ids() for sha256.
+    """
+    return [
+        asset.asset_id
+        for step in run.steps
+        for asset in step.assets
+        if not is_valid_asset_metadata(asset)
+    ]
+
+
 def _hash_payload(schema_version: str, run: Run) -> dict:
     """Build the hash payload with operational fields stripped.
 
@@ -203,19 +218,22 @@ class ManifestVerification:
     """Structured manifest verification result used by CLI and API callers.
 
     ``unverified_sha256_ids`` contains output asset IDs whose ``sha256`` value
-    is missing or malformed. It is populated from the manifest payload
-    regardless of ``hash_ok``. Callers must still treat ``hash_ok=False`` as a
-    failed integrity check; the unverified-sha list is diagnostic context, not
-    proof that a tampered payload is otherwise trustworthy.
+    is missing or malformed. ``invalid_metadata_ids`` contains output asset
+    IDs whose numeric/``media_type`` fields are out of spec (#149) — e.g.
+    ``width=0`` or a non-MIME-shaped ``media_type``. Both are populated from
+    the manifest payload regardless of ``hash_ok``. Callers must still treat
+    ``hash_ok=False`` as a failed integrity check; these lists are diagnostic
+    context, not proof that a tampered payload is otherwise trustworthy.
     """
 
     hash_ok: bool
     unverified_sha256_ids: tuple[str, ...]
+    invalid_metadata_ids: tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
-        """True when hash verification passes and all outputs have valid sha256."""
-        return self.hash_ok and not self.unverified_sha256_ids
+        """True when the hash verifies and every output has valid sha256 + metadata."""
+        return self.hash_ok and not self.unverified_sha256_ids and not self.invalid_metadata_ids
 
 
 class Manifest(BaseModel):
@@ -289,16 +307,20 @@ class Manifest(BaseModel):
         return canonical_json(self.model_dump(mode="python"))
 
     def verify(self) -> bool:
-        """Verify the manifest hash and declared output asset sha256 coverage.
+        """Verify the manifest hash and declared output asset integrity.
 
         Behavior note for 0.3.4: this exported method is stricter than the
         pre-0.3.4 hash-only contract. Use ``verify_hash()`` for legacy
         hash-only checks, or ``verification_report()`` when callers need to
-        distinguish a hash mismatch from outputs missing ``sha256``.
+        distinguish a hash mismatch from outputs missing ``sha256`` or
+        carrying out-of-spec metadata.
 
         This method verifies that each output declares a 64-character
-        lowercase hex ``sha256``. It does not fetch ``asset.url`` or re-hash
-        remote bytes.
+        lowercase hex ``sha256`` and that numeric/``media_type`` fields
+        (``width``, ``height``, ``duration``, ...) satisfy the same
+        invariants enforced on construction (#149) — values a tolerantly
+        loaded manifest (``parse_manifest()``) may carry but never generates
+        itself. It does not fetch ``asset.url`` or re-hash remote bytes.
         """
         return self.verification_report().ok
 
@@ -311,13 +333,19 @@ class Manifest(BaseModel):
         """Return output asset IDs missing or carrying malformed sha256."""
         return _unhashed_output_asset_ids(self.run)
 
+    def output_asset_ids_with_invalid_metadata(self) -> list[str]:
+        """Return output asset IDs with out-of-spec numeric/media_type metadata (#149)."""
+        return _invalid_metadata_output_asset_ids(self.run)
+
     def verification_report(self) -> ManifestVerification:
-        """Return the shared hash-plus-output-sha256 verification result."""
+        """Return the shared hash-plus-output-integrity verification result."""
         hash_ok = self.verify_hash()
         unverified_sha256_ids = tuple(self.output_asset_ids_missing_sha256())
+        invalid_metadata_ids = tuple(self.output_asset_ids_with_invalid_metadata())
         return ManifestVerification(
             hash_ok=hash_ok,
             unverified_sha256_ids=unverified_sha256_ids,
+            invalid_metadata_ids=invalid_metadata_ids,
         )
 
     def to_embed_json(self, policy: EmbedPolicy) -> str:
@@ -468,7 +496,10 @@ def parse_manifest(data: dict) -> Manifest:
     elif version == "1.4":
         data = _migrate_v1_4_to_v1_5(data)
 
-    manifest = Manifest.model_validate(data)
+    # tolerant_load relaxes Asset numeric/media_type constraints (#149) so an
+    # older/foreign manifest still parses; Manifest.verify() is the
+    # enforcement boundary for values that violate them (see asset.py NOTE).
+    manifest = Manifest.model_validate(data, context={"tolerant_load": True})
 
     # Validate encrypted prompt constraint
     for step in manifest.run.steps:

--- a/libs/core/genblaze_core/sinks/parquet.py
+++ b/libs/core/genblaze_core/sinks/parquet.py
@@ -6,6 +6,7 @@ Requires the ``parquet`` extra: ``pip install "genblaze-core[parquet]"``
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import threading
 from pathlib import Path
@@ -103,15 +104,37 @@ class ParquetSink(BaseSink):
         #150). The index directory's mere existence marks this done, so a
         brand-new or already-bootstrapped ``base_dir`` costs a single
         directory stat and never pays for a full-tree glob again.
+
+        Built in a temp directory and atomically renamed into place only
+        once fully populated: writing entries directly into
+        ``self._index_dir`` would create that directory as a side effect of
+        the *first* entry, before the backfill loop finishes, so a crash
+        mid-backfill would leave a partially-populated directory that a
+        later ``ParquetSink`` would mistake for "already bootstrapped" and
+        trust as complete — silently losing index entries for pre-existing
+        run_ids and reintroducing #72 for them.
         """
         if self._index_dir.exists():
             return
         runs_dir = self.base_dir / "runs"
-        if runs_dir.exists():
-            for sentinel in runs_dir.glob("**/*.parquet"):
-                partition = sentinel.relative_to(runs_dir).parent.as_posix()
-                self._write_run_index_entry(sentinel.stem, partition)
-        self._index_dir.mkdir(parents=True, exist_ok=True)
+        if not runs_dir.exists():
+            # No data to backfill — nothing can be partially done, so no
+            # atomicity concern; just mark bootstrap complete.
+            self._index_dir.mkdir(parents=True, exist_ok=True)
+            return
+        tmp_dir = Path(tempfile.mkdtemp(dir=self.base_dir, prefix=f"{_INDEX_DIRNAME}.tmp-"))
+        for sentinel in runs_dir.glob("**/*.parquet"):
+            partition = sentinel.relative_to(runs_dir).parent.as_posix()
+            _atomic_write_bytes(partition.encode("utf-8"), tmp_dir / f"{sentinel.stem}.partition")
+        try:
+            os.replace(tmp_dir, self._index_dir)
+        except OSError:
+            # Lost a race with another ParquetSink instance that finished
+            # bootstrapping first (self._index_dir now exists and is
+            # non-empty, which os.replace refuses to clobber) — its result
+            # is equally valid since both are derived from the same runs/
+            # tree, so just discard our redundant copy.
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
     def _run_index_entry_path(self, run_id: str) -> Path:
         return self._index_dir / f"{run_id}.partition"
@@ -188,6 +211,12 @@ class ParquetSink(BaseSink):
             # dropped the new steps/assets (#152). Only a genuine repeat
             # (identical content) short-circuits here.
             if self._existing_canonical_hash(runs_path) == manifest.canonical_hash:
+                # Refresh (not just trust) the index entry before returning:
+                # if an earlier write crashed between writing this sentinel
+                # and persisting its index entry, this confirmed-correct
+                # no-op is the first opportunity to self-heal it, rather than
+                # only a future full rewrite doing so.
+                self._write_run_index_entry(run.run_id, partition)
                 return
         else:
             # New sentinel path for this run_id. The partition is derived
@@ -297,12 +326,17 @@ class ParquetSink(BaseSink):
 
         # Record the partition this run_id now lives at *after* the sentinel
         # write succeeds, so the index only ever reflects confirmed on-disk
-        # state. As with the stale-partition cleanup above, this is not a
-        # cross-file transaction: a crash between the sentinel write and this
-        # persist leaves this run_id's index entry stale (pointing at the
-        # *previous* partition) — the same accepted trade-off already
-        # documented for the sentinel-cleanup step, and just as narrow: the
-        # run's own data is fully and correctly sunk either way.
+        # state. This is not a cross-file transaction: a crash right here
+        # leaves this run_id's index entry stale (pointing at the *previous*
+        # partition) — the run's own data is fully and correctly sunk either
+        # way, and the very next write_run() call for this run_id self-heals
+        # the entry (the no-op branch above refreshes it too, not just this
+        # one). The one residual gap — this crash immediately followed by a
+        # *second* partition move before any intervening call — could still
+        # leave the first move's files un-cleaned; narrow enough, and in the
+        # same spirit as the accepted first-write-completion-sentinel
+        # trade-off, that we accept it rather than adding cross-file
+        # transactions here.
         self._write_run_index_entry(run.run_id, partition)
 
     def close(self) -> None:

--- a/libs/core/genblaze_core/sinks/parquet.py
+++ b/libs/core/genblaze_core/sinks/parquet.py
@@ -127,6 +127,18 @@ class ParquetSink(BaseSink):
         """Persist run_id -> partition as its own small file (see _INDEX_DIRNAME)."""
         _atomic_write_bytes(partition.encode("utf-8"), self._run_index_entry_path(run_id))
 
+    def _existing_canonical_hash(self, runs_path: Path) -> str | None:
+        """Return the canonical_hash already sunk at runs_path, or None if
+        unreadable — treated as "unknown" so callers rewrite rather than
+        silently trust a corrupt sentinel."""
+        try:
+            table = pq.read_table(runs_path, columns=["canonical_hash"])
+        except Exception:
+            return None
+        if table.num_rows == 0:
+            return None
+        return table.column("canonical_hash")[0].as_py()
+
     def _remove_partition_files(self, run_id: str, partition: str) -> None:
         """Remove a stale run's steps/assets/runs files under `partition`.
 
@@ -165,29 +177,32 @@ class ParquetSink(BaseSink):
         partition = self._partition_path(run)
 
         # Idempotency: runs table is written last as a completion sentinel.
-        # Fast path first: an exact-path match (unchanged content, including
-        # every ordinary first-time write) is a pure no-op re-write and the
-        # overwhelmingly common case, so check it with a single stat() before
-        # paying for anything more expensive.
+        # Fast path first: an exact-path match at the *current* partition.
         runs_path = self.base_dir / "runs" / partition / f"{run.run_id}.parquet"
         if runs_path.exists():
-            return
-
-        # The partition is derived from run *content* (step modality/provider
-        # set), which can change between sinks of the same run_id — e.g. a
-        # resume that completes more steps, or a CLI replay re-indexing a
-        # richer manifest. The fast-path check above only covers the current
-        # partition, so it misses a sentinel written earlier under a
-        # *different* partition, letting a second `runs` row and duplicate
-        # `steps`/`assets` rows accumulate for one run_id (#72). Only pay for
-        # a lookup once the fast path misses (new run_id or a moved
-        # partition): find any prior sentinel via the persisted run_id ->
-        # partition index instead of globbing the whole tree on every write
-        # (#150) — a genuinely new run_id has no index entry and costs a
-        # single file stat.
-        stale_partition = self._lookup_run_partition(run.run_id)
-        if stale_partition is not None and stale_partition != partition:
-            self._remove_partition_files(run.run_id, stale_partition)
+            # Same partition as the last sink of this run_id. Compare content
+            # via canonical_hash (already stored in the runs row) rather than
+            # assuming unchanged: a resume that completes more steps keeps the
+            # same modality/provider set (same partition) but changes the
+            # run's content, and previously this was a silent no-op that
+            # dropped the new steps/assets (#152). Only a genuine repeat
+            # (identical content) short-circuits here.
+            if self._existing_canonical_hash(runs_path) == manifest.canonical_hash:
+                return
+        else:
+            # New sentinel path for this run_id. The partition is derived
+            # from run *content* (step modality/provider set), which can
+            # change between sinks of the same run_id — e.g. a resume that
+            # adds a new modality, or a CLI replay re-indexing a richer
+            # manifest — so a prior sentinel may exist under a *different*
+            # partition, and leaving it would accumulate a second `runs` row
+            # plus duplicate `steps`/`assets` rows for one run_id (#72).
+            # Look it up in the persisted run_id -> partition index instead
+            # of globbing the whole tree on every write (#150): a genuinely
+            # new run_id has no index entry and costs a single file stat.
+            stale_partition = self._lookup_run_partition(run.run_id)
+            if stale_partition is not None and stale_partition != partition:
+                self._remove_partition_files(run.run_id, stale_partition)
 
         # --- steps table (written before runs) ---
         step_rows = []

--- a/libs/core/genblaze_core/sinks/parquet.py
+++ b/libs/core/genblaze_core/sinks/parquet.py
@@ -35,6 +35,14 @@ from genblaze_core.sinks.base import BaseSink
 # Only allow safe characters in partition path components
 _SAFE_PARTITION = re.compile(r"[^A-Za-z0-9_\-.]")
 
+# run_id -> partition index, one small file per run_id under this directory
+# (a sibling of runs/steps/assets, not inside them, so Hive-style dataset
+# readers scanning those trees never see it). Sharding by run_id — rather
+# than one shared index file — means concurrent writers sinking *different*
+# run_ids into the same base_dir (e.g. parallel `genblaze index` invocations)
+# never race on the same file (#150).
+_INDEX_DIRNAME = "_run_index"
+
 
 def _atomic_write_table(table: pa.Table, dest: Path) -> None:
     """Write a Parquet table atomically via temp file + os.replace."""
@@ -43,6 +51,22 @@ def _atomic_write_table(table: pa.Table, dest: Path) -> None:
     os.close(fd)
     try:
         pq.write_table(table, tmp)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_bytes(data: bytes, dest: Path) -> None:
+    """Write bytes atomically via temp file + os.replace (mirrors _atomic_write_table)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
         os.replace(tmp, dest)
     except BaseException:
         try:
@@ -66,10 +90,55 @@ class ParquetSink(BaseSink):
         self.base_dir.mkdir(parents=True, exist_ok=True)
         self._policy = policy
         self._lock = threading.Lock()
+        self._index_dir = self.base_dir / _INDEX_DIRNAME
+        self._bootstrap_run_index()
 
     def _sanitize(self, value: str) -> str:
         """Sanitize a string for use in partition paths (prevent traversal)."""
         return _SAFE_PARTITION.sub("_", value)
+
+    def _bootstrap_run_index(self) -> None:
+        """One-time backfill of the run_id -> partition index from an
+        existing ``runs/`` tree (e.g. the first use after upgrading past
+        #150). The index directory's mere existence marks this done, so a
+        brand-new or already-bootstrapped ``base_dir`` costs a single
+        directory stat and never pays for a full-tree glob again.
+        """
+        if self._index_dir.exists():
+            return
+        runs_dir = self.base_dir / "runs"
+        if runs_dir.exists():
+            for sentinel in runs_dir.glob("**/*.parquet"):
+                partition = sentinel.relative_to(runs_dir).parent.as_posix()
+                self._write_run_index_entry(sentinel.stem, partition)
+        self._index_dir.mkdir(parents=True, exist_ok=True)
+
+    def _run_index_entry_path(self, run_id: str) -> Path:
+        return self._index_dir / f"{run_id}.partition"
+
+    def _lookup_run_partition(self, run_id: str) -> str | None:
+        """Return the partition this run_id was last sunk under, or None if unknown."""
+        try:
+            return self._run_index_entry_path(run_id).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+    def _write_run_index_entry(self, run_id: str, partition: str) -> None:
+        """Persist run_id -> partition as its own small file (see _INDEX_DIRNAME)."""
+        _atomic_write_bytes(partition.encode("utf-8"), self._run_index_entry_path(run_id))
+
+    def _remove_partition_files(self, run_id: str, partition: str) -> None:
+        """Remove a stale run's steps/assets/runs files under `partition`.
+
+        Steps/assets removed before runs (mirroring "runs is written last" on
+        the write side) so an interrupted cleanup is safely retryable: if a
+        crash lands mid-cleanup, the stale runs sentinel is still present, a
+        retry's probe finds it again, and the whole stale partition is
+        cleaned from scratch — never leaving orphaned steps/assets with no
+        sentinel pointing at them.
+        """
+        for table in ("steps", "assets", "runs"):
+            (self.base_dir / table / partition / f"{run_id}.parquet").unlink(missing_ok=True)
 
     def _partition_path(self, run: Run) -> str:
         date_str = run.created_at.strftime("%Y-%m-%d")
@@ -111,26 +180,14 @@ class ParquetSink(BaseSink):
         # partition, so it misses a sentinel written earlier under a
         # *different* partition, letting a second `runs` row and duplicate
         # `steps`/`assets` rows accumulate for one run_id (#72). Only pay for
-        # a full-tree probe once the fast path misses (new run_id or a moved
-        # partition): find any prior sentinel and remove its partition's
-        # files first — the run_id, not the partition, is the identity, and
-        # the freshest write should win.
-        # Materialize before deleting — mutating the tree mid-walk while a
-        # generator is still traversing it is unsafe.
-        stale_sentinels = list((self.base_dir / "runs").glob(f"**/{run.run_id}.parquet"))
-        for stale_runs_path in stale_sentinels:
-            stale_partition = stale_runs_path.relative_to(self.base_dir / "runs").parent
-            # Delete steps/assets before the runs sentinel itself (mirroring
-            # "runs is written last" on the write side) so an interrupted
-            # cleanup is safely retryable: if a crash lands mid-cleanup, the
-            # stale runs sentinel is still present, a retry's probe finds it
-            # again, and the whole stale partition is cleaned from scratch —
-            # never leaving orphaned steps/assets with no sentinel pointing
-            # at them.
-            for table in ("steps", "assets", "runs"):
-                (self.base_dir / table / stale_partition / f"{run.run_id}.parquet").unlink(
-                    missing_ok=True
-                )
+        # a lookup once the fast path misses (new run_id or a moved
+        # partition): find any prior sentinel via the persisted run_id ->
+        # partition index instead of globbing the whole tree on every write
+        # (#150) — a genuinely new run_id has no index entry and costs a
+        # single file stat.
+        stale_partition = self._lookup_run_partition(run.run_id)
+        if stale_partition is not None and stale_partition != partition:
+            self._remove_partition_files(run.run_id, stale_partition)
 
         # --- steps table (written before runs) ---
         step_rows = []
@@ -222,6 +279,16 @@ class ParquetSink(BaseSink):
             "created_at": run.created_at.isoformat(),
         }
         _atomic_write_table(pa.Table.from_pylist([run_row]), runs_path)
+
+        # Record the partition this run_id now lives at *after* the sentinel
+        # write succeeds, so the index only ever reflects confirmed on-disk
+        # state. As with the stale-partition cleanup above, this is not a
+        # cross-file transaction: a crash between the sentinel write and this
+        # persist leaves this run_id's index entry stale (pointing at the
+        # *previous* partition) — the same accepted trade-off already
+        # documented for the sentinel-cleanup step, and just as narrow: the
+        # run's own data is fully and correctly sunk either way.
+        self._write_run_index_entry(run.run_id, partition)
 
     def close(self) -> None:
         pass

--- a/libs/core/tests/unit/test_models.py
+++ b/libs/core/tests/unit/test_models.py
@@ -394,6 +394,43 @@ def test_parse_manifest_tolerates_malformed_sha256_but_verify_rejects():
     assert not parsed.verify()
 
 
+def test_parse_manifest_tolerates_impossible_asset_metadata_but_verify_rejects():
+    """#149: an older/foreign manifest with width=0 (a common "unknown
+    dimensions" placeholder) or a nonstandard media_type must still load via
+    parse_manifest() instead of raising ValidationError. verify() is the
+    enforcement boundary — mirroring the sha256 tolerance pattern.
+    """
+    # Build the "foreign" asset via the same tolerant path parse_manifest()
+    # uses (Asset(...) construction still rejects these values by design).
+    asset = Asset.model_validate(
+        {
+            "url": "https://cdn.example.com/output.png",
+            "media_type": "unknown",
+            "sha256": "a" * 64,
+            "width": 0,
+            "height": 0,
+        },
+        context={"tolerant_load": True},
+    )
+    step = Step(
+        provider="mock",
+        model="m",
+        prompt="same prompt",
+        status=StepStatus.SUCCEEDED,
+        assets=[asset],
+    )
+    manifest = Manifest(run=Run(name="same", steps=[step]))
+    manifest.compute_hash()
+
+    parsed = parse_manifest(manifest.model_dump(mode="python"))
+
+    assert parsed.run.steps[0].assets[0].width == 0
+    assert parsed.run.steps[0].assets[0].media_type == "unknown"
+    assert parsed.verify_hash()
+    assert parsed.output_asset_ids_with_invalid_metadata() == [asset.asset_id]
+    assert not parsed.verify()
+
+
 @pytest.mark.parametrize("schema_version", ["0", "1.7", "2.0", "1.x"])
 def test_manifest_unsupported_schema_version_is_rejected(schema_version):
     step = Step(provider="mock", model="m", prompt="same prompt")

--- a/libs/core/tests/unit/test_parquet.py
+++ b/libs/core/tests/unit/test_parquet.py
@@ -184,6 +184,44 @@ def test_new_run_write_does_not_scan_unrelated_partitions(tmp_path: Path, monkey
     assert glob_calls == []
 
 
+def test_resume_same_partition_content_change_is_written(tmp_path: Path):
+    """A resume that completes more steps within the same modality/provider
+    set (partition unchanged) must not be a silent no-op — the newly
+    completed steps/assets must be persisted, not dropped (#152)."""
+    step1 = Step(provider="replicate", model="m", modality=Modality.IMAGE)
+    step1.assets.append(Asset(url="https://example.com/out1.png", media_type="image/png"))
+    run = Run(steps=[step1])
+    manifest = Manifest(run=run)
+    manifest.compute_hash()
+
+    sink = ParquetSink(tmp_path / "out")
+    sink.write_run(run, manifest)
+
+    # Resume: same provider/modality, so the content-derived partition is
+    # unchanged, but a second step (and asset) is now complete.
+    step2 = Step(provider="replicate", model="m", modality=Modality.IMAGE)
+    step2.assets.append(Asset(url="https://example.com/out2.png", media_type="image/png"))
+    run.steps.append(step2)
+    manifest2 = Manifest(run=run)
+    manifest2.compute_hash()
+    sink.write_run(run, manifest2)
+
+    runs_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
+    steps_files = list((tmp_path / "out" / "steps").rglob("*.parquet"))
+    assets_files = list((tmp_path / "out" / "assets").rglob("*.parquet"))
+
+    # Same partition throughout — a single sentinel, updated in place.
+    assert len(runs_files) == 1
+    run_table = pq.ParquetFile(runs_files[0]).read()
+    assert run_table.column("step_count")[0].as_py() == 2
+    assert run_table.column("canonical_hash")[0].as_py() == manifest2.canonical_hash
+
+    assert len(steps_files) == 1
+    assert pq.ParquetFile(steps_files[0]).read().num_rows == 2
+    assert len(assets_files) == 1
+    assert pq.ParquetFile(assets_files[0]).read().num_rows == 2
+
+
 def test_write_run_applies_embed_policy_redaction(tmp_path: Path):
     """ParquetSink redacts prompt, params, and seed when policy requires it."""
     step = Step(

--- a/libs/core/tests/unit/test_parquet.py
+++ b/libs/core/tests/unit/test_parquet.py
@@ -151,6 +151,39 @@ def test_idempotent_write_when_content_changes_moves_partition(tmp_path: Path):
     assert pq.ParquetFile(assets_files[0]).read().num_rows == 2
 
 
+def test_new_run_write_does_not_scan_unrelated_partitions(tmp_path: Path, monkeypatch):
+    """A brand-new run_id must resolve via the run_id -> partition index (a
+    single file stat) rather than a full-tree glob over runs/, even once the
+    tree already holds many unrelated partitions (#150)."""
+    sink = ParquetSink(tmp_path / "out")
+
+    # Populate several unrelated partitions (distinct run_ids/tenants).
+    for i in range(5):
+        step = Step(provider="test", model="m")
+        run = Run(steps=[step], tenant_id=f"tenant-{i}")
+        manifest = Manifest(run=run)
+        manifest.compute_hash()
+        sink.write_run(run, manifest)
+
+    glob_calls: list[str] = []
+    original_glob = Path.glob
+
+    def spy_glob(self, pattern, *args, **kwargs):
+        glob_calls.append(pattern)
+        return original_glob(self, pattern, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "glob", spy_glob)
+
+    # A genuinely new run_id — must never trigger a full-tree glob.
+    new_step = Step(provider="test", model="m")
+    new_run = Run(steps=[new_step], tenant_id="tenant-new")
+    new_manifest = Manifest(run=new_run)
+    new_manifest.compute_hash()
+    sink.write_run(new_run, new_manifest)
+
+    assert glob_calls == []
+
+
 def test_write_run_applies_embed_policy_redaction(tmp_path: Path):
     """ParquetSink redacts prompt, params, and seed when policy requires it."""
     step = Step(

--- a/libs/core/tests/unit/test_parquet.py
+++ b/libs/core/tests/unit/test_parquet.py
@@ -1,5 +1,6 @@
 """Tests for Parquet sink."""
 
+import shutil
 from pathlib import Path
 
 import pyarrow.parquet as pq
@@ -99,6 +100,31 @@ def test_idempotent_write(tmp_path: Path):
 
     parquet_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
     assert len(parquet_files) == 1
+
+
+def test_no_op_write_repairs_missing_index_entry(tmp_path: Path):
+    """If an earlier write crashed after writing the runs sentinel but
+    before persisting its run_id -> partition index entry, the entry is
+    missing even though the sentinel is correct. The next write_run() call
+    for that run_id -- even an identical-content no-op -- must repair it,
+    not just wait for a future full rewrite; otherwise a later moved-
+    partition write could look up the stale/missing entry and fail to clean
+    up the true prior partition, silently reintroducing #72."""
+    step = Step(provider="test", model="m")
+    run = Run(steps=[step])
+    manifest = Manifest(run=run)
+    manifest.compute_hash()
+
+    sink = ParquetSink(tmp_path / "out")
+    sink.write_run(run, manifest)
+
+    index_entry = tmp_path / "out" / "_run_index" / f"{run.run_id}.partition"
+    assert index_entry.exists()
+    index_entry.unlink()  # simulate the crash window: sentinel written, index entry lost
+
+    sink.write_run(run, manifest)  # identical content -- a no-op for the tables
+
+    assert index_entry.exists()
 
 
 def test_idempotent_write_when_content_changes_moves_partition(tmp_path: Path):
@@ -220,6 +246,42 @@ def test_resume_same_partition_content_change_is_written(tmp_path: Path):
     assert pq.ParquetFile(steps_files[0]).read().num_rows == 2
     assert len(assets_files) == 1
     assert pq.ParquetFile(assets_files[0]).read().num_rows == 2
+
+
+def test_fresh_sink_backfills_index_from_existing_runs_tree(tmp_path: Path):
+    """A runs/ tree that predates the run_id -> partition index (e.g. one
+    written by an older build, or with the index directory lost) is
+    backfilled once at construction, so a brand-new ParquetSink instance
+    (the CLI's `index` command creates one per invocation) can still detect
+    and clean up a moved partition without a full-tree glob (#150)."""
+    step1 = Step(provider="replicate", model="m", modality=Modality.IMAGE)
+    step1.assets.append(Asset(url="https://example.com/out.png", media_type="image/png"))
+    run = Run(steps=[step1])
+    manifest = Manifest(run=run)
+    manifest.compute_hash()
+
+    sink1 = ParquetSink(tmp_path / "out")
+    sink1.write_run(run, manifest)
+    # Simulate a runs/ tree that predates the index entirely.
+    shutil.rmtree(tmp_path / "out" / "_run_index")
+
+    # A brand-new instance must backfill the index from runs/ at construction.
+    sink2 = ParquetSink(tmp_path / "out")
+    assert (tmp_path / "out" / "_run_index" / f"{run.run_id}.partition").exists()
+
+    # Resume with a new modality/provider -> the partition moves. sink2 must
+    # find and remove the stale partition via the backfilled index.
+    step2 = Step(provider="elevenlabs", model="m2", modality=Modality.AUDIO)
+    step2.assets.append(Asset(url="https://example.com/out.mp3", media_type="audio/mp3"))
+    run.steps.append(step2)
+    manifest2 = Manifest(run=run)
+    manifest2.compute_hash()
+    sink2.write_run(run, manifest2)
+
+    runs_files = list((tmp_path / "out" / "runs").rglob("*.parquet"))
+    assert len(runs_files) == 1
+    run_table = pq.ParquetFile(runs_files[0]).read()
+    assert run_table.column("step_count")[0].as_py() == 2
 
 
 def test_write_run_applies_embed_policy_redaction(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes three pre-release correctness bugs found during review of the #138–#147 wave, before any of this behavior ships:

- **#149** — `Asset` numeric/`media_type` field constraints (added for #78) were enforced on the manifest **load** path, so an older or foreign-authored manifest carrying a previously-valid value (`width=0`, a non-MIME `media_type`, ...) raised `ValidationError` from `parse_manifest()`, breaking `verify`/`index`/`replay` on files that used to load fine.
- **#150** — `ParquetSink.write_run()` globbed the entire `runs/` tree on every write for a brand-new `run_id`, not just the idempotent-rewrite case the #72 fix targeted — an O(number of partitions) cost paid on every single write over a long-lived dataset.
- **#152** — The #72 idempotency fix still silently dropped a same-partition re-sink whose content changed (e.g. a resume that completes more steps without changing modality/provider, so the partition — and the fast-path check — is unchanged).

## Changes

- `libs/core/genblaze_core/models/asset.py` / `models/manifest.py` (#149): `Asset`/`VideoMetadata`/`AudioMetadata` numeric/`media_type` constraints moved from Pydantic `Field(...)` kwargs to `field_validator`s gated on `info.context["tolerant_load"]`. `parse_manifest()` now calls `Manifest.model_validate(data, context={"tolerant_load": True})`, so construction stays strict but loading a manifest tolerates out-of-spec values (mirroring the existing `sha256` pattern). `is_valid_asset_metadata()` + `Manifest.verify()`/`verification_report()` is the new enforcement boundary for loaded data, mirroring `is_valid_sha256()`.
- `libs/core/genblaze_core/sinks/parquet.py` (#150, #152): `write_run()` now maintains a persisted `run_id -> partition` index — one small file per `run_id` under `_run_index/` (sharded, not a shared JSON blob, so concurrent writers sinking different `run_id`s into the same output dir — e.g. parallel `genblaze index` invocations — never race on one file), consulted instead of a full-tree glob. An existing `runs/` tree without an index is backfilled once, atomically (temp dir + `os.replace`). The same-partition fast path now compares the existing sentinel's `canonical_hash` against the new manifest's instead of unconditionally no-op'ing, and refreshes the index entry even on that no-op path so a prior crash between a sentinel write and its index persist self-heals on the next call.
- Tests: `libs/core/tests/unit/test_models.py` (#149 tolerant-load + verify regression), `libs/core/tests/unit/test_parquet.py` (new-run write doesn't glob, same-partition content change is written, fresh-instance index backfill, no-op write repairs a missing index entry).
- Docs: `docs/features/manifest-provenance.md`, `docs/features/parquet-sink.md`, `CHANGELOG.md` `[Unreleased]` under `### genblaze-core`.

## Panel review

Three independent reviewers examined the branch diff before push, each with no knowledge of the others:

- **Correctness/issue-coverage** — confirmed all three issues are resolved end-to-end (traced the exact failure scenarios, confirmed all manifest-load call sites route through `parse_manifest()`, confirmed context propagation to nested `Asset` sub-models). Found a **P1**: `_bootstrap_run_index()`'s completion marker was non-atomic (directory created as a side effect of the first entry write, before the full backfill loop finished) — fixed by building the backfill in a temp directory and atomically `os.replace`-ing it into place.
- **Data integrity** — confirmed no `EmbedPolicy`/canonical-hash-determinism regressions, confirmed `Manifest.verify()` still rejects out-of-spec loaded data. Found a **P1**: the index entry was only persisted on the full-rewrite path, never on the same-partition no-op fast path, so a crash between a sentinel write and its index persist could permanently desync the index (reintroducing #72) — fixed by refreshing the index entry on the no-op path too.
- **Engineering quality** — confirmed the tolerant-load mechanism is the idiomatic Pydantic v2 pattern (not a parallel/duplicated validation path) and correctly scoped the sharded-index design against real concurrent-usage patterns (`cli/genblaze_cli/commands/index.py` creates one `ParquetSink` per invocation). Corrected an assumption in the original brief: `ParquetSink` already shipped in `0.1.0`, so the bootstrap-backfill path is a real migration necessity, not speculative — which raised the bar on the missing bootstrap test (also fixed).

Both P1s (independently corroborated: the bootstrap-atomicity gap was raised by two reviewers from different angles) were fixed and covered by new regression tests; `make lint`/full core test suite re-run clean afterward. Remaining P2s (minor validator-boilerplate dedup, `size_bytes` scope, flat index directory at scale) were accepted as documented, non-blocking follow-ups.

## Test plan

- [x] `cd libs/core && PYTHONPATH="$(pwd)" pytest tests/ -q` — 1932 passed, 8 skipped, 1 pre-existing failure (`test_pipeline_chain_integration.py::test_chain_pipeline_to_parquet_sink`, a local numpy/pyarrow ABI mismatch — confirmed identical on unmodified `origin/main`, not a regression)
- [x] `make lint` — clean
- [x] `mypy libs/core/genblaze_core/models/asset.py libs/core/genblaze_core/models/manifest.py libs/core/genblaze_core/sinks/parquet.py` — clean (the one pre-existing repo-wide mypy error in `media/aac.py` is unrelated and reproduces on `origin/main`)
- [x] `cd cli && PYTHONPATH=<worktree>/libs/core pytest tests/` — 9 pre-existing failures (Click `stderr` capture + same pyarrow ABI issue) confirmed identical on a clean `origin/main` checkout; no new CLI failures introduced (this PR does not touch `cli/`)

## Related

Closes #149
Closes #150
Closes #152