### PR TITLE
fix(core): let hasattr/getattr probe optional lazy imports safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### genblaze-core
+
+- **Fixed** `hasattr(genblaze_core, "ParquetSink")` (and
+  `getattr(module, name, default)`, `inspect`/IDE attribute probing) raised
+  `OptionalDependencyError` instead of returning `False`/the default when the
+  `parquet` extra isn't installed (#165). The umbrella package's lazy
+  `__getattr__` propagated `OptionalDependencyError` from the failed
+  `pyarrow` import, but that error is an `ImportError`, not an
+  `AttributeError` — the only exception type `hasattr` swallows — so
+  capability probing crashed instead of reporting the symbol as absent.
+  `genblaze_core.__getattr__` now catches `OptionalDependencyError` at the
+  lazy-import call site and re-raises `AttributeError` with the original
+  install-hint message preserved (chained via `__cause__`); direct usage
+  (e.g. `genblaze_core.ParquetSink(...)`) still gets the actionable
+  `pip install "genblaze[parquet]"` hint. `OptionalDependencyError` itself is
+  unchanged (still `ImportError`-catchable) for non-attribute import paths.
+
 ### genblaze-cli
 
 - `genblaze verify --fetch` downloads each output asset and compares its bytes

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -139,7 +139,21 @@ def __getattr__(name: str):
         module_path, attr = _LAZY_IMPORTS[name]
         import importlib
 
-        mod = importlib.import_module(module_path)
+        from genblaze_core._optional import OptionalDependencyError
+
+        try:
+            mod = importlib.import_module(module_path)
+        except OptionalDependencyError as exc:
+            # Issue #165: OptionalDependencyError is an ImportError, not an
+            # AttributeError, so hasattr()/getattr(obj, name, default) and
+            # introspection tooling (which only swallow AttributeError) would
+            # otherwise crash instead of treating the symbol as absent. Since
+            # this exact except clause *is* the __getattr__ path a consumer
+            # also hits on real usage (e.g. genblaze_core.ParquetSink(...)),
+            # re-raise as AttributeError with the original install-hint
+            # message preserved (chained via `from` so the typed error is
+            # still reachable through __cause__).
+            raise AttributeError(str(exc)) from exc
         val = getattr(mod, attr)
         globals()[name] = val
         return val

--- a/libs/core/genblaze_core/_optional.py
+++ b/libs/core/genblaze_core/_optional.py
@@ -35,6 +35,16 @@ class OptionalDependencyError(ImportError):
     lets new callers be more specific (``except
     OptionalDependencyError:``).
 
+    Note (issue #165): this is deliberately *not* also a subclass of
+    :class:`AttributeError` — CPython forbids multiple inheritance from
+    both (``TypeError: multiple bases have instance lay-out conflict``,
+    since both gained C-level slots in 3.10+). ``genblaze_core``'s
+    umbrella ``__getattr__`` catches this error at the lazy-import call
+    site and re-raises it as ``AttributeError`` (message preserved) so
+    ``hasattr``/``getattr(obj, name, default)`` probing works; direct
+    ``import genblaze_core.sinks.parquet`` (or any other non-attribute
+    import path) still sees this typed, ``ImportError``-catchable class.
+
     The error message embeds the install incantation —
     ``pip install "genblaze[parquet]"`` for ``ParquetSink``, etc. —
     so the failure mode points users at the fix rather than at a bare

--- a/libs/core/tests/unit/test_optional_imports.py
+++ b/libs/core/tests/unit/test_optional_imports.py
@@ -27,6 +27,15 @@ class TestOptionalDependencyError:
         optional deps generically."""
         assert issubclass(OptionalDependencyError, ImportError)
 
+    def test_is_not_subclass_of_attribute_error(self):
+        """Issue #165: CPython forbids a single class from subclassing both
+        ImportError and AttributeError (``TypeError: multiple bases have
+        instance lay-out conflict`` — both gained C-level slots in 3.10+).
+        So this type stays a pure ImportError; ``genblaze_core.__getattr__``
+        is responsible for converting it to AttributeError at the lazy-
+        attribute-resolution call site (see TestLazyAttributeCapabilityProbing)."""
+        assert not issubclass(OptionalDependencyError, AttributeError)
+
     def test_message_includes_install_incantation(self):
         err = OptionalDependencyError(extra="parquet", package="pyarrow", symbol="ParquetSink")
         msg = str(err)
@@ -74,37 +83,88 @@ class TestRequireHelper:
             pytest.fail("expected ImportError-shaped exception")
 
 
+@pytest.fixture
+def missing_pyarrow():
+    """Simulate the ``parquet`` extra not being installed.
+
+    pyarrow IS available in this dev env, so we evict any cached import
+    and shadow it in ``sys.modules`` with ``None`` — Python's import
+    machinery treats that as "this module cannot be imported," mirroring
+    what a fresh-install user without the parquet extra would experience.
+    """
+    for cached in list(sys.modules):
+        if cached.startswith("pyarrow") or cached == "genblaze_core.sinks.parquet":
+            sys.modules.pop(cached, None)
+    sys.modules["pyarrow"] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        # Restore a clean state for downstream tests in the same session.
+        sys.modules.pop("pyarrow", None)
+        sys.modules.pop("genblaze_core.sinks.parquet", None)
+
+
 class TestParquetSinkOptionalDep:
     """End-to-end: importing ParquetSink without pyarrow raises
     OptionalDependencyError with a useful message.
-
-    pyarrow IS available in this dev env, so we simulate its absence
-    by evicting it from ``sys.modules`` and shadowing it with a
-    finder that fails. This mirrors how a fresh-install user without
-    the parquet extra would experience the import.
     """
 
-    def test_parquet_sink_module_raises_typed_error_when_pyarrow_missing(self):
-        # Evict any cached imports.
-        for cached in list(sys.modules):
-            if cached.startswith("pyarrow") or cached == "genblaze_core.sinks.parquet":
-                sys.modules.pop(cached, None)
+    def test_parquet_sink_module_raises_typed_error_when_pyarrow_missing(self, missing_pyarrow):
+        with pytest.raises(OptionalDependencyError) as exc_info:
+            import genblaze_core.sinks.parquet  # noqa: F401
+        err = exc_info.value
+        assert err.extra == "parquet"
+        assert err.package == "pyarrow"
+        assert err.symbol == "ParquetSink"
+        # And the legacy except-ImportError path catches it.
+        assert isinstance(err, ImportError)
 
-        # Block any future ``import pyarrow`` by assigning None into sys.modules.
-        # Python's import machinery treats this as "pyarrow is shadowed and
-        # cannot be imported" — re-importing parquet.py now fails the
-        # ``import pyarrow`` line at the top.
-        sys.modules["pyarrow"] = None  # type: ignore[assignment]
-        try:
-            with pytest.raises(OptionalDependencyError) as exc_info:
-                import genblaze_core.sinks.parquet  # noqa: F401
-            err = exc_info.value
-            assert err.extra == "parquet"
-            assert err.package == "pyarrow"
-            assert err.symbol == "ParquetSink"
-            # And the legacy except-ImportError path catches it.
-            assert isinstance(err, ImportError)
-        finally:
-            # Restore a clean state for downstream tests in the same session.
-            sys.modules.pop("pyarrow", None)
-            sys.modules.pop("genblaze_core.sinks.parquet", None)
+
+class TestLazyAttributeCapabilityProbing:
+    """Issue #165: ``genblaze_core.__getattr__`` (the umbrella-package lazy
+    import table) must let ``hasattr``/``getattr(..., default)`` probe a
+    lazy-imported symbol whose optional extra isn't installed without
+    crashing — while a consumer who actually *uses* the symbol still gets
+    the actionable install hint, not a bare AttributeError.
+    """
+
+    @staticmethod
+    def _evict_cached_lazy_attr(name: str) -> None:
+        # __getattr__ caches a resolved lazy import into module globals
+        # (see genblaze_core/__init__.py: ``globals()[name] = val``);
+        # pop the cache so __getattr__ runs again instead of returning
+        # the class resolved by an earlier, unrelated test/import.
+        import genblaze_core
+
+        genblaze_core.__dict__.pop(name, None)
+
+    def test_hasattr_returns_false_when_optional_dep_missing(self, missing_pyarrow):
+        import genblaze_core
+
+        self._evict_cached_lazy_attr("ParquetSink")
+        assert hasattr(genblaze_core, "ParquetSink") is False
+
+    def test_getattr_with_default_returns_default_when_optional_dep_missing(self, missing_pyarrow):
+        import genblaze_core
+
+        self._evict_cached_lazy_attr("ParquetSink")
+        sentinel = object()
+        assert getattr(genblaze_core, "ParquetSink", sentinel) is sentinel
+
+    def test_direct_access_still_raises_with_install_hint(self, missing_pyarrow):
+        """Real usage (not probing) must still surface the actionable
+        install hint. The raised type is AttributeError (required for
+        correct __getattr__ semantics — see module docstring), but the
+        message is the original OptionalDependencyError's, and the typed
+        error is still reachable via ``__cause__`` for callers that want
+        to branch on it specifically."""
+        import genblaze_core
+
+        self._evict_cached_lazy_attr("ParquetSink")
+        with pytest.raises(AttributeError) as exc_info:
+            _ = genblaze_core.ParquetSink
+        msg = str(exc_info.value)
+        assert "pyarrow" in msg
+        assert "pip install 'genblaze[parquet]'" in msg
+        assert "ParquetSink" in msg
+        assert isinstance(exc_info.value.__cause__, OptionalDependencyError)


### PR DESCRIPTION
Makes capability probing (`hasattr` / `getattr(mod, name, default)` / introspection) work for optional lazy-imported symbols like `ParquetSink` when the extra isn't installed.

## Related
Closes #165

## Root cause
`genblaze_core.__getattr__` resolves optional symbols via `importlib.import_module()`. When the extra (e.g. `pyarrow`) is absent, that raises `OptionalDependencyError` — an `ImportError`, **not** an `AttributeError`. Since `hasattr`/`getattr(..., default)`/introspection only swallow `AttributeError`, probing crashed instead of reporting the symbol absent.

## Fix
The issue suggested making `OptionalDependencyError` subclass both `ImportError` and `AttributeError`; CPython forbids that (`multiple bases have instance lay-out conflict`, verified with a repro). Instead, `__getattr__` now catches `OptionalDependencyError` at the lazy-import call site and re-raises `AttributeError(str(exc)) from exc`. This:
- fixes probing for **all** lazy optional symbols, present and future (single chokepoint);
- **preserves the install hint** on direct use — `genblaze_core.ParquetSink(...)` still surfaces `pip install 'genblaze[parquet]'`, and the typed error is reachable via `__cause__`;
- leaves `OptionalDependencyError` as `ImportError`-only, so `import genblaze_core.sinks.parquet` paths and existing `except ImportError:` contracts are unchanged;
- scopes the catch to `OptionalDependencyError` specifically, so a genuinely broken lazy-import entry still fails loudly rather than masquerading as "attribute absent."

## Tests
New TDD cases (failed pre-fix): `hasattr → False`, `getattr(..., default)` returns default, direct-usage still raises with the install hint, and a class-hierarchy assertion that `OptionalDependencyError` is not an `AttributeError`. `test_optional_imports.py`: 12 passed. Full core suite: 1950 passed / 7 skipped (the 3 `test_pattern_safety` failures are the pre-existing `re2`-missing env issue, present on `main`). `ruff check` + `format`: pass.