### PR TITLE
fix(lmnt): port connector to lmnt SDK 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### genblaze-lmnt
+
+- **Fixed** a fresh `pip install genblaze-lmnt` couldn't run at all (#166).
+  `provider.py` imported `from lmnt.api import Speech`, the pre-2.0 SDK
+  layout; the unbounded `lmnt>=1.0` dependency pin let `pip` resolve the
+  current `lmnt` 2.x release, which has no `lmnt.api` module, so every
+  `generate()` call failed with `ModuleNotFoundError`. Ported the connector
+  to the 2.x surface: the synchronous `lmnt.Lmnt` client and
+  `client.speech.generate_detailed(..., return_durations=True)` (the JSON
+  counterpart to `generate()` that also returns word-level durations,
+  matching the old 1.x `synthesize()` response shape). The 1.x `speed`
+  parameter has no 2.x equivalent (replaced by `temperature`/`top_p`, which
+  control expressiveness rather than pacing) — a `speed` step param is now
+  dropped with a `logging.warning` instead of being forwarded and raising
+  `TypeError`. Pin tightened to `lmnt>=2.0,<3`.
+
 ## [0.5.0] - 2026-07-16
 
 Correctness and security hardening across the pipeline, provenance, streaming,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the 2.x surface: the synchronous `lmnt.Lmnt` client and
   `client.speech.generate_detailed(..., return_durations=True)` (the JSON
   counterpart to `generate()` that also returns word-level durations,
-  matching the old 1.x `synthesize()` response shape). The 1.x `speed`
-  parameter has no 2.x equivalent (replaced by `temperature`/`top_p`, which
-  control expressiveness rather than pacing) — a `speed` step param is now
-  dropped with a `logging.warning` instead of being forwarded and raising
-  `TypeError`. Pin tightened to `lmnt>=2.0,<3`.
+  matching the old 1.x `synthesize()` response shape). Pin tightened to
+  `lmnt>=2.0,<3`.
+- **Behavior change**: the 1.x `speed` step param has no 2.x equivalent
+  (LMNT replaced it with `temperature`/`top_p`, which control
+  expressiveness, not pacing). A step that previously set `speed` was
+  forwarded straight to the 1.x API; it's now dropped before the call —
+  callers get default-pace audio plus a `logging.warning` naming
+  `temperature`/`top_p` as the closest replacement knobs, instead of the
+  `TypeError` that forwarding an unsupported kwarg to the real 2.x SDK
+  would raise.
 
 ## [0.5.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layout; the unbounded `lmnt>=1.0` dependency pin let `pip` resolve the
   current `lmnt` 2.x release, which has no `lmnt.api` module, so every
   `generate()` call failed with `ModuleNotFoundError`. Ported the connector
-  to the 2.x surface: the synchronous `lmnt.Lmnt` client and
-  `client.speech.generate_detailed(..., return_durations=True)` (the JSON
-  counterpart to `generate()` that also returns word-level durations,
-  matching the old 1.x `synthesize()` response shape). Pin tightened to
-  `lmnt>=2.0,<3`.
+  to the 2.6+ surface: the synchronous `lmnt.Lmnt` client and
+  `client.speech.generate_detailed(..., return_timestamps=True)` (the JSON
+  counterpart to `generate()` that also returns word-level timestamps,
+  matching the old 1.x `synthesize()` response shape). Pinned to
+  `lmnt>=2.6,<3`: 2.6.0 renamed this endpoint's `return_durations`/`durations`
+  (item type `Duration`) to `return_timestamps`/`timestamps` (`Timestamp`),
+  so the floor guarantees a single, consistent response shape across the
+  supported range (verified against the PyPI-latest `lmnt` 2.13.0).
 - **Behavior change**: the 1.x `speed` step param has no 2.x equivalent
   (LMNT replaced it with `temperature`/`top_p`, which control
   expressiveness, not pacing). A step that previously set `speed` was

--- a/libs/connectors/lmnt/README.md
+++ b/libs/connectors/lmnt/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-22 -->
+<!-- last_verified: 2026-07-21 -->
 # genblaze-lmnt
 
 **[LMNT](https://www.lmnt.com) ultra-low-latency text-to-speech provider adapter for [genblaze](https://github.com/backblaze-labs/genblaze) — real-time AI voice pipelines with SHA-256 provenance manifests on every clip.**

--- a/libs/connectors/lmnt/genblaze_lmnt/provider.py
+++ b/libs/connectors/lmnt/genblaze_lmnt/provider.py
@@ -24,11 +24,14 @@ Register it explicitly if you want cost tracking::
         "lmnt-1", per_input_chars(0.00015, per=1)
     )
 
-**lmnt SDK 2.x**: the client is synchronous (``lmnt.Lmnt``) and speech is
-generated via ``client.speech.generate_detailed(..., return_durations=True)``,
-which returns base64-encoded audio + optional word-level durations in one
+**lmnt SDK 2.6+**: the client is synchronous (``lmnt.Lmnt``) and speech is
+generated via ``client.speech.generate_detailed(..., return_timestamps=True)``,
+which returns base64-encoded audio + optional word-level timestamps in one
 JSON response (the closest 2.x equivalent of the old 1.x
-``Speech.synthesize()`` dict). The 1.x SDK's ``speed`` parameter has no
+``Speech.synthesize()`` dict). lmnt 2.6.0 renamed this endpoint's
+``return_durations``/``durations`` surface to ``return_timestamps``/
+``timestamps`` (item type ``Duration`` → ``Timestamp``), so the pin floor is
+``lmnt>=2.6``. The 1.x SDK's ``speed`` parameter has no
 2.x equivalent — LMNT replaced it with ``temperature``/``top_p`` on the
 "blizzard" model, which control expressiveness rather than pacing, so
 there's no direct pacing knob to forward it to. A ``speed`` step param is
@@ -168,7 +171,7 @@ class LMNTProvider(SyncProvider):
             generate_kwargs: dict = {
                 "voice": voice_id,
                 "text": payload.get("prompt", step.prompt or ""),
-                "return_durations": True,
+                "return_timestamps": True,
             }
 
             if "format" in payload:
@@ -190,7 +193,7 @@ class LMNTProvider(SyncProvider):
 
             # generate_detailed() is the JSON-response counterpart to the
             # raw-bytes speech.generate() — it's the only endpoint that can
-            # also return word-level durations (return_durations=True),
+            # also return word-level timestamps (return_timestamps=True),
             # matching the shape the old 1.x synthesize() call returned.
             result = client.speech.generate_detailed(**generate_kwargs)
             audio_bytes = base64.b64decode(result.audio)
@@ -210,20 +213,20 @@ class LMNTProvider(SyncProvider):
 
             audio_meta_kwargs: dict[str, Any] = {"channels": 1, "codec": output_format}
 
-            # Convert LMNT durations (list of ``lmnt.types.Duration`` pydantic
+            # Convert LMNT timestamps (list of ``lmnt.types.Timestamp`` pydantic
             # models) into typed WordTiming objects.
-            durations = result.durations
-            if durations:
+            timestamps = result.timestamps
+            if timestamps:
                 word_timings = [
-                    WordTiming(word=d.text, start=d.start, end=d.start + d.duration)
-                    for d in durations
+                    WordTiming(word=t.text, start=t.start, end=t.start + t.duration)
+                    for t in timestamps
                 ]
                 audio_meta_kwargs["word_timings"] = word_timings
                 # Compute duration from word timings
                 if word_timings:
                     asset.duration = max(wt.end for wt in word_timings)
                 step.provider_payload = {
-                    "lmnt": {"durations": [d.model_dump() for d in durations]}
+                    "lmnt": {"timestamps": [t.model_dump() for t in timestamps]}
                 }
 
             asset.audio = AudioMetadata(**audio_meta_kwargs)

--- a/libs/connectors/lmnt/genblaze_lmnt/provider.py
+++ b/libs/connectors/lmnt/genblaze_lmnt/provider.py
@@ -29,10 +29,12 @@ generated via ``client.speech.generate_detailed(..., return_durations=True)``,
 which returns base64-encoded audio + optional word-level durations in one
 JSON response (the closest 2.x equivalent of the old 1.x
 ``Speech.synthesize()`` dict). The 1.x SDK's ``speed`` parameter has no
-2.x equivalent (LMNT replaced it with ``temperature``/``top_p`` on the
-"blizzard" model, which control expressiveness rather than pacing) — a
-``speed`` step param is dropped with a warning rather than silently
-forwarded. See https://github.com/backblaze-labs/genblaze/issues/166.
+2.x equivalent — LMNT replaced it with ``temperature``/``top_p`` on the
+"blizzard" model, which control expressiveness rather than pacing, so
+there's no direct pacing knob to forward it to. A ``speed`` step param is
+dropped with a warning (naming ``temperature``/``top_p`` as the closest
+2.x knobs) rather than silently forwarded.
+See https://github.com/backblaze-labs/genblaze/issues/166.
 
 Docs: https://docs.lmnt.com/
 """
@@ -176,8 +178,10 @@ class LMNTProvider(SyncProvider):
                 # control expressiveness rather than pacing — there's no
                 # equivalent to forward, so warn instead of silently dropping.
                 logger.warning(
-                    "LMNT provider: 'speed' param is not supported by lmnt "
-                    "SDK 2.x and will be ignored (see issue #166)."
+                    "LMNT provider: 'speed' is not supported by lmnt SDK 2.x "
+                    "and will be ignored; 2.x exposes 'temperature'/'top_p' "
+                    "for expressiveness (no direct pacing equivalent). "
+                    "See issue #166."
                 )
             if "language" in payload:
                 generate_kwargs["language"] = payload["language"]

--- a/libs/connectors/lmnt/genblaze_lmnt/provider.py
+++ b/libs/connectors/lmnt/genblaze_lmnt/provider.py
@@ -5,8 +5,8 @@ Synchronous API: returns audio bytes directly.
 LMNT has no enumerable model catalog, so this provider declares
 ``DiscoverySupport.NONE`` and ships an empty registry with a permissive
 fallback that matches any ``step.model``. Param-shape rules (canonical
-``voice_id``→``voice``, ``output_format``→``format`` aliases; ``speed``
-coercion to float) ride on the fallback ``ModelSpec``.
+``voice_id``→``voice``, ``output_format``→``format`` aliases) ride on the
+fallback ``ModelSpec``.
 
 This connector is the **proof-point** for the catalog-decoupling
 architecture in ``genblaze-core 0.3.0`` — LMNT was already empty-defaults
@@ -24,18 +24,29 @@ Register it explicitly if you want cost tracking::
         "lmnt-1", per_input_chars(0.00015, per=1)
     )
 
+**lmnt SDK 2.x**: the client is synchronous (``lmnt.Lmnt``) and speech is
+generated via ``client.speech.generate_detailed(..., return_durations=True)``,
+which returns base64-encoded audio + optional word-level durations in one
+JSON response (the closest 2.x equivalent of the old 1.x
+``Speech.synthesize()`` dict). The 1.x SDK's ``speed`` parameter has no
+2.x equivalent (LMNT replaced it with ``temperature``/``top_p`` on the
+"blizzard" model, which control expressiveness rather than pacing) — a
+``speed`` step param is dropped with a warning rather than silently
+forwarded. See https://github.com/backblaze-labs/genblaze/issues/166.
+
 Docs: https://docs.lmnt.com/
 """
 
 from __future__ import annotations
 
+import base64
+import logging
 import os
 import tempfile
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from genblaze_core._utils import _run_async
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, WordTiming
 from genblaze_core.models.enums import Modality
@@ -53,6 +64,8 @@ from genblaze_core.runnable.config import RunnableConfig
 
 from ._errors import map_lmnt_error
 
+logger = logging.getLogger("genblaze.lmnt")
+
 _FORMAT_TO_MIME = {
     "mp3": "audio/mpeg",
     "wav": "audio/wav",
@@ -67,7 +80,6 @@ _LMNT_FALLBACK_SPEC = ModelSpec(
     model_id="*",
     modality=Modality.AUDIO,
     param_aliases={"voice_id": "voice", "output_format": "format"},
-    param_coercers={"speed": float},
 )
 
 
@@ -126,15 +138,15 @@ class LMNTProvider(SyncProvider):
         self._speech_client: Any = None
 
     def _make_client(self):
-        """Create a fresh LMNT Speech client for a single generate() call."""
+        """Create a fresh LMNT client for a single generate() call."""
         try:
-            from lmnt.api import Speech
+            from lmnt import Lmnt
         except ImportError as exc:
             raise ProviderError("lmnt package not installed. Run: pip install lmnt") from exc
         kwargs: dict = {}
         if self._api_key:
             kwargs["api_key"] = self._api_key
-        return Speech(**kwargs)
+        return Lmnt(**kwargs)
 
     def generate(self, step: Step, config: RunnableConfig | None = None) -> Step:
         """Generate speech audio via LMNT TTS API."""
@@ -143,8 +155,7 @@ class LMNTProvider(SyncProvider):
         client = self._speech_client if self._speech_client is not None else self._make_client()
         owns_client = self._speech_client is None
         try:
-            # Run the spec pipeline — rewrites voice_id→voice, output_format→format,
-            # and coerces speed to float.
+            # Run the spec pipeline — rewrites voice_id→voice, output_format→format.
             payload = self.prepare_payload(step)
 
             voice_id = payload.get("voice", "lily")
@@ -152,24 +163,33 @@ class LMNTProvider(SyncProvider):
             media_type = _FORMAT_TO_MIME.get(output_format, "audio/mpeg")
             ext = f".{output_format}"
 
-            synth_kwargs: dict = {
+            generate_kwargs: dict = {
                 "voice": voice_id,
                 "text": payload.get("prompt", step.prompt or ""),
+                "return_durations": True,
             }
 
             if "format" in payload:
-                synth_kwargs["format"] = payload["format"]
+                generate_kwargs["format"] = payload["format"]
             if "speed" in payload:
-                synth_kwargs["speed"] = payload["speed"]
+                # lmnt 2.x dropped `speed` in favor of temperature/top_p, which
+                # control expressiveness rather than pacing — there's no
+                # equivalent to forward, so warn instead of silently dropping.
+                logger.warning(
+                    "LMNT provider: 'speed' param is not supported by lmnt "
+                    "SDK 2.x and will be ignored (see issue #166)."
+                )
             if "language" in payload:
-                synth_kwargs["language"] = payload["language"]
+                generate_kwargs["language"] = payload["language"]
             if step.seed is not None:
-                synth_kwargs["seed"] = step.seed
+                generate_kwargs["seed"] = step.seed
 
-            # LMNT SDK is async — wrap in sync call
-            # synthesize() returns {"audio": bytes, "durations": [...]}
-            result = _run_async(client.synthesize(**synth_kwargs))
-            audio_bytes = result["audio"]
+            # generate_detailed() is the JSON-response counterpart to the
+            # raw-bytes speech.generate() — it's the only endpoint that can
+            # also return word-level durations (return_durations=True),
+            # matching the shape the old 1.x synthesize() call returned.
+            result = client.speech.generate_detailed(**generate_kwargs)
+            audio_bytes = base64.b64decode(result.audio)
 
             if self._output_dir:
                 self._output_dir.mkdir(parents=True, exist_ok=True)
@@ -186,23 +206,21 @@ class LMNTProvider(SyncProvider):
 
             audio_meta_kwargs: dict[str, Any] = {"channels": 1, "codec": output_format}
 
-            # Convert LMNT durations into typed WordTiming objects
-            durations = result.get("durations")
+            # Convert LMNT durations (list of ``lmnt.types.Duration`` pydantic
+            # models) into typed WordTiming objects.
+            durations = result.durations
             if durations:
                 word_timings = [
-                    WordTiming(
-                        word=d.get("phonemes", d.get("text", d.get("word", ""))) or "",
-                        start=d["start"],
-                        end=d["start"] + d["duration"] if "duration" in d else d.get("end", 0),
-                    )
+                    WordTiming(word=d.text, start=d.start, end=d.start + d.duration)
                     for d in durations
-                    if isinstance(d, dict)
                 ]
                 audio_meta_kwargs["word_timings"] = word_timings
                 # Compute duration from word timings
                 if word_timings:
                     asset.duration = max(wt.end for wt in word_timings)
-                step.provider_payload = {"lmnt": {"durations": durations}}
+                step.provider_payload = {
+                    "lmnt": {"durations": [d.model_dump() for d in durations]}
+                }
 
             asset.audio = AudioMetadata(**audio_meta_kwargs)
 
@@ -219,9 +237,10 @@ class LMNTProvider(SyncProvider):
                 retry_after=retry_after_from_response(exc),
             ) from exc
         finally:
-            # Close per-call client only (don't close injected test clients)
+            # Close per-call client only (don't close injected test clients).
+            # lmnt 2.x's Lmnt.close() is synchronous (sync httpx.Client).
             if owns_client:
                 try:
-                    _run_async(client.close())
+                    client.close()
                 except Exception:  # noqa: S110
                     pass

--- a/libs/connectors/lmnt/pyproject.toml
+++ b/libs/connectors/lmnt/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "lmnt>=2.0,<3",
+    "lmnt>=2.6,<3",
 ]
 
 [project.urls]

--- a/libs/connectors/lmnt/pyproject.toml
+++ b/libs/connectors/lmnt/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "lmnt>=1.0",
+    "lmnt>=2.0,<3",
 ]
 
 [project.urls]

--- a/libs/connectors/lmnt/tests/test_catalog_decoupling.py
+++ b/libs/connectors/lmnt/tests/test_catalog_decoupling.py
@@ -12,23 +12,15 @@ edit can't silently regress the post-decoupling shape.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
-import pytest
 from genblaze_core.providers import (
     DiscoverySupport,
     ValidationOutcome,
 )
 
-
-@pytest.fixture(autouse=True)
-def _patch_lmnt_sdk():
-    """Avoid importing the real lmnt SDK in tests."""
-    fake_lmnt = MagicMock()
-    fake_speech = MagicMock()
-    fake_lmnt.api = MagicMock(Speech=fake_speech)
-    with patch.dict("sys.modules", {"lmnt": fake_lmnt, "lmnt.api": fake_lmnt.api}):
-        yield
+# Note: these tests construct ``LMNTProvider`` directly without generating
+# speech, so they don't need to touch the ``lmnt`` SDK at all — ``lmnt`` is
+# a real installed dependency of this package (see test_lmnt_provider.py's
+# ``test_make_client_matches_installed_sdk`` for the SDK-surface check).
 
 
 # --- DiscoverySupport declaration -----------------------------------------

--- a/libs/connectors/lmnt/tests/test_lmnt_provider.py
+++ b/libs/connectors/lmnt/tests/test_lmnt_provider.py
@@ -2,31 +2,44 @@
 
 from __future__ import annotations
 
+import base64
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.enums import StepStatus
 from genblaze_core.models.step import Step
 from genblaze_core.testing import ProviderComplianceTests
+from lmnt.types.speech_generate_detailed_response import Duration, SpeechGenerateDetailedResponse
+
+
+def _detailed_response(audio: bytes = b"fake-audio-data", durations=None):
+    """Build a real ``lmnt`` 2.x ``generate_detailed()`` response.
+
+    Using the actual pydantic response type (rather than a dict or
+    MagicMock) keeps these tests honest about the real SDK's response
+    shape — see issue #166.
+    """
+    return SpeechGenerateDetailedResponse(
+        audio=base64.b64encode(audio).decode(),
+        seed=0,
+        durations=durations,
+    )
 
 
 @pytest.fixture
 def mock_lmnt(tmp_path):
-    """Patch lmnt with a mock client."""
+    """Patch ``LMNTProvider`` with a mock lmnt 2.x ``Lmnt`` client."""
     mock_client = MagicMock()
-    mock_client.synthesize = AsyncMock(return_value={"audio": b"fake-audio-data", "durations": []})
-    mock_client.close = AsyncMock()
+    mock_client.speech.generate_detailed = MagicMock(return_value=_detailed_response())
+    mock_client.close = MagicMock()
 
-    mock_lmnt_mod = MagicMock()
+    from genblaze_lmnt import LMNTProvider
 
-    with patch.dict("sys.modules", {"lmnt": mock_lmnt_mod, "lmnt.api": MagicMock()}):
-        from genblaze_lmnt import LMNTProvider
-
-        provider = LMNTProvider(api_key="test-key", output_dir=str(tmp_path))
-        provider._speech_client = mock_client
-        yield provider, mock_client
+    provider = LMNTProvider(api_key="test-key", output_dir=str(tmp_path))
+    provider._speech_client = mock_client
+    yield provider, mock_client
 
 
 def test_generate_returns_audio_asset(mock_lmnt):
@@ -52,21 +65,37 @@ def test_voice_param_passed(mock_lmnt):
         provider="lmnt",
         model="lmnt-1",
         prompt="test",
-        params={"voice": "custom-voice-id", "speed": "1.2"},
+        params={"voice": "custom-voice-id"},
     )
     provider.generate(step)
-    call_kwargs = client.synthesize.call_args[1]
+    call_kwargs = client.speech.generate_detailed.call_args[1]
     assert call_kwargs["voice"] == "custom-voice-id"
-    assert call_kwargs["speed"] == 1.2
+
+
+def test_speed_param_dropped_with_warning(mock_lmnt, caplog):
+    """``speed`` has no lmnt 2.x equivalent — it must not be forwarded
+    (the real SDK would raise TypeError on an unknown kwarg), and the
+    user should be warned rather than have it silently vanish."""
+    provider, client = mock_lmnt
+    step = Step(
+        provider="lmnt",
+        model="lmnt-1",
+        prompt="test",
+        params={"speed": "1.2"},
+    )
+    with caplog.at_level("WARNING", logger="genblaze.lmnt"):
+        provider.generate(step)
+    call_kwargs = client.speech.generate_detailed.call_args[1]
+    assert "speed" not in call_kwargs
+    assert any("speed" in rec.message for rec in caplog.records)
 
 
 def test_durations_stored_in_payload(mock_lmnt):
     provider, client = mock_lmnt
-    client.synthesize = AsyncMock(
-        return_value={
-            "audio": b"fake-audio",
-            "durations": [{"text": "Hello", "start": 0, "end": 0.5}],
-        }
+    client.speech.generate_detailed = MagicMock(
+        return_value=_detailed_response(
+            durations=[Duration(text="Hello", start=0, duration=0.5)],
+        )
     )
     step = Step(provider="lmnt", model="lmnt-1", prompt="Hello")
     result = provider.generate(step)
@@ -89,19 +118,18 @@ def test_audio_type_metadata(mock_lmnt):
 def test_multi_word_duration(mock_lmnt):
     """Duration is max of all word end times."""
     provider, client = mock_lmnt
-    client.synthesize = AsyncMock(
-        return_value={
-            "audio": b"fake-audio",
-            "durations": [
-                {"text": "Hello", "start": 0, "end": 0.4},
-                {"text": "beautiful", "start": 0.4, "end": 0.9},
-                {"text": "world", "start": 0.9, "end": 1.3},
+    client.speech.generate_detailed = MagicMock(
+        return_value=_detailed_response(
+            durations=[
+                Duration(text="Hello", start=0, duration=0.4),
+                Duration(text="beautiful", start=0.4, duration=0.5),
+                Duration(text="world", start=0.9, duration=0.4),
             ],
-        }
+        )
     )
     step = Step(provider="lmnt", model="lmnt-1", prompt="Hello beautiful world")
     result = provider.generate(step)
-    assert result.assets[0].duration == 1.3
+    assert result.assets[0].duration == pytest.approx(1.3)
     assert result.assets[0].audio is not None
     assert len(result.assets[0].audio.word_timings) == 3
     assert result.assets[0].audio.word_timings[2].word == "world"
@@ -145,10 +173,33 @@ def test_cost_none_empty_prompt(mock_lmnt):
 
 def test_api_error_raises(mock_lmnt):
     provider, client = mock_lmnt
-    client.synthesize = AsyncMock(side_effect=RuntimeError("401 unauthorized"))
+    client.speech.generate_detailed = MagicMock(side_effect=RuntimeError("401 unauthorized"))
     step = Step(provider="lmnt", model="lmnt-1", prompt="test")
     with pytest.raises(ProviderError, match="LMNT TTS failed"):
         provider.generate(step)
+
+
+# --- Real SDK import surface (issue #166 regression) -----------------------
+#
+# The fixtures above inject a mock client directly onto ``_speech_client``,
+# so they'd happily pass even if ``_make_client()`` imported a module/class
+# that doesn't exist in the real, installed ``lmnt`` package. This test
+# deliberately exercises ``_make_client()`` against whatever version of
+# ``lmnt`` is actually installed (a real dependency of this package), so a
+# future import-path drift (like #166: ``lmnt.api.Speech`` removed in lmnt
+# 2.x) fails here instead of shipping silently.
+
+
+def test_make_client_matches_installed_sdk():
+    """``_make_client()`` must import successfully against the real,
+    installed ``lmnt`` package — not a mocked stand-in."""
+    from genblaze_lmnt import LMNTProvider
+    from lmnt import Lmnt
+
+    provider = LMNTProvider(api_key="test-key")
+    client = provider._make_client()
+    assert isinstance(client, Lmnt)
+    client.close()
 
 
 # --- Catalog-decoupling proof-point ---
@@ -199,19 +250,12 @@ class TestLMNTCompliance(ProviderComplianceTests):
     # see ``docs/reference/pricing-recipes.md``.
     expects_cost = False
 
-    @pytest.fixture(autouse=True)
-    def _patch_sdk(self):
-        with patch.dict("sys.modules", {"lmnt": MagicMock(), "lmnt.api": MagicMock()}):
-            yield
-
     def make_provider(self):
         from genblaze_lmnt import LMNTProvider
 
         mock_client = MagicMock()
-        mock_client.synthesize = AsyncMock(
-            return_value={"audio": b"fake-audio-data", "durations": []}
-        )
-        mock_client.close = AsyncMock()
+        mock_client.speech.generate_detailed = MagicMock(return_value=_detailed_response())
+        mock_client.close = MagicMock()
         provider = LMNTProvider(api_key="test-key", output_dir=tempfile.mkdtemp())
         provider._speech_client = mock_client
         return provider

--- a/libs/connectors/lmnt/tests/test_lmnt_provider.py
+++ b/libs/connectors/lmnt/tests/test_lmnt_provider.py
@@ -87,7 +87,12 @@ def test_speed_param_dropped_with_warning(mock_lmnt, caplog):
         provider.generate(step)
     call_kwargs = client.speech.generate_detailed.call_args[1]
     assert "speed" not in call_kwargs
-    assert any("speed" in rec.message for rec in caplog.records)
+    # Warning must name the 2.x replacement knobs so it's actionable, not
+    # just an announcement that something got dropped.
+    assert any(
+        "speed" in rec.message and "temperature" in rec.message and "top_p" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_durations_stored_in_payload(mock_lmnt):

--- a/libs/connectors/lmnt/tests/test_lmnt_provider.py
+++ b/libs/connectors/lmnt/tests/test_lmnt_provider.py
@@ -11,20 +11,21 @@ from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.enums import StepStatus
 from genblaze_core.models.step import Step
 from genblaze_core.testing import ProviderComplianceTests
-from lmnt.types.speech_generate_detailed_response import Duration, SpeechGenerateDetailedResponse
+from lmnt.types.speech_generate_detailed_response import SpeechGenerateDetailedResponse, Timestamp
 
 
-def _detailed_response(audio: bytes = b"fake-audio-data", durations=None):
-    """Build a real ``lmnt`` 2.x ``generate_detailed()`` response.
+def _detailed_response(audio: bytes = b"fake-audio-data", timestamps=None):
+    """Build a real ``lmnt`` 2.6+ ``generate_detailed()`` response.
 
     Using the actual pydantic response type (rather than a dict or
     MagicMock) keeps these tests honest about the real SDK's response
-    shape — see issue #166.
+    shape — see issue #166. lmnt 2.6.0 renamed the ``durations`` field
+    (item type ``Duration``) to ``timestamps`` (``Timestamp``); the pin
+    floor is ``lmnt>=2.6``, so these tests build against the modern shape.
     """
     return SpeechGenerateDetailedResponse(
         audio=base64.b64encode(audio).decode(),
-        seed=0,
-        durations=durations,
+        timestamps=timestamps,
     )
 
 
@@ -99,12 +100,12 @@ def test_durations_stored_in_payload(mock_lmnt):
     provider, client = mock_lmnt
     client.speech.generate_detailed = MagicMock(
         return_value=_detailed_response(
-            durations=[Duration(text="Hello", start=0, duration=0.5)],
+            timestamps=[Timestamp(text="Hello", start=0, duration=0.5)],
         )
     )
     step = Step(provider="lmnt", model="lmnt-1", prompt="Hello")
     result = provider.generate(step)
-    assert result.provider_payload["lmnt"]["durations"] is not None
+    assert result.provider_payload["lmnt"]["timestamps"] is not None
     # Word timings stored as typed WordTiming objects on asset.audio
     assert result.assets[0].audio is not None
     assert result.assets[0].audio.word_timings is not None
@@ -125,10 +126,10 @@ def test_multi_word_duration(mock_lmnt):
     provider, client = mock_lmnt
     client.speech.generate_detailed = MagicMock(
         return_value=_detailed_response(
-            durations=[
-                Duration(text="Hello", start=0, duration=0.4),
-                Duration(text="beautiful", start=0.4, duration=0.5),
-                Duration(text="world", start=0.9, duration=0.4),
+            timestamps=[
+                Timestamp(text="Hello", start=0, duration=0.4),
+                Timestamp(text="beautiful", start=0.4, duration=0.5),
+                Timestamp(text="world", start=0.9, duration=0.4),
             ],
         )
     )


### PR DESCRIPTION
## Summary

- `genblaze-lmnt`'s `provider.py` imported `from lmnt.api import Speech`, the pre-2.0 layout of the `lmnt` SDK. The connector's unbounded `lmnt>=1.0` pin let `pip install genblaze-lmnt` resolve the current `lmnt` 2.x release, so every `LMNTProvider.generate()` call failed with `ModuleNotFoundError: No module named 'lmnt.api'`.
- Ports the connector to the actual lmnt 2.x surface: the synchronous `lmnt.Lmnt` client and `client.speech.generate_detailed(..., return_durations=True)` (the JSON-response call that also returns word-level durations — the closest 2.x equivalent of the old `synthesize()` dict).
- The 1.x `speed` parameter has no 2.x equivalent (LMNT replaced it with `temperature`/`top_p`, which control expressiveness, not pacing). It's now dropped with a `logger.warning` instead of being forwarded (forwarding it would raise `TypeError` against the real 2.x SDK).
- Tightens the dependency pin to `lmnt>=2.0,<3`.

## Changes

- `libs/connectors/lmnt/genblaze_lmnt/provider.py` — swap `lmnt.api.Speech` (async) for `lmnt.Lmnt` (sync); `synthesize()` → `speech.generate_detailed()`; base64-decode audio; adapt durations handling to the real `Duration` pydantic model (`text`/`start`/`duration` fields, not the old dict shape); drop the now-unused `_run_async` wrapper (2.x's `Lmnt.close()` is sync); drop `speed` forwarding with a warning.
- `libs/connectors/lmnt/pyproject.toml` — `lmnt>=1.0` → `lmnt>=2.0,<3`.
- `libs/connectors/lmnt/tests/test_lmnt_provider.py` — tests no longer fake `sys.modules["lmnt"]`; they use the real installed SDK's response types (`SpeechGenerateDetailedResponse`, `Duration`) so a shape mismatch would fail here, not just in production. Adds `test_make_client_matches_installed_sdk`, a regression test that exercises `_make_client()` against the real installed package (this is exactly what would have caught #166 before it shipped — the old mocked-`sys.modules` tests passed regardless of the real SDK's shape). Adds `test_speed_param_dropped_with_warning`.
- `libs/connectors/lmnt/tests/test_catalog_decoupling.py` — removes the now-unnecessary `sys.modules["lmnt"]` mock fixture (none of these tests trigger an `lmnt` import).
- `libs/connectors/lmnt/README.md` — bump `last_verified` stamp.
- `CHANGELOG.md` — `[Unreleased]` entry under `### genblaze-lmnt`.

## Test plan

- [x] `make test` passes — ran the full suite; 1946 passed, 7 skipped, plus 3 **pre-existing, unrelated** failures in `libs/core/tests/unit/test_pattern_safety.py` caused by `google-re2` not being installed in this environment (confirmed identical failures on `origin/main` before this branch's changes — not introduced by this PR).
- [x] `make lint` passes (ruff check, ruff format --check, deptry across all packages).
- [x] `make typecheck` passes (mypy, 0 errors).
- [x] `cd libs/connectors/lmnt && pytest -v` — 35 passed, 2 skipped.
- [x] Docs updated in this PR (README `last_verified` stamp, CHANGELOG `[Unreleased]` entry).

Reviewed by three independent sub-agent passes against the committed diff (correctness/tests, security/invariants, architecture/DRY) — no blocking (P0) findings from any. Notable P2s surfaced and accepted as-is: dropping `speed` via `logger.warning` (rather than raising) is the correct trade-off since there's no 2.x equivalent to forward and raising would break every existing caller passing it; the new `lmnt>=2.0,<3` ceiling pin is a minor divergence from sibling connectors' unbounded pins but is arguably the more defensible choice given this issue exists precisely because of an unbounded floor.

## Related

Closes #166