### PR TITLE
fix(sink): trust backend-owned asset URLs instead of HeadObject under B2 403

### DIFF
--- a/libs/core/genblaze_core/storage/sink.py
+++ b/libs/core/genblaze_core/storage/sink.py
@@ -527,7 +527,15 @@ class ObjectStorageSink(BaseSink):
             return False
         if key is None:
             return False
-        return self._backend.exists(key)
+        # asset.url already points into this backend, so the bytes were
+        # stored here: transfer() only rewrites url to the durable URL after
+        # a successful put. Trust that directly instead of probing exists() —
+        # a B2 HeadObject 403 (daily Class B caps / restricted keys) makes
+        # exists() report "not-exist", which would re-schedule a transfer of
+        # the now-private durable URL over an unauthenticated GET (401) and
+        # fail an otherwise-complete run. There is also no source left to
+        # re-download from, so a re-transfer could never succeed. See #162.
+        return True
 
     def _effective_allow_unverified_assets(self, allow_unverified_assets: bool) -> bool:
         if (

--- a/libs/core/tests/unit/test_object_storage_sink.py
+++ b/libs/core/tests/unit/test_object_storage_sink.py
@@ -1961,3 +1961,86 @@ class TestBaseSinkPutAssetDefaults:
             sink.put_assets([asset])
         with pytest.raises(NotImplementedError, match="read_manifest_for_asset"):
             sink.read_manifest_for_asset("11111111-1111-4111-8111-111111111111", tenant_id="t")
+
+
+class _HeadForbiddenBackend(_AssetIndexBackend):
+    """Backend whose ``exists()`` always reports False, mimicking a B2
+    HeadObject 403.
+
+    Backblaze returns 403/AccessDenied for HEAD once a daily Class B
+    transaction cap is hit or when an app key can't HEAD, which
+    ``S3StorageBackend.exists()`` folds into "does not exist". This double
+    reports every ``exists()`` probe as a miss while still storing bytes,
+    so a sink that trusts ``exists()`` to detect an already-transferred
+    asset will re-schedule the transfer. Regression harness for #162.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.exists_calls = 0
+
+    def exists(self, key):
+        self.exists_calls += 1
+        return False
+
+
+class TestHeadObject403DoubleTransfer:
+    """#162: a HeadObject 403 must not trigger a destructive re-transfer.
+
+    Under B2 daily caps / restricted keys, ``exists()`` cannot tell absent
+    from forbidden. An asset whose ``url`` already points into the backend
+    has, by definition, been stored there (``transfer()`` only rewrites the
+    url after a successful put), so ``key_from_url`` resolving must be
+    trusted directly — re-downloading the now-private durable URL over an
+    unauthenticated GET can only 401 and fail the whole run.
+    """
+
+    def test_asset_already_transferred_trusts_backend_url_without_head(self):
+        """A backend-owned URL short-circuits to True, never probing exists()."""
+        backend = _HeadForbiddenBackend()
+        sink = ObjectStorageSink(backend, prefix="genmedia")
+        asset = Asset(
+            url="https://mem/genmedia/runs/r1/clip.mp4",
+            media_type="video/mp4",
+            sha256="a" * 64,
+            size_bytes=123,
+        )
+
+        assert sink._asset_already_transferred(asset) is True
+        assert backend.exists_calls == 0
+
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer._http_get_stream")
+    def test_ingest_flow_transfers_once_under_head_403(self, mock_get, _mock_dns):
+        """put_asset then write_run (the ingest order) transfers exactly once.
+
+        Pre-fix, write_run's ``exists()``-based re-derivation misses the
+        403-lying backend and re-downloads the rewritten durable URL — the
+        second ``_http_get_stream`` call. Post-fix there is only one."""
+        mock_resp = MagicMock()
+        mock_resp.read.side_effect = [b"clip-bytes", b""]
+        mock_resp.headers = {"Content-Type": "video/mp4"}
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        backend = _HeadForbiddenBackend()
+        sink = ObjectStorageSink(backend, prefix="genmedia")
+        asset = Asset(url="https://cdn.example.com/clip.mp4", media_type="video/mp4")
+        step = Step(
+            provider="test",
+            model="test-model",
+            status=StepStatus.SUCCEEDED,
+            assets=[asset],
+        )
+        run = Run(name="repro", status=RunStatus.COMPLETED, steps=[step])
+
+        # Mirror ingest_assets: bytes are written first, then the manifest.
+        sink.put_asset(asset)
+        manifest = Manifest(run=run)
+        manifest.compute_hash()
+        sink.write_run(run, manifest)  # must not raise / re-download
+
+        assert mock_get.call_count == 1
+        assert asset.url.startswith("https://mem/")
+        assert sink.manifest_key_for(run) in backend.store


### PR DESCRIPTION
## Summary

Fixes a HeadObject 403 on Backblaze B2 (daily Class B transaction caps, or restricted app keys) that triggered a destructive double-transfer in `ObjectStorageSink`, failing an already-complete run.

`_asset_already_transferred()` relied on `backend.exists()` to decide whether an asset's bytes were already stored. On B2, HeadObject returns 403 under caps/restricted keys, which `S3StorageBackend.exists()` folds into "not-exist". In the ingest flow, `put_asset()` uploads bytes and rewrites `asset.url` to the durable backend URL, then `write_run()` re-derives `remaining` via `_asset_already_transferred` → `exists()` → 403 → `False`. The asset is re-scheduled for transfer, but its URL now points into the **private** bucket, so the remote-GET path does an unauthenticated GET → 401 → `SinkError: 1/1 asset transfer(s) failed; manifest was not uploaded`. The bytes were already safely uploaded; only the manifest write was lost. Deterministic on B2 free tier once the daily cap trips mid-batch.

## Changes

- `libs/core/genblaze_core/storage/sink.py` — `_asset_already_transferred()` now returns `True` as soon as `key_from_url(asset.url)` resolves to a non-None key (a backend-owned URL), skipping the `exists()` probe. Per the transfer contract (`transfer.py:402`), `asset.url` is rewritten to the durable URL **only after a successful `put()`**, so a backend-owned URL implies the bytes are present by construction. Stateless — no per-run completion set (rejected for unbounded memory growth on long-lived sinks). CAS cross-run dedup is unaffected (it has its own `exists()` on the sha256 key in `transfer.py`); the `sha256`/`size_bytes` guards stay live.
- `libs/core/tests/unit/test_object_storage_sink.py` — new `TestHeadObject403DoubleTransfer`: a unit test (backend-owned URL short-circuits to `True`, `exists()` never called) and an integration test (`put_asset` → `write_run` against a 403-lying backend transfers exactly once and writes the manifest). Both fail on a clean tree, pass with the fix.

**Trade-off (accepted, red-teamed):** a backend-owned URL whose object was externally deleted now writes a stale manifest reference rather than raising. Not a lost-bytes regression — the pre-fix re-transfer could never recover it either (the source URL was already overwritten), so it only trades a loud unrecoverable error for a silent stale reference. No existence invariant breaks: manifest verification is hash-based, and neither `write_run` nor `read_manifest` asserts object existence.

## Test plan

- [ ] `make test` passes — **red only due to pre-existing #157**: 3 `test_pattern_safety.py::test_rejected_regardless_of_has_re2[re2-present-*]` failures (test-harness monkeypatches a `_re2` attribute that doesn't exist); they fail on clean `main` and are unrelated to this change. Everything else: `1946 passed`. Targeted `test_object_storage_sink.py` / `test_transfer.py` / `test_pipeline_ingest.py`: all green.
- [x] `make lint` passes
- [ ] Docs updated (if behavior changed) — no user-facing API/docs change (internal sink behavior); CHANGELOG is cut per release wave, not per PR.

## Related

Closes #162