### PR TITLE
chore(release): bump versions and cut CHANGELOG v0.5.0 wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-16
+
+Correctness and security hardening across the pipeline, provenance, streaming,
+and media layers, plus connector fixes (Replicate community models, OpenAI Sora
+on the openai SDK 2.x, Google Veo on Vertex AI). Highlights: the ReDoS guard's
+heuristic now always runs, manifests load tolerantly while `verify()` stays the
+enforcement boundary, `ParquetSink` writes are index-backed and resink-correct,
+stream emitters are per-instance, and a batch of connector patch-republishes.
+
+### Released package versions
+
+- `genblaze` (umbrella) 0.4.1 → **0.4.3** — raises the `genblaze-core` floor to
+  0.3.6 and `genblaze-s3` to 0.3.5 (plus the gmicloud/google/openai/replicate
+  extra floors) so `pip install genblaze` resolves this wave's fixes.
+- `genblaze-core` 0.3.4 → **0.3.6** (ReDoS heuristic always runs; per-instance
+  stream emitters; `metadata`/`prompt_visibility` routed to `Step` fields;
+  `max_concurrency` validation; `PipelineTemplate` param rendering; tolerant
+  manifest load with `verify()` enforcement; `ParquetSink` run-index + resink
+  correctness; SSRF/ffmpeg/`canonical_hash` hardening; stable ingest hash;
+  order-preserving cache key; JPEG/WebP read cap; Windows `file://` fixes;
+  pytest-free mocks)
+- `genblaze-cli` 0.3.2 → **0.3.4** (rejects directory arguments; `replay.py`
+  Optional fixes; `verify` surfaces invalid output metadata; `extract -o`)
+- `genblaze-s3` 0.3.4 → **0.3.5** (widens the `aioboto3` pin to `<16`)
+- `genblaze-google` 0.3.1 → **0.3.2** (`VeoProvider` Vertex AI poll/fetch fix)
+- `genblaze-replicate` 0.3.2 → **0.3.3** (`submit()` endpoint routing for
+  community models)
+- `genblaze-openai` 0.3.1 → **0.3.2** (Sora SDK 2.x submit/download; Windows
+  `file://` in `dalle.py`)
+- `genblaze-gmicloud` 0.3.2 → **0.3.3** (ships the `py.typed` marker; video
+  `duration` validation)
+- All other connectors unchanged — their existing `genblaze-core>=0.3.4,<0.4`
+  floor already admits 0.3.6.
+
 ### genblaze-core
 
 - **Security** `pattern_safety.assert_safe()` no longer skips its
@@ -267,6 +301,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every fresh batch starts with and falls back to caller input order. The
   determinism contract now holds for fresh asset batches and sink-populated
   hashes, not just permuted reuses of already-hashed objects.
+- **Security** `PromptTemplate` now rejects attribute and item traversal such
+  as `{user.api_key}` and `{settings[voice]}`. Pass explicit top-level values
+  instead, for example `{api_key}` or `{voice}`. Top-level format specs and
+  conversions such as `{price:.2f}` and `{name!r}` remain supported (#88).
 
 ### genblaze-openai
 
@@ -326,6 +364,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as every other connector's marker — no `pyproject.toml` change needed,
   since hatchling already includes all files under the declared
   `[tool.hatch.build.targets.wheel] packages` directory.
+- **Changed** video `duration` now requires whole-second integer values from
+  1 to 60 seconds; fractional, zero/negative, and oversized inputs fail
+  invalid-input validation instead of being silently truncated or forwarded
+  (#90).
+
+### genblaze-s3
+
+- **Changed** widened the `aioboto3` pin in the `async` extra from `>=12,<13`
+  to `>=12,<16`, so `genblaze-s3` installs alongside newer `aioboto3` releases
+  (#128).
 
 ### genblaze-cli
 
@@ -360,22 +408,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze (umbrella)
 
-- **Changed** 0.4.1 → 0.4.2: raises its `genblaze-core` floor to 0.3.5
-  so `pip install genblaze` resolves the mock-import fix above.
-
-### Security
-
-- `genblaze-core`: `PromptTemplate` now rejects attribute and item traversal
-  such as `{user.api_key}` and `{settings[voice]}`. Pass explicit top-level
-  values instead, for example `{api_key}` or `{voice}`. Top-level format specs
-  and conversions such as `{price:.2f}` and `{name!r}` remain supported (#88).
-
-### Changed
-
-- `genblaze-gmicloud`: video `duration` now requires whole-second integer
-  values from 1 to 60 seconds; fractional, zero/negative, and oversized
-  inputs fail invalid-input validation instead of being silently truncated
-  or forwarded (#90).
+- **Changed** 0.4.1 → 0.4.3: raises its `genblaze-core` floor to 0.3.6 and
+  `genblaze-s3` floor to 0.3.5 (and the gmicloud/google/openai/replicate extra
+  floors to their new versions) so `pip install genblaze` resolves this wave's
+  fixes.
 
 ## [0.4.0] - 2026-06-25
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-cli"
-version = "0.3.3"
+version = "0.3.4"
 description = "CLI for genblaze manifest operations"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "cli", "command-line"]
 
 dependencies = [
-    "genblaze-core>=0.3.5,<0.4",
+    "genblaze-core>=0.3.6,<0.4",
     "click>=8.0",
 ]
 

--- a/libs/connectors/gmicloud/pyproject.toml
+++ b/libs/connectors/gmicloud/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-gmicloud"
-version = "0.3.2"
+version = "0.3.3"
 description = "GMICloud media provider adapters for genblaze (video, image, audio)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/google/pyproject.toml
+++ b/libs/connectors/google/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-google"
-version = "0.3.1"
+version = "0.3.2"
 description = "Google provider adapters for genblaze (Veo video, Imagen image)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/openai/pyproject.toml
+++ b/libs/connectors/openai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-openai"
-version = "0.3.1"
+version = "0.3.2"
 description = "OpenAI provider adapters for genblaze (Sora, DALL-E, TTS)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/replicate/pyproject.toml
+++ b/libs/connectors/replicate/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-replicate"
-version = "0.3.2"
+version = "0.3.3"
 description = "Replicate provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/s3/pyproject.toml
+++ b/libs/connectors/s3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-s3"
-version = "0.3.4"
+version = "0.3.5"
 description = "S3-compatible storage backend for genblaze (B2, R2, MinIO, AWS)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "Core SDK for genblaze media generation orchestration"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze"
-version = "0.4.2"
+version = "0.4.3"
 description = "Umbrella package for genblaze — installs genblaze-core + genblaze-s3 and re-exports the core API; use extras for provider bundles"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"
@@ -23,8 +23,8 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "umbrella"]
 
 dependencies = [
-    "genblaze-core>=0.3.5,<0.4",
-    "genblaze-s3>=0.3.4,<0.4",
+    "genblaze-core>=0.3.6,<0.4",
+    "genblaze-s3>=0.3.5,<0.4",
 ]
 
 [project.urls]
@@ -36,10 +36,10 @@ Issues = "https://github.com/backblaze-labs/genblaze/issues"
 
 [project.optional-dependencies]
 # Individual connectors
-gmicloud = ["genblaze-gmicloud>=0.3.2,<0.4"]
-openai = ["genblaze-openai>=0.3.1,<0.4"]
-google = ["genblaze-google>=0.3.1,<0.4"]
-replicate = ["genblaze-replicate>=0.3.2,<0.4"]
+gmicloud = ["genblaze-gmicloud>=0.3.3,<0.4"]
+openai = ["genblaze-openai>=0.3.2,<0.4"]
+google = ["genblaze-google>=0.3.2,<0.4"]
+replicate = ["genblaze-replicate>=0.3.3,<0.4"]
 runway = ["genblaze-runway>=0.3.1,<0.4"]
 luma = ["genblaze-luma>=0.3.1,<0.4"]
 decart = ["genblaze-decart>=0.3.1,<0.4"]
@@ -53,17 +53,17 @@ nvidia = ["genblaze-nvidia>=0.3.1,<0.4"]
 
 # Curated bundles
 video = [
-    "genblaze-gmicloud>=0.3.2,<0.4",
-    "genblaze-google>=0.3.1,<0.4",
+    "genblaze-gmicloud>=0.3.3,<0.4",
+    "genblaze-google>=0.3.2,<0.4",
     "genblaze-runway>=0.3.1,<0.4",
     "genblaze-luma>=0.3.1,<0.4",
     "genblaze-decart>=0.3.1,<0.4",
     "genblaze-nvidia>=0.3.1,<0.4",
 ]
 image = [
-    "genblaze-gmicloud>=0.3.2,<0.4",
-    "genblaze-openai>=0.3.1,<0.4",
-    "genblaze-google>=0.3.1,<0.4",
+    "genblaze-gmicloud>=0.3.3,<0.4",
+    "genblaze-openai>=0.3.2,<0.4",
+    "genblaze-google>=0.3.2,<0.4",
     "genblaze-nvidia>=0.3.1,<0.4",
 ]
 audio = [
@@ -71,14 +71,14 @@ audio = [
     "genblaze-lmnt>=0.3.1,<0.4",
     "genblaze-hume>=0.3.1,<0.4",
     "genblaze-stability-audio>=0.3.1,<0.4",
-    "genblaze-gmicloud>=0.3.2,<0.4",
+    "genblaze-gmicloud>=0.3.3,<0.4",
     "genblaze-nvidia>=0.3.1,<0.4",
 ]
 all = [
-    "genblaze-gmicloud>=0.3.2,<0.4",
-    "genblaze-openai>=0.3.1,<0.4",
-    "genblaze-google>=0.3.1,<0.4",
-    "genblaze-replicate>=0.3.2,<0.4",
+    "genblaze-gmicloud>=0.3.3,<0.4",
+    "genblaze-openai>=0.3.2,<0.4",
+    "genblaze-google>=0.3.2,<0.4",
+    "genblaze-replicate>=0.3.3,<0.4",
     "genblaze-runway>=0.3.1,<0.4",
     "genblaze-luma>=0.3.1,<0.4",
     "genblaze-decart>=0.3.1,<0.4",


### PR DESCRIPTION
## Release bookkeeping for **v0.5.0**

Pure bookkeeping — **no source or behavior changes**. Prepares the merged fix wave (#138–#156) to be tagged and published.

### Version bumps (8)
| Package | From (published) | → | Notes |
|---|---|---|---|
| `genblaze-core` | 0.3.5 | **0.3.6** | not 0.4.0 — reserved in-code for the `raise_on_failure` flip / `probe_model()` removal |
| `genblaze-cli` | 0.3.3 | **0.3.4** | |
| `genblaze-s3` | 0.3.4 | **0.3.5** | clears `pin-parity` (widened `aioboto3` pin from #128) |
| `genblaze-google` | 0.3.1 | **0.3.2** | |
| `genblaze-replicate` | 0.3.2 | **0.3.3** | |
| `genblaze-openai` | 0.3.1 | **0.3.2** | |
| `genblaze-gmicloud` | 0.3.2 | **0.3.3** | |
| `genblaze` (umbrella) | 0.4.2 | **0.4.3** | + floor bumps: core `>=0.3.6`, s3 `>=0.3.5`, gmicloud/google/openai/replicate extras |

Other connectors are untouched — their `genblaze-core>=0.3.4,<0.4` floor already admits 0.3.6, so they don't need republishing.

### CHANGELOG
- Folded two mis-sectioned entries into their package sections: PromptTemplate **#88** (was under a bare `### Security`) → `genblaze-core`; gmicloud duration **#90** (was under a bare `### Changed`) → `genblaze-gmicloud`.
- Added the missing `### genblaze-s3` entry for the widened `aioboto3` pin (**#128**).
- Updated the umbrella note and cut `[Unreleased]` → **`## [0.5.0] - 2026-07-16`** with a `Released package versions` list.

### Verification
- `[Unreleased]` is empty → `changelog-gate` passes.
- Top wave header is `## [0.5.0]` → `validate-version` will require tag **`v0.5.0`**.
- `ruff check` / `ruff format --check` clean.

### After merge (release steps — your call)
1. `make pre-release` in a full env (local `twine` was missing here).
2. `git tag -a v0.5.0 -m "Release 0.5.0"` && push the tag.
3. Create the GitHub Release on `v0.5.0` using the `[0.5.0]` CHANGELOG slice as the body — this fires `.github/workflows/release.yml`.

Refs #128 #88 #90
