### PR TITLE
fix(elevenlabs): port to elevenlabs 2.x response objects, enable model-error fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--allowed-root <dir>`. `--fetch` and `--hash-only` are mutually exclusive.
   Default `verify` behavior and `Manifest.verify()` semantics are unchanged.
 
+### genblaze-elevenlabs
+
+- **Fixed** `with_timestamps=True` TTS steps failed against elevenlabs 2.x
+  (#163). `convert_with_timestamps` returns an `AudioWithTimestampsResponse`
+  pydantic model, not a dict — `response.get("audio_base64", ...)` raised
+  `'AudioWithTimestampsResponse' object has no attribute 'get'`, and even a
+  dict-shaped stand-in would have missed the field, which is `audio_base_64`
+  (underscores) on the parsed object. `provider.py` now reads
+  `response.audio_base_64` and `response.alignment.characters` /
+  `character_start_times_seconds` / `character_end_times_seconds` directly,
+  and tolerates `alignment` being `None` (it's `Optional` on the real model).
+  Verified against the installed `elevenlabs` 2.38.1 SDK's response types;
+  the object-response surface has been present since 2.0.0, so no floor bump
+  was needed — pinned to `elevenlabs>=2.0,<3` (previously unbounded) so a
+  fresh install can't resolve an incompatible future major version.
+- **Fixed** `fallback_models` could never fire on ElevenLabs steps (#167).
+  `_errors.py`'s mapper had no `MODEL_ERROR` branch, so an unknown/retired
+  `model_id` surfaced as `INVALID_INPUT` or `UNKNOWN` and the pipeline's
+  fallback retry (which only triggers on `MODEL_ERROR`) never engaged. A 404
+  status code (elevenlabs.errors.NotFoundError — raised for any missing
+  resource, most commonly an unknown model_id or voice_id) now maps to
+  `MODEL_ERROR`; the message-based fallback delegates to the shared
+  `classify_api_error` classifier instead of duplicating its "model" +
+  "not found" pattern.
+
 ### genblaze-lmnt
 
 - **Fixed** a fresh `pip install genblaze-lmnt` couldn't run at all (#166).

--- a/libs/connectors/elevenlabs/genblaze_elevenlabs/_errors.py
+++ b/libs/connectors/elevenlabs/genblaze_elevenlabs/_errors.py
@@ -1,10 +1,22 @@
 """Shared ElevenLabs error mapping — used by provider.py, sfx.py."""
 
 from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_core.providers.base import classify_api_error
 
 
 def map_elevenlabs_error(exc: Exception) -> ProviderErrorCode:
     """Map an ElevenLabs API exception to a ProviderErrorCode."""
+    # 404 is the one status we dispatch on the attribute rather than the
+    # message: NotFoundError (an unknown model_id or voice_id) must map to
+    # MODEL_ERROR so the pipeline's `fallback_models` retry can fire (#167),
+    # but the shared classifier only maps 404 → MODEL_ERROR when the body
+    # contains "model", which ElevenLabs' 404 body does not guarantee. A bad
+    # voice_id takes this path too — same tradeoff genblaze_nvidia accepts.
+    # The other codes (401/403/429/5xx) are matched below via str(exc), which
+    # embeds `status_code: NNN`; the local checks intentionally run before the
+    # delegated classifier so this connector's historical mapping wins.
+    if getattr(exc, "status_code", None) == 404:
+        return ProviderErrorCode.MODEL_ERROR
     msg = str(exc).lower()
     if "rate" in msg or "429" in msg:
         return ProviderErrorCode.RATE_LIMIT
@@ -16,4 +28,7 @@ def map_elevenlabs_error(exc: Exception) -> ProviderErrorCode:
         return ProviderErrorCode.TIMEOUT
     if "500" in msg or "502" in msg or "503" in msg:
         return ProviderErrorCode.SERVER_ERROR
-    return ProviderErrorCode.UNKNOWN
+    # Delegate remaining classification (including "model" + "not found"/
+    # "not available" → MODEL_ERROR) to the shared classifier instead of
+    # re-duplicating that pattern here.
+    return classify_api_error(exc)

--- a/libs/connectors/elevenlabs/genblaze_elevenlabs/provider.py
+++ b/libs/connectors/elevenlabs/genblaze_elevenlabs/provider.py
@@ -282,13 +282,20 @@ class ElevenLabsTTSProvider(SyncProvider):
                 response = client.text_to_speech.convert_with_timestamps(**kwargs)
                 import base64
 
-                audio_bytes = base64.b64decode(response.get("audio_base64", ""))
-                alignment = response.get("alignment", {})
-                al_chars = alignment.get("characters", [])
-                starts = alignment.get("character_start_times_seconds", [])
-                ends = alignment.get("character_end_times_seconds", [])
-                if al_chars and starts and ends:
-                    word_timings = _parse_elevenlabs_alignment(al_chars, starts, ends)
+                # elevenlabs 2.x returns AudioWithTimestampsResponse, a
+                # pydantic model — not a dict. The audio field is
+                # `audio_base_64` (underscores); the wire alias
+                # `audio_base64` only applies to raw JSON, not the parsed
+                # object. `alignment` is itself a model (Optional — the API
+                # may omit it), not a dict of lists.
+                audio_bytes = base64.b64decode(response.audio_base_64)
+                alignment = response.alignment
+                if alignment is not None:
+                    al_chars = alignment.characters
+                    starts = alignment.character_start_times_seconds
+                    ends = alignment.character_end_times_seconds
+                    if al_chars and starts and ends:
+                        word_timings = _parse_elevenlabs_alignment(al_chars, starts, ends)
             else:
                 # convert() returns an iterator of audio bytes
                 audio_iter = client.text_to_speech.convert(**kwargs)

--- a/libs/connectors/elevenlabs/pyproject.toml
+++ b/libs/connectors/elevenlabs/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "elevenlabs>=2.0",
+    "elevenlabs>=2.0,<3",
 ]
 
 [project.urls]

--- a/libs/connectors/elevenlabs/tests/test_elevenlabs_provider.py
+++ b/libs/connectors/elevenlabs/tests/test_elevenlabs_provider.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from genblaze_core.exceptions import ProviderError
-from genblaze_core.models.enums import StepStatus
+from genblaze_core.models.enums import ProviderErrorCode, StepStatus
 from genblaze_core.models.step import Step
 from genblaze_core.testing import ProviderComplianceTests
 
@@ -92,6 +93,90 @@ def test_tts_api_error_raises(mock_tts):
     step = Step(provider="elevenlabs-tts", model="eleven_v3", prompt="test")
     with pytest.raises(ProviderError, match="ElevenLabs TTS failed"):
         provider.generate(step)
+
+
+class _FakeApiError(Exception):
+    """Mirrors elevenlabs.core.api_error.ApiError — carries status_code."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_tts_404_surfaces_as_model_error(mock_tts):
+    """A 404 (unknown model_id) must surface on the ProviderError as
+    MODEL_ERROR — the code the pipeline's fallback_models retry gates on
+    (#167). This asserts the classification only; the actual fallback-firing
+    is covered by the pipeline tests in libs/core."""
+    provider, client = mock_tts
+    client.text_to_speech.convert.side_effect = _FakeApiError("model not found", 404)
+    step = Step(provider="elevenlabs-tts", model="eleven_bogus", prompt="test")
+    with pytest.raises(ProviderError) as exc_info:
+        provider.generate(step)
+    assert exc_info.value.error_code == ProviderErrorCode.MODEL_ERROR
+
+
+def _fake_timestamps_response(text: str = "hi there"):
+    """Builds an object matching elevenlabs 2.x's
+    ``AudioWithTimestampsResponse`` — a Pydantic model exposing
+    ``audio_base_64`` (not ``audio_base64``) and an ``alignment`` object
+    (not a dict) with ``characters`` / ``character_start_times_seconds`` /
+    ``character_end_times_seconds`` list attributes. See
+    elevenlabs.types.audio_with_timestamps_response for the real shape."""
+    import base64
+
+    chars = list(text)
+    starts = [i * 0.1 for i in range(len(chars))]
+    ends = [(i + 1) * 0.1 for i in range(len(chars))]
+    alignment = SimpleNamespace(
+        characters=chars,
+        character_start_times_seconds=starts,
+        character_end_times_seconds=ends,
+    )
+    return SimpleNamespace(
+        audio_base_64=base64.b64encode(b"fake-audio").decode(),
+        alignment=alignment,
+        normalized_alignment=alignment,
+    )
+
+
+def test_tts_with_timestamps_reads_object_response(mock_tts):
+    """elevenlabs 2.x's convert_with_timestamps returns a pydantic model,
+    not a dict — .get(...) raises AttributeError (#163). generate() must
+    read attributes (audio_base_64, alignment.characters, ...) instead."""
+    provider, client = mock_tts
+    client.text_to_speech.convert_with_timestamps.return_value = _fake_timestamps_response("hi")
+    step = Step(
+        provider="elevenlabs-tts",
+        model="eleven_v3",
+        prompt="hi",
+        params={"with_timestamps": True},
+    )
+    result = provider.generate(step)
+    assert len(result.assets) == 1
+    asset = result.assets[0]
+    assert asset.size_bytes == len(b"fake-audio")
+    word_timings = asset.audio.word_timings
+    assert word_timings, "expected word_timings populated from alignment"
+    assert word_timings[0].word == "hi"
+
+
+def test_tts_with_timestamps_handles_missing_alignment(mock_tts):
+    """``alignment`` is Optional on the real response model — must not
+    crash when the API omits it."""
+    provider, client = mock_tts
+    response = _fake_timestamps_response("hi")
+    response.alignment = None
+    client.text_to_speech.convert_with_timestamps.return_value = response
+    step = Step(
+        provider="elevenlabs-tts",
+        model="eleven_v3",
+        prompt="hi",
+        params={"with_timestamps": True},
+    )
+    result = provider.generate(step)
+    assert len(result.assets) == 1
+    assert not result.assets[0].audio.word_timings
 
 
 # --- SFX Tests ---

--- a/libs/connectors/elevenlabs/tests/test_errors.py
+++ b/libs/connectors/elevenlabs/tests/test_errors.py
@@ -1,0 +1,68 @@
+"""Tests for ElevenLabs error mapping."""
+
+from __future__ import annotations
+
+from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_elevenlabs._errors import map_elevenlabs_error
+
+
+class _ApiErrorLike(Exception):
+    """Stand-in for elevenlabs.errors.* — real SDK exceptions carry
+    ``status_code`` as an attribute (see elevenlabs.core.api_error.ApiError)."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_rate_limit():
+    assert map_elevenlabs_error(Exception("429 rate limit")) == ProviderErrorCode.RATE_LIMIT
+
+
+def test_auth_failure():
+    assert map_elevenlabs_error(Exception("401 unauthorized")) == ProviderErrorCode.AUTH_FAILURE
+
+
+def test_invalid_input():
+    assert (
+        map_elevenlabs_error(Exception("400 invalid request")) == ProviderErrorCode.INVALID_INPUT
+    )
+
+
+def test_timeout():
+    assert map_elevenlabs_error(Exception("request timed out")) == ProviderErrorCode.TIMEOUT
+
+
+def test_server_error():
+    assert map_elevenlabs_error(Exception("502 bad gateway")) == ProviderErrorCode.SERVER_ERROR
+
+
+def test_unknown():
+    assert map_elevenlabs_error(Exception("something went wrong")) == ProviderErrorCode.UNKNOWN
+
+
+def test_404_status_code_is_model_error():
+    """elevenlabs.errors.NotFoundError carries status_code=404 for an
+    unknown model_id/voice_id — must map to MODEL_ERROR so
+    `fallback_models` can fire (#167)."""
+    assert (
+        map_elevenlabs_error(_ApiErrorLike("not found", status_code=404))
+        == ProviderErrorCode.MODEL_ERROR
+    )
+
+
+def test_model_not_found_message_without_status_code():
+    """String-only fallback (delegated to classify_api_error) for callers
+    that don't surface status_code."""
+    assert (
+        map_elevenlabs_error(Exception("model not found: no such model"))
+        == ProviderErrorCode.MODEL_ERROR
+    )
+
+
+def test_status_code_priority_over_message():
+    """status_code wins even when the message reads like something else."""
+    assert (
+        map_elevenlabs_error(_ApiErrorLike("rate limited", status_code=404))
+        == ProviderErrorCode.MODEL_ERROR
+    )


### PR DESCRIPTION
Ports the ElevenLabs connector to the elevenlabs 2.x SDK surface and unblocks `fallback_models` on ElevenLabs steps.

## Related
Closes #163
Closes #167

## Changes
- **#163 — `with_timestamps=True` broken on elevenlabs 2.x.** `convert_with_timestamps()` returns an `AudioWithTimestampsResponse` pydantic model, not a dict; the old `response.get("audio_base64", ...)` raised `AttributeError`, and the field is `audio_base_64` (underscores) on the parsed object. `provider.py` now reads attributes (`audio_base_64`, `alignment.characters` / `character_start_times_seconds` / `character_end_times_seconds`) and tolerates `alignment` being `None` (it is `Optional`). Verified against elevenlabs 2.38.1; object-response surface present since 2.0.0. Dependency tightened from `elevenlabs>=2.0` to `elevenlabs>=2.0,<3`.
- **#167 — `fallback_models` never fired.** `_errors.py` never produced `MODEL_ERROR`, the only code the pipeline's `_try_fallback_models` retries on. A 404 (`NotFoundError`, e.g. unknown `model_id`) now maps to `MODEL_ERROR`; the message-based tail delegates to the shared `classify_api_error()` instead of duplicating its "model not found" pattern. Blanket-404 tradeoff (a bad `voice_id` also 404s) is documented and matches the existing `genblaze_nvidia` precedent.

## Tests
- New `tests/test_errors.py` and added cases in `tests/test_elevenlabs_provider.py`: object-response happy path, missing-alignment path, 404→`MODEL_ERROR`, string-fallback delegation, and status-over-message priority.
- elevenlabs package suite: 68 passed, 4 skipped. `make lint`: pass.

## Reviewed
Ran a three-lens independent panel review (engineering-manager / OSS / DX). All three verified both fixes against the real SDK; no blocker/high findings. Applied: a mapper comment correction and a test rename for clarity.

## Follow-up (not in this PR)
The panel flagged that this connector's error mapper keeps a bespoke string block on top of the delegated classifier, diverging from the sibling connectors (nvidia/hume/assemblyai) that route all status codes through `status_code`. Aligning them is cross-cutting error-classifier work tracked by #39, deferred here to keep the fix minimal.