### PR TITLE
feat(cli): add opt-in --fetch flag for byte-level asset verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### genblaze-cli
+
+- `genblaze verify --fetch` downloads each output asset and compares its bytes
+  against the manifest's committed `sha256` (with a `size_bytes` cross-check),
+  closing the gap where verification stopped at declared digests. Remote fetches
+  stream through the transfer layer's SSRF-validated, DNS-pinned path; presigned
+  query strings are redacted from output; `file://` assets resolve against the
+  same allowlist as the storage and ffmpeg paths, extensible via repeatable
+  `--allowed-root <dir>`. `--fetch` and `--hash-only` are mutually exclusive.
+  Default `verify` behavior and `Manifest.verify()` semantics are unchanged.
+
 ## [0.5.0] - 2026-07-16
 
 Correctness and security hardening across the pipeline, provenance, streaming,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-17 -->
+<!-- last_verified: 2026-07-21 -->
 <h1 align="center" style="border-bottom: none">
     Genblaze
 </h1>
@@ -18,7 +18,7 @@
 
 **Genblaze** is an AI pipeline SDK by [Backblaze](https://www.backblaze.com/cloud-storage?utm_source=github&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=genblaze) for building and orchestrating generative media workflows across video, image, and audio.
 
-A unified `Pipeline` API spans providers like OpenAI, Google, Runway, Luma, ElevenLabs, and Stability Audio, plus models served through platforms such as GMI Cloud and NVIDIA NIM (`build.nvidia.com`) — so you swap providers without rewriting orchestration. Every run produces a canonical provenance manifest you can embed directly into media files (`.mp4`, `.png`, `.mp3`, …) and persist to [Backblaze B2](https://www.backblaze.com/cloud-storage?utm_source=github&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=genblaze) or any S3-compatible store. `Manifest.verify()` checks the manifest hash and requires every output asset to declare a valid `sha256`; callers that fetch `asset.url` should re-hash those bytes separately.
+A unified `Pipeline` API spans providers like OpenAI, Google, Runway, Luma, ElevenLabs, and Stability Audio, plus models served through platforms such as GMI Cloud and NVIDIA NIM (`build.nvidia.com`) — so you swap providers without rewriting orchestration. Every run produces a canonical provenance manifest you can embed directly into media files (`.mp4`, `.png`, `.mp3`, …) and persist to [Backblaze B2](https://www.backblaze.com/cloud-storage?utm_source=github&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=genblaze) or any S3-compatible store. `Manifest.verify()` checks the manifest hash and requires every output asset to declare a valid `sha256`; callers that fetch `asset.url` should re-hash those bytes separately, and the CLI's opt-in `genblaze verify --fetch` mode does exactly that.
 
 ## Why Genblaze
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-22 -->
+<!-- last_verified: 2026-07-21 -->
 # genblaze-cli
 
 **Command-line toolkit for inspecting, verifying, and indexing genblaze AI-generated-media provenance manifests.**
@@ -30,6 +30,7 @@ genblaze extract video.mp4                # Extract embedded manifest → stdout
 genblaze extract video.mp4 -o m.json      # …or to a file
 
 genblaze verify video.mp4                 # Verify manifest hash + output sha256 declarations
+genblaze verify video.mp4 --fetch         # …and re-hash the actual asset bytes
 genblaze verify manifest.json             # Or verify a standalone manifest file
 
 genblaze replay manifest.json             # Show what a replay would do (dry run)
@@ -37,7 +38,7 @@ genblaze replay manifest.json             # Show what a replay would do (dry run
 genblaze index manifest.json -o data/     # Index into partitioned Parquet tables
 ```
 
-Exit codes are non-zero on verification failure — safe to drop into CI pipelines, release checks, or content-moderation workflows. The command does not fetch remote asset URLs; consumers that dereference `asset.url` must hash those bytes separately and compare them with the manifest's `asset.sha256`.
+Exit codes are non-zero on verification failure; safe to drop into CI pipelines, release checks, or content-moderation workflows. By default verify checks the manifest only; `--fetch` also downloads each output asset (through the same SSRF-hardened transfer path the pipeline uses) and compares its bytes against the declared sha256. Local pipelines that wrote assets outside the system temp directories (e.g. `output_dir=./out`) can admit them with `--allowed-root <dir>`.
 
 ## Typical flow
 

--- a/cli/genblaze_cli/commands/verify.py
+++ b/cli/genblaze_cli/commands/verify.py
@@ -1,10 +1,128 @@
 """Verify command — check manifest hash and output sha256 coverage."""
 
+from __future__ import annotations
+
+import hashlib
+import re
 from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import url2pathname
 
 import click
 
 from genblaze_cli.manifest_io import extract_manifest
+
+if TYPE_CHECKING:
+    from genblaze_core.models.manifest import Manifest
+
+# 256 KB chunks; matches the transfer layer's streaming granularity.
+_FETCH_CHUNK = 256 * 1024
+
+# A presigned URL's query string is a bearer credential for that object (#75);
+# it must never be echoed in CLI output or error messages.
+_URL_QUERY_RE = re.compile(r"https?://\S+?\?\S+")
+
+
+def _redact_url(url: str) -> str:
+    parsed = urlsplit(url)
+    if parsed.query:
+        return urlunsplit(parsed._replace(query="REDACTED"))
+    return url
+
+
+def _redact_text(text: str) -> str:
+    return _URL_QUERY_RE.sub(lambda m: _redact_url(m.group(0)), text)
+
+
+def _hash_url_bytes(url: str, extra_roots: tuple[Path, ...] = ()) -> tuple[str, int]:
+    """Stream the bytes at ``url`` and return ``(sha256_hex, size)``.
+
+    ``https://`` URLs go through the transfer layer's SSRF-pinned stream;
+    every redirect hop is re-validated against the SSRF blocklist and DNS
+    pinned, because a manifest is untrusted input and ``asset.url`` can point
+    anywhere. ``file://`` paths must resolve under the same allowed roots the
+    storage and ffmpeg paths accept, plus any ``extra_roots`` the caller
+    explicitly opted into (mirroring ``_read_local_file``'s ``extra_roots``
+    semantics; pipelines run with ``output_dir=`` write assets outside the
+    temp-dir allowlist). Bytes are hashed as they arrive; a whole asset is
+    never held in memory.
+    """
+    scheme = urlsplit(url).scheme
+    if scheme == "https":
+        from genblaze_core.exceptions import StorageError
+        from genblaze_core.storage.transfer import (
+            _DEFAULT_DOWNLOAD_TIMEOUT,
+            _DEFAULT_MAX_DOWNLOAD_BYTES,
+            _http_get_stream,
+        )
+
+        digest = hashlib.sha256()
+        size = 0
+        resp = _http_get_stream(url, timeout=_DEFAULT_DOWNLOAD_TIMEOUT)
+        try:
+            while chunk := resp.read(_FETCH_CHUNK):
+                digest.update(chunk)
+                size += len(chunk)
+                if size > _DEFAULT_MAX_DOWNLOAD_BYTES:
+                    # Same exception type and message shape as the transfer
+                    # layer's own cap, so callers see one error taxonomy.
+                    raise StorageError(
+                        f"Download exceeds {_DEFAULT_MAX_DOWNLOAD_BYTES} byte limit"
+                    )
+        finally:
+            resp.release_conn()
+        return digest.hexdigest(), size
+    if scheme == "file":
+        from genblaze_core._utils import ALLOWED_FILE_ROOTS
+
+        allowed = (*ALLOWED_FILE_ROOTS, *(r.resolve() for r in extra_roots))
+        resolved = Path(url2pathname(urlsplit(url).path)).resolve()
+        if not any(resolved.is_relative_to(root) for root in allowed):
+            raise ValueError(f"file:// path outside allowed roots: {resolved}")
+        digest = hashlib.sha256()
+        size = 0
+        with resolved.open("rb") as fh:
+            while chunk := fh.read(_FETCH_CHUNK):
+                digest.update(chunk)
+                size += len(chunk)
+        return digest.hexdigest(), size
+    raise ValueError(f"unsupported URL scheme {scheme!r} (https:// or file:// only)")
+
+
+def _fetch_and_compare(
+    manifest: Manifest, extra_roots: tuple[Path, ...] = ()
+) -> tuple[int, list[str]]:
+    """Fetch every output asset and compare bytes against the manifest.
+
+    Returns ``(asset_count, failures)``. An asset that cannot be fetched is a
+    failure, not a skip. ``--fetch`` promises byte verification, so an
+    unverifiable asset must not contribute to an OK verdict. One asset
+    failing does not stop the rest: a corrupt asset and an unreachable one
+    should both surface in a single pass.
+    """
+    count = 0
+    failures: list[str] = []
+    for step in manifest.run.steps:
+        for asset in step.assets:
+            count += 1
+            label = f"asset {asset.asset_id[:8]} ({_redact_url(asset.url)})"
+            try:
+                digest, size = _hash_url_bytes(asset.url, extra_roots)
+            except Exception as exc:
+                failures.append(f"{label}: fetch failed: {_redact_text(str(exc))}")
+                continue
+            if digest != asset.sha256:
+                failures.append(
+                    f"{label}: sha256 mismatch: manifest declares {asset.sha256}, "
+                    f"fetched bytes hash to {digest}"
+                )
+            elif asset.size_bytes is not None and size != asset.size_bytes:
+                failures.append(
+                    f"{label}: size mismatch: manifest declares "
+                    f"{asset.size_bytes} bytes, fetched {size}"
+                )
+    return count, failures
 
 
 @click.command()
@@ -14,8 +132,28 @@ from genblaze_cli.manifest_io import extract_manifest
     is_flag=True,
     help="Only verify canonical_hash; skip output sha256 and asset-metadata checks.",
 )
-def verify(file: Path, hash_only: bool) -> None:
+@click.option(
+    "--fetch",
+    is_flag=True,
+    help="Also download each output asset and compare its bytes to the declared sha256.",
+)
+@click.option(
+    "--allowed-root",
+    "allowed_roots",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help=(
+        "With --fetch: additionally trust file:// assets under this directory "
+        "(repeatable). By default only the system temp directories are allowed; "
+        "pipelines run with output_dir= write assets elsewhere."
+    ),
+)
+def verify(file: Path, hash_only: bool, fetch: bool, allowed_roots: tuple[Path, ...]) -> None:
     """Verify an embedded, sidecar, or standalone genblaze manifest."""
+    if fetch and hash_only:
+        raise click.UsageError("--fetch and --hash-only are mutually exclusive.")
+    if allowed_roots and not fetch:
+        raise click.UsageError("--allowed-root requires --fetch.")
     try:
         manifest = extract_manifest(file)
         report = manifest.verification_report()
@@ -44,9 +182,26 @@ def verify(file: Path, hash_only: bool) -> None:
                 err=True,
             )
             raise click.exceptions.Exit(1)
+        if fetch:
+            count, failures = _fetch_and_compare(manifest, allowed_roots)
+            if failures:
+                for line in failures:
+                    click.echo(f"FAIL: {line}", err=True)
+                raise click.exceptions.Exit(1)
+            if count == 0:
+                # Distinguish "nothing to check" from "checked and matched":
+                # a vacuous OK must not read like a byte-verification pass.
+                click.echo("OK: manifest hash verified; no output assets to fetch.")
+                return
+            click.echo(
+                f"OK: manifest hash verified; {count} output asset(s) "
+                "fetched and matched their declared sha256."
+            )
+            return
         click.echo(
             "OK: manifest hash verified; all output assets declare sha256 and "
-            "carry in-spec metadata. Asset bytes were not fetched or compared."
+            "carry in-spec metadata. Asset bytes were not fetched or compared; "
+            "add --fetch to verify the media itself."
         )
     except click.exceptions.Exit:
         raise

--- a/cli/tests/test_verify_fetch.py
+++ b/cli/tests/test_verify_fetch.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from genblaze_cli.main import cli
+from genblaze_core.builders import RunBuilder, StepBuilder
+from genblaze_core.models.asset import Asset
+from genblaze_core.models.enums import StepStatus
+from genblaze_core.models.manifest import Manifest
+
+
+def _create_fetch_manifest(tmp_path: Path, data: bytes = b"genblaze bytes") -> tuple[Path, Path]:
+    """Manifest JSON + on-disk file:// asset whose sha256/size are byte-bound."""
+    asset_path = tmp_path / "asset.bin"
+    asset_path.write_bytes(data)
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url=asset_path.as_uri(), media_type="image/png")
+    asset.set_hash(data)
+    step.assets = [asset]
+    run = RunBuilder("fetch-test").add_step(step).build()
+    manifest = Manifest.from_run(run)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(manifest.to_canonical_json(), encoding="utf-8")
+    return manifest_path, asset_path
+
+
+def test_verify_fetch_matching_bytes(tmp_path: Path) -> None:
+    manifest_path, _ = _create_fetch_manifest(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "1 output asset(s) fetched and matched their declared sha256" in result.output
+
+
+def test_verify_fetch_detects_tampered_bytes(tmp_path: Path) -> None:
+    manifest_path, asset_path = _create_fetch_manifest(tmp_path)
+    asset_path.write_bytes(b"tampered after the manifest was written")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "sha256 mismatch" in combined
+
+
+def test_verify_fetch_detects_size_mismatch(tmp_path: Path) -> None:
+    """Correct digest but wrong declared size_bytes must fail --fetch."""
+    data = b"genblaze bytes"
+    asset_path = tmp_path / "asset.bin"
+    asset_path.write_bytes(data)
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url=asset_path.as_uri(), media_type="image/png")
+    asset.set_hash(data)
+    asset.size_bytes = len(data) + 1
+    step.assets = [asset]
+    run = RunBuilder("fetch-size").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "size mismatch" in combined
+
+
+def test_verify_fetch_reports_every_failing_asset(tmp_path: Path) -> None:
+    """One bad asset must not stop verification of the rest."""
+    tampered = tmp_path / "tampered.bin"
+    tampered.write_bytes(b"original")
+    missing = tmp_path / "missing.bin"
+    missing.write_bytes(b"will be deleted")
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    assets = []
+    for path in (tampered, missing):
+        asset = Asset(url=path.as_uri(), media_type="image/png")
+        asset.set_hash(path.read_bytes())
+        assets.append(asset)
+    step.assets = assets
+    run = RunBuilder("fetch-multi").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+    tampered.write_bytes(b"changed")
+    missing.unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "sha256 mismatch" in combined
+    assert "fetch failed" in combined
+
+
+def test_verify_fetch_rejects_hash_only_combo(tmp_path: Path) -> None:
+    manifest_path, _ = _create_fetch_manifest(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", "--hash-only", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in combined
+
+
+def test_verify_fetch_https_streams_through_pinned_transfer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """https assets must go through transfer's SSRF-pinned stream, chunked, and
+    release the connection afterwards."""
+    data = b"remote asset bytes" * 1024
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="https://cdn.example.com/output.png", media_type="image/png")
+    asset.set_hash(data)
+    step.assets = [asset]
+    run = RunBuilder("fetch-https").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    released = {"called": False}
+
+    class _FakeResp:
+        def __init__(self) -> None:
+            self._buf = data
+
+        def read(self, size: int) -> bytes:
+            chunk, self._buf = self._buf[:size], self._buf[size:]
+            return chunk
+
+        def release_conn(self) -> None:
+            released["called"] = True
+
+    monkeypatch.setattr(
+        "genblaze_core.storage.transfer._http_get_stream",
+        lambda url, *, timeout: _FakeResp(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "fetched and matched" in result.output
+    assert released["called"]
+
+
+def test_verify_fetch_redacts_presigned_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A presigned query string is a bearer credential; it must not survive
+    into CLI output even when the transfer layer's error message echoes it."""
+    from genblaze_core.exceptions import StorageError
+
+    url = "https://cdn.example.com/output.png?X-Amz-Signature=SECRETSIG"
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url=url, media_type="image/png")
+    asset.set_hash(b"whatever")
+    step.assets = [asset]
+    run = RunBuilder("fetch-redact").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    def _raise(url: str, *, timeout: float) -> None:
+        raise StorageError(f"HTTP 403 downloading {url}")
+
+    monkeypatch.setattr("genblaze_core.storage.transfer._http_get_stream", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "SECRETSIG" not in combined
+    assert "REDACTED" in combined
+
+
+def test_verify_fetch_rejects_file_url_outside_allowed_roots(tmp_path: Path) -> None:
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="file:///etc/hosts", media_type="image/png")
+    asset.sha256 = "f" * 64
+    step.assets = [asset]
+    run = RunBuilder("fetch-roots").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "outside allowed roots" in combined
+
+
+def test_verify_default_message_points_to_fetch(tmp_path: Path) -> None:
+    """The default OK verdict must route users to --fetch instead of
+    dead-ending at 'bytes were not compared'."""
+    manifest_path, _ = _create_fetch_manifest(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", str(manifest_path)])
+
+    assert result.exit_code == 0
+    assert "add --fetch" in result.output
+
+
+def test_verify_fetch_blocks_ssrf_urls_via_real_transfer_guard(tmp_path: Path) -> None:
+    """No mocking: --fetch must route through core's real SSRF guard.
+
+    localhost and the cloud-metadata IP are rejected by resolve_ssrf before any
+    connection is opened, so this exercises the genuine security path offline.
+    If anyone ever swaps the hardened fetch for a naive HTTP client, this test
+    starts making real network calls and fails.
+    """
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    assets = []
+    for url in ("https://localhost/asset.png", "https://169.254.169.254/latest/meta-data"):
+        asset = Asset(url=url, media_type="image/png")
+        asset.sha256 = "f" * 64
+        assets.append(asset)
+    step.assets = assets
+    run = RunBuilder("fetch-ssrf").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    # result.output is the mixed stream on every click version (stderr raises
+    # on click<8.2; on >=8.2 output+stderr would double-count these lines).
+    combined = result.output
+
+    assert result.exit_code != 0
+    # Both assets must surface as fetch failures in a single pass.
+    assert combined.count("fetch failed") == 2
+    # And the failures must come from the SSRF guard, not a connection attempt.
+    assert "not allowed" in combined
+
+
+def test_verify_fetch_allowed_root_admits_file_outside_default_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--allowed-root extends the file:// allowlist, mirroring the transfer
+    layer's extra_roots semantics for pipelines run with output_dir=."""
+    manifest_path, _ = _create_fetch_manifest(tmp_path)
+    # Simulate a root outside the temp-dir allowlist: with no default roots,
+    # tmp_path is only reachable via --allowed-root.
+    monkeypatch.setattr("genblaze_core._utils.ALLOWED_FILE_ROOTS", ())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["verify", "--fetch", "--allowed-root", str(tmp_path), str(manifest_path)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "fetched and matched" in result.output
+
+
+def test_verify_fetch_allowed_root_requires_fetch(tmp_path: Path) -> None:
+    manifest_path, _ = _create_fetch_manifest(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--allowed-root", str(tmp_path), str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "requires --fetch" in combined
+
+
+def test_verify_fetch_no_output_assets_reports_nothing_to_fetch(tmp_path: Path) -> None:
+    """Zero output assets must not print a vacuous 'fetched and matched' OK."""
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    step.assets = []
+    run = RunBuilder("fetch-empty").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "no output assets to fetch" in result.output
+
+
+def test_verify_fetch_rejects_http_scheme(tmp_path: Path) -> None:
+    """Plain http:// is rejected; https-only, same policy as the transfer layer."""
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="http://cdn.example.com/output.png", media_type="image/png")
+    asset.sha256 = "f" * 64
+    step.assets = [asset]
+    run = RunBuilder("fetch-http").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "unsupported URL scheme" in combined

--- a/docs/exec-plans/active/verify-fetch-byte-verification.md
+++ b/docs/exec-plans/active/verify-fetch-byte-verification.md
@@ -1,0 +1,165 @@
+<!-- last_verified: 2026-07-21 -->
+# `genblaze verify --fetch`: opt-in byte-level asset verification
+
+## Problem
+
+`genblaze verify` validates the manifest's canonical hash and requires every
+output asset to declare a well-formed `sha256`, but never dereferences
+`asset.url` to compare live bytes against the declared digest. The gap is
+self-documented in five places:
+
+- The command itself prints "Asset bytes were not fetched or compared."
+- `README.md` (line 21): "callers that fetch `asset.url` should re-hash
+  those bytes separately."
+- `cli/README.md` (line 40): "does not fetch remote asset URLs; consumers
+  … must hash those bytes separately."
+- `docs/features/cli.md` (line 47): same consumer-responsibility language.
+- `docs/features/trust-modes.md` (lines 90–93): "do not fetch `asset.url`
+  and re-hash remote bytes."
+
+trust-modes.md path 1 (line 116) recommends "Verify against the upstream
+artifact: keep the original asset … and recompute sha256 from those bytes"
+as the blessed verification path for embedded media, but no shipped tool
+performs it. The consequence: `verify` can report OK while the stored asset
+has been corrupted, truncated, or replaced; Mode 1's stated use case
+("storage-corruption detection, internal audit trail") is not fully served
+at the consumer layer.
+
+## Fix
+
+Add an opt-in `--fetch` flag to `cli/genblaze_cli/commands/verify.py`.
+`--fetch` gives consumers a native, integrated way to do the byte-check
+the docs already tell them to do manually; a real command they can run,
+not a recipe they have to assemble themselves. Default behavior is
+byte-for-byte unchanged; no core model or schema changes.
+
+### Implementation (completed)
+
+1. **`--fetch` flag**: after existing manifest-hash and sha256-coverage
+   checks pass, stream each output asset's bytes and compare the computed
+   SHA-256 to `asset.sha256`. `--fetch` and `--hash-only` are mutually
+   exclusive.
+
+2. **SSRF-hardened streaming**: stream the bytes via the SSRF-validated
+   helper in `libs/core/genblaze_core/storage/transfer.py`
+   (`_http_get_stream`; per-hop redirect validation, DNS pinning, existing
+   max-bytes cap), hashing incrementally in chunks. Never buffer a full
+   asset in memory. Decision to surface in the PR: import the private helper
+   directly (CLI already depends on core) vs. promoting a thin public
+   wrapper in `transfer.py`; neither touches models or schemas. Uses the
+   transfer layer's existing `_DEFAULT_DOWNLOAD_TIMEOUT` and
+   `_DEFAULT_MAX_DOWNLOAD_BYTES`.
+
+3. **Chunked hashing**: 256 KB chunks (`_FETCH_CHUNK`), matching the
+   transfer layer's streaming granularity. A whole asset is never held in
+   memory. The download size cap (`_DEFAULT_MAX_DOWNLOAD_BYTES`) is
+   checked after each chunk read, consistent with the transfer layer's
+   own read-then-check pattern; overshoot is bounded by one chunk.
+
+4. **`size_bytes` cross-check**: when `asset.size_bytes` is declared, the
+   fetched byte count is compared after the digest matches.
+
+5. **`file://` root restrictions**: hash the local file only when the
+   resolved path is under the allowed roots (mirror `resolve_input_path`
+   validation); otherwise fail the asset with a reason. `--allowed-root
+   <dir>` (repeatable) extends the allowlist for pipelines run with
+   `output_dir=` that write assets outside the temp-dir default.
+   `--allowed-root` requires `--fetch`. URL-only assets without `sha256`
+   are already rejected by the existing checks before `--fetch` runs.
+
+6. **Per-asset failure isolation**: one unreachable, oversize, or
+   mismatched asset does not abort verification of the rest. All failures
+   surface in a single pass.
+
+7. **Presigned URL redaction**: redact presigned URL query strings from all CLI output
+   and error messages (reuse the redaction pattern from `_ffmpeg_utils.py`
+   / #75; a presigned query string is a bearer credential).
+   `_redact_url` and `_redact_text` also catch exceptions propagated from
+   the transfer layer, where the URL can be echoed in error text.
+
+8. **Default message update**: the no-flag OK message now ends with
+   "add --fetch to verify the media itself" instead of dead-ending at
+   "bytes were not fetched or compared."
+
+9. **Vacuous-OK guard**: zero output assets with `--fetch` prints
+   "no output assets to fetch" instead of a misleading "fetched and matched."
+
+### Files touched
+
+- `cli/genblaze_cli/commands/verify.py`: `_redact_url`, `_redact_text`,
+  `_hash_url_bytes`, `_fetch_and_compare`, updated `verify` command with
+  `--fetch`, `--hash-only`, `--allowed-root` options.
+- `cli/tests/test_verify_fetch.py`: 14 tests: matching bytes, tampered
+  bytes, size mismatch, multi-asset failure isolation, hash-only mutual
+  exclusion, HTTPS streaming via pinned transfer, presigned query redaction,
+  file:// outside allowed roots, default message points to --fetch, SSRF
+  guard (no mocking; real security path), allowed-root admission,
+  allowed-root requires --fetch, vacuous-OK for zero assets, HTTP scheme
+  rejection.
+
+### Docs (in the same PR)
+
+- `README.md`: append "or run `genblaze verify --fetch`" to the re-hash
+  sentence.
+- `cli/README.md`: same pattern; add `--fetch` to the usage block.
+- `docs/features/cli.md`: update edge-case bullet and add `--fetch` to
+  verification section.
+- `docs/features/trust-modes.md`: update lines 90–93 with opt-in clause;
+  add `--fetch` pointer to path 1 (line 116).
+- `docs/features/media-embedding.md`: add `--fetch` pointer to the
+  "hash the upstream artifact" sentence (line 67).
+- `docs/features/manifest-provenance.md`: add `--fetch` pointer to the
+  self-verification step 4 (line 76).
+- `CHANGELOG.md`: entry under `[Unreleased]` / genblaze-cli.
+
+### Known limitations
+
+- `--fetch` verifies the bytes returned at fetch time. It does not prove
+  those bytes were not served from an intermediary cache or CDN. If origin
+  freshness matters for the threat model, that should be called out
+  explicitly; for immutable object storage this is usually acceptable.
+
+### Out of scope
+
+- No changes to `Manifest`, core models, or JSON Schema; deep verification
+  stays CLI-side; no schema/ts-types churn.
+- No strip-then-hash of embedded files; the verification target is the
+  pristine pre-embed artifact at `asset.url`, per trust-modes.md path 1.
+- No `http://` support. HTTPS-only, same policy as the transfer layer.
+
+### Future scope
+
+- Support a deliberate "new version" path for assets whose bytes are meant
+  to change. The original manifest should stay immutable as the record of
+  what was first produced; any accepted modification should create a new
+  manifest linked back to the original rather than overwriting it in place.
+  This separates verification of what exists now from intentional versioning
+  of changed content later.
+
+## Relationship to #77 / #100
+
+PR #100 (issue #77, 3500+ lines) fixed model-level verification: URL-only
+output assets now fail `Manifest.verify()`, and `ObjectStorageSink` populates
+`sha256` at upload time. That work explicitly kept byte fetching out of the
+default verification path; the "consumers must hash fetched bytes
+themselves" language in the docs was written as part of #100.
+
+This PR does not relitigate that decision. `--fetch` is opt-in, builds the
+consumer-side tool those docs point to, and requires no core changes. If
+maintainers prefer this as a docs recipe or example script instead of a
+CLI flag, the PR can be reshaped accordingly.
+
+## Risk
+
+Low. Default `verify` behavior is unchanged (no `--fetch` = identical
+output, tested). The fetch path reuses core's existing SSRF-hardened
+`_http_get_stream` rather than introducing a new HTTP client. Private-API
+import (`_http_get_stream`, `_DEFAULT_DOWNLOAD_TIMEOUT`,
+`_DEFAULT_MAX_DOWNLOAD_BYTES`) is disclosed in the PR description.
+
+## Verification
+
+- `cd cli && pytest tests/test_verify_fetch.py -v`
+- `mypy cli/genblaze_cli/ --ignore-missing-imports`
+- `make lint`
+- `make test`

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-14 -->
+<!-- last_verified: 2026-07-21 -->
 # Feature: CLI
 
 ## Purpose
@@ -9,7 +9,7 @@ Command-line tools to extract, verify, replay, and index manifests from media fi
 
 ## Core Functions
 - `extract` — Extract and display manifest from any supported media file (auto-detects format)
-- `verify` — Verify manifest hash integrity and output `sha256` coverage from media, sidecar JSON, or standalone manifest JSON (exit code 0=OK, 1=failed verification)
+- `verify` — Verify manifest hash integrity and output `sha256` coverage from media, sidecar JSON, or standalone manifest JSON (exit code 0=OK, 1=failed verification); the opt-in `--fetch` mode also downloads each output asset and re-hashes its bytes against the declared digest, and `--allowed-root <dir>` (repeatable) admits `file://` assets outside the temp-dir allowlist, which you need when your pipeline wrote assets via `output_dir=` to a non-default location
 - `replay` — Preview (`--dry-run`) or re-execute (`--no-dry-run`) a pipeline from manifest JSON
 - `index` — Write manifest data to a Parquet sink
 
@@ -44,7 +44,7 @@ Command-line tools to extract, verify, replay, and index manifests from media fi
 - Missing, uppercase, or malformed output `sha256` → verify exits with code 1
 - Standalone JSON manifests enforce `MAX_MANIFEST_BYTES` before reading
 - Pointer-mode sidecars passed directly produce an actionable pointer-sidecar error
-- `verify` does not fetch `asset.url` or re-hash remote bytes; callers that dereference URLs must compare fetched bytes to `asset.sha256`
+- A bare `verify` does not fetch `asset.url`; the opt-in `--fetch` mode closes that gap by streaming bytes through the SSRF-pinned transfer path and comparing them to `asset.sha256`. Fetched bytes prove integrity at fetch time, not forever after; a mutable URL can serve different bytes tomorrow
 - Replay dry-run (default) → no API calls made
 - Replay `--no-dry-run` → requires provider package installed (e.g., `genblaze-replicate`)
 - Unknown provider in manifest → error with list of known providers
@@ -56,8 +56,8 @@ Command-line tools to extract, verify, replay, and index manifests from media fi
   → same clean `ManifestError` from `index` and `replay`
 
 ## Verification
-- Test files: `cli/tests/test_cli.py`
-- Required cases: extract from PNG, verify pass/fail, direct JSON and sidecar JSON inputs, oversized standalone JSON rejection, missing or malformed output `sha256`, replay dry-run
-- Quick verify: `cd cli && pytest tests/test_cli.py -v`
+- Test files: `cli/tests/test_cli.py`, `cli/tests/test_verify_fetch.py`
+- Required cases: extract from PNG, verify pass/fail, direct JSON and sidecar JSON inputs, oversized standalone JSON rejection, missing or malformed output `sha256`, replay dry-run, `--fetch` byte match/mismatch, `--allowed-root` admission
+- Quick verify: `cd cli && pytest tests/ -v`
 - Full verify: `make test`
 - Pass criteria: all CLI commands handle happy path and error cases

--- a/docs/features/manifest-provenance.md
+++ b/docs/features/manifest-provenance.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-15 -->
+<!-- last_verified: 2026-07-21 -->
 # Feature: Manifest Provenance
 
 ## Purpose
@@ -73,7 +73,7 @@ authoritative reference.
 1. Read the embedded / sidecar manifest JSON (full canonical form).
 2. Parse with `parse_manifest(json.loads(text))` so schema migrations and manifest invariants are enforced.
 3. Call `manifest.verify_hash()` to check only canonical payload integrity, or `manifest.verify()` to also reject URL-only output assets, malformed sha256 declarations, and out-of-spec asset metadata.
-4. If you will fetch asset URLs, hash those fetched bytes separately and compare them with `asset.sha256`; manifest verification does not perform network reads.
+4. If you will fetch asset URLs, hash those fetched bytes separately and compare them with `asset.sha256`; manifest verification does not perform network reads (the CLI's `genblaze verify --fetch` does exactly this for you).
 
 ### Trust modes
 The hash provides **integrity**, not **authentication**. See

--- a/docs/features/media-embedding.md
+++ b/docs/features/media-embedding.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-14 -->
+<!-- last_verified: 2026-07-21 -->
 # Feature: Media Embedding
 
 ## Purpose
@@ -67,7 +67,12 @@ Manifest verification checks the canonical manifest payload and output asset
 sha256 coverage. `manifest.verify()` and `genblaze verify <file>` reject
 URL-only output assets and malformed sha256 declarations regardless of schema
 version; hash-only callers can use `manifest.verify_hash()`. None of these
-paths fetch asset URLs or hash the post-embed container file. See
+default paths fetch asset URLs or hash the post-embed container file.
+The opt-in `genblaze verify --fetch` fetches each `asset.url` and re-hashes
+those bytes against `asset.sha256`. One caveat: on a locally embedded file
+whose `asset.url` still points at that same file, `--fetch` compares post-embed
+bytes against a pre-embed hash and fails by design. Verify against the upstream
+artifact instead (option 1 above). See
 [trust-modes.md](trust-modes.md#asset-binding-caveat).
 
 ## WebP lossless preservation

--- a/docs/features/trust-modes.md
+++ b/docs/features/trust-modes.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-20 -->
+<!-- last_verified: 2026-07-21 -->
 # Feature: Trust Modes
 
 ## Purpose
@@ -87,11 +87,15 @@ legacy schema versions too, so an attacker cannot set `schema_version="1.5"` to
 bypass output sha256 coverage. Use `verify_hash()` for historical hash-only
 CI gates or audits where URL-only outputs are expected.
 
-`Manifest.verify()` and `genblaze verify` do not fetch `asset.url` and re-hash
-remote bytes. They verify the canonical manifest hash and require every output
-asset to declare a syntactically valid lowercase sha256 digest. Consumers that
-dereference asset URLs must independently hash the fetched bytes and compare
-them to `asset.sha256` before trusting those bytes.
+`Manifest.verify()` and a bare `genblaze verify` do not fetch `asset.url` and
+re-hash remote bytes. They verify the canonical manifest hash and require every
+output asset to declare a syntactically valid lowercase sha256 digest.
+`genblaze verify --fetch` performs that byte-level check as an opt-in CLI mode;
+it streams each output asset through the SSRF-hardened transfer path and
+compares fetched bytes to `asset.sha256` (path 1 below). It does not change
+what `Manifest.verify()` or a bare `genblaze verify` accepts. Programmatic
+consumers that dereference asset URLs should do the same independently before
+trusting those bytes.
 
 Use `Manifest.verify_hash()` when a caller only needs to check that
 `canonical_hash` matches the manifest payload. This distinction matters for
@@ -113,7 +117,7 @@ verification.
 
 `asset.sha256` in the manifest is computed against the asset bytes at the moment the manifest is built — i.e., **before** embedding. After `SmartEmbedder.embed()` modifies the file to insert the manifest, the on-disk file's sha256 will not match `asset.sha256`. Two paths to verify the asset:
 
-1. **Verify against the upstream artifact** — keep the original asset (e.g., in B2 storage) and recompute sha256 from those bytes. Recommended for any sink that already uploads the asset.
+1. **Verify against the upstream artifact** — keep the original asset (e.g., in B2 storage) and recompute sha256 from those bytes. `genblaze verify --fetch` performs this check from the CLI. Recommended for any sink that already uploads the asset.
 2. **Strip-then-hash** — extract the manifest, remove the embed region per format, re-hash the remaining bytes. Format-specific; not currently shipped as a helper. C2PA's hard-binding algorithm in Mode 3 solves this for free.
 
 ## Choosing a mode


### PR DESCRIPTION
Refs #170

## Summary

Five docs locations tell consumers to hash fetched bytes themselves, and trust-modes.md recommends "verify against the upstream artifact" as the preferred path but ships no tool that does it. This PR builds that consumer-side byte-check as a first-class opt-in tool in the CLI, without changing the default verification semantics.

`genblaze verify` validates the manifest hash and requires every output asset to declare a valid sha256, but stops there. The declared digests are never compared against the actual bytes at `asset.url`. The opt-in `--fetch` flag closes that gap at the consumer layer:

- Stream each output asset's bytes and compare the computed SHA-256 against `asset.sha256`; cross-check `size_bytes` when declared
- HTTPS assets go through `_http_get_stream` from the transfer layer (per-hop SSRF validation, DNS pinning, existing max-bytes cap); bytes are hashed in 256 KB chunks, never buffered in memory
- `file://` assets resolve against the same `ALLOWED_FILE_ROOTS` the storage and ffmpeg paths use; `--allowed-root <dir>` (repeatable) extends the allowlist for pipelines run with `output_dir=`
- Per-asset failure isolation: one unreachable or mismatched asset does not stop verification of the rest
- Presigned URL query strings are redacted from all CLI output and error messages (#75 parity)
- `--fetch` and `--hash-only` are mutually exclusive
- Default `verify` behaviour is byte-for-byte unchanged; `Manifest.verify()` is untouched

One intentional default-behaviour delta to disclose: the bare-verify OK message now ends with "add --fetch to verify the media itself" instead of dead-ending at "bytes were not fetched or compared." The original wording is preserved verbatim; this appends a pointer to the new flag.

## Design tension (I've read #77 and #100)

Naming this directly rather than leaving it for review: #100 deliberately kept byte-fetching out of verification semantics, and the docs say in several places that verify does not fetch `asset.url`. I read that as a decision about what the verdict means (canonical hash plus declared digests) rather than a decision against consumer-side tooling, for two reasons:

1. The same docs assign byte-hashing to consumers explicitly ("consumers that dereference asset URLs must hash those bytes and compare them to `asset.sha256`"), and trust-modes.md lists "verify against the upstream artifact" as the recommended path for embedded media. No shipped tool performs it.
2. This PR changes none of what #100 established: `Manifest.verify()` untouched, schema untouched, default `genblaze verify` verdicts identical (one disclosed exception above).

`--fetch` is the consumer-layer tool those docs point to: opt-in, off by default, and routed through the same SSRF-hardened transfer path the pipeline itself uses. If you'd rather this live as an example recipe or a docs section instead of a flag, I'm happy to reshape it.

## User impact

`--fetch` gives consumers a native, integrated way to do the byte-check the docs already tell them to do manually. It is a real command users can run, not a recipe they have to assemble themselves.

A few deliberate UX choices:

- The bare-verify OK message now says "add --fetch to verify the media itself" instead of dead-ending at "bytes were not fetched or compared." The "OK" prefix still signals "all good" to a semi-technical user at a glance; the addendum routes them to the next step rather than leaving them wondering what else they should do.
- Zero output assets with `--fetch` prints "no output assets to fetch" rather than a vacuous "fetched and matched" that would mislead a user into thinking byte verification actually ran.
- Per-asset failure isolation means a user gets the full picture in one pass. One corrupt asset and one unreachable asset both surface in the same invocation; they don't have to fix one, rerun, and discover the next.
- Presigned URL query strings are redacted from all output. A user who copies CLI output into a Slack thread or a support ticket doesn't accidentally leak bearer credentials.
- `--allowed-root` exists because real pipelines write assets outside the system temp directories via `output_dir=`. Without it, `--fetch` on those assets would just fail with "outside allowed roots" and no obvious fix.

## Notable design decisions

- The SSRF test (`test_verify_fetch_blocks_ssrf_urls_via_real_transfer_guard`) exercises the real security guard with localhost and the AWS metadata IP (169.254.169.254), no mocking. If anyone ever swaps the hardened fetch for a naive HTTP client, this test starts making actual network calls and fails. It's a tripwire, not just a test.
- Presigned URL redaction is applied to exception messages propagated from the transfer layer, not just the URL being passed in. The transfer layer can echo the URL in its own error text; `_redact_text` catches that too.
- The size cap is checked after each chunk, so overshoot is bounded by one chunk (256 KB) rather than requiring the entire download to complete before enforcement.
- The SSRF count assertion uses `result.output` alone because click >=8.2 keeps `.output` mixed (adding `.stderr` would double-count); the substring assertions in the other tests are insensitive to it. Same CliRunner version drift #145's test plan documents.

## Known limitations

- `--fetch` verifies the bytes returned at fetch time. It does not prove those bytes were not served from an intermediary cache or CDN. For immutable object storage this is usually acceptable; if origin freshness matters for the threat model, that should be called out explicitly.
- Assets are fetched sequentially; concurrency is a deliberate v1 omission to keep the diff small.

## Future scope

- Support a deliberate "new version" path for assets whose bytes are meant to change. The original manifest stays immutable as the record of what was first produced; any accepted modification creates a new manifest linked back to the original rather than overwriting it in place.

## Private API imports

This PR imports `_http_get_stream`, `_DEFAULT_DOWNLOAD_TIMEOUT`, and `_DEFAULT_MAX_DOWNLOAD_BYTES` from `genblaze_core.storage.transfer`. The CLI already depends on core, and these are the right primitives for the job (SSRF validation, DNS pinning, streaming). I've left the decision about whether to promote a public wrapper to the maintainers; surfacing them is a one-line change in `transfer.py` if that's preferred.

## Files changed

- `cli/genblaze_cli/commands/verify.py`: `_redact_url`, `_redact_text`, `_hash_url_bytes`, `_fetch_and_compare`, updated `verify` command
- `cli/tests/test_verify_fetch.py`: 14 tests (see test plan below)
- `docs/exec-plans/active/verify-fetch-byte-verification.md`: exec plan
- 6 docs updated with `--fetch` pointers (opt-in framing throughout)
- `CHANGELOG.md`: entry under `[Unreleased]` / genblaze-cli

## Test plan

- [ ] `cd cli && pytest tests/test_verify_fetch.py -v`: 14 tests covering: matching bytes, tampered bytes, size mismatch, multi-asset failure isolation, hash-only mutual exclusion, HTTPS streaming via pinned transfer, presigned-query redaction, file:// outside allowed roots, default message points to --fetch, SSRF guard (no mocking; real security path), allowed-root admission, allowed-root requires --fetch, vacuous-OK for zero assets, HTTP scheme rejection
- [ ] `mypy cli/genblaze_cli/ --ignore-missing-imports` (per #145's bar)
- [ ] `make lint`
- [ ] `make test` (full matrix runs in CI)
