### PR TITLE
fix(gmicloud): route seedance FLF2V frames to first_frame/last_frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `classify_api_error` classifier instead of duplicating its "model" +
   "not found" pattern.
 
+### genblaze-gmicloud
+
+- **Fixed** data loss on Seedance first/last-frame (FLF2V) video steps
+  (#175). Seedance slugs (e.g. `seedance-2-0-260128`,
+  `seedance-1-0-pro-fast-251015`) matched no dedicated family, so they fell
+  through to the permissive fallback's `route_images(slots=("image",))`
+  mapping — the second frame was silently dropped and the first landed in
+  an `image` key that Seedance's API doesn't document. A new
+  `gmi-video-seedance` family routes both frames to GMI's documented
+  `first_frame`/`last_frame` slots (a single-image call still maps to
+  `first_frame` for I2V). Every other video family is unaffected.
+
 ### genblaze-lmnt
 
 - **Fixed** a fresh `pip install genblaze-lmnt` couldn't run at all (#166).

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -1,6 +1,6 @@
 """GMICloud video-model families.
 
-Three families, ordered most-specific-first:
+Families, ordered most-specific-first:
 
 1. ``gmi-video-pixverse`` — Pixverse v5.6 t2v / i2v / transition. Adds
    ``quality`` to the allowlist (required by the upstream API but
@@ -12,6 +12,13 @@ Three families, ordered most-specific-first:
    = True`` so ``fetch_output`` knows to attach audio metadata to the
    asset alongside the video track. Carries ``veo3-fast`` as a known
    unstable example.
+4. ``gmi-video-kling-v21`` — Kling V2.1 (Text2Video / Image2Video),
+   PascalCase wire form via ``canonical_slug``.
+5. ``gmi-video-seedance`` — Seedance first/last-frame (FLF2V) and
+   single-image I2V. Adds ``first_frame`` / ``last_frame`` — GMI's
+   documented native slot names — so both frames of an FLF2V pair reach
+   the wire instead of silently degrading to the fallback's single
+   ``image`` slot (#175).
 
 Slugs that don't match any family fall through to the permissive
 fallback. Registry-level ``unstable_slugs`` carries the remaining
@@ -112,6 +119,10 @@ _PIXVERSE = _VIDEO_BASE.extend("quality")
 
 # Wan transition / r2v variants accept multiple keyframes via image_url.
 _WAN_REF = _VIDEO_BASE.extend("image_url", "tail_image_url")
+
+# Seedance first/last-frame (FLF2V) and single-image I2V both take GMI's
+# documented ``first_frame`` / ``last_frame`` native slots.
+_SEEDANCE = _VIDEO_BASE.extend("first_frame", "last_frame")
 
 
 _COMMON_INPUT = route_images(slots=("image",))
@@ -242,6 +253,28 @@ _GMI_VIDEO_KLING_V21_FAMILY = ModelFamily(
 )
 
 
+# Seedance FLF2V (first/last-frame) and single-image I2V — GMI documents
+# ``first_frame``/``last_frame`` as the native slot names. Without this
+# family, seedance slugs fell through to the permissive fallback's
+# ``route_images(slots=("image",))`` mapping, which both mis-named the
+# first frame and silently dropped the second (#175 — no warning, no
+# error, just a smaller-than-requested payload on the wire).
+_GMI_VIDEO_SEEDANCE_FAMILY = ModelFamily(
+    name="gmi-video-seedance",
+    pattern=re.compile(r"^seedance-"),
+    spec_template=ModelSpec(
+        model_id="*",
+        modality=Modality.VIDEO,
+        input_mapping=route_images(slots=("first_frame", "last_frame")),
+        extras=_ENVELOPE,
+        **_video_surface_fields(_SEEDANCE),
+    ),
+    description="Seedance first/last-frame (FLF2V) and single-image I2V.",
+    example_slugs=("seedance-2-0-260128", "seedance-1-0-pro-fast-251015"),
+    probe=empty_payload_request_probe,
+)
+
+
 _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
@@ -279,6 +312,7 @@ def build_video_registry() -> ModelRegistry:
             _GMI_VIDEO_WAN_R2V_FAMILY,
             _GMI_VIDEO_VEO_FAMILY,
             _GMI_VIDEO_KLING_V21_FAMILY,
+            _GMI_VIDEO_SEEDANCE_FAMILY,
         ),
         fallback=_FALLBACK,
         unstable_slugs=_UNSTABLE_SLUGS,

--- a/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
+++ b/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
@@ -156,12 +156,11 @@ class TestVideoFamilyResolution:
 
     def test_other_video_slugs_fall_through_to_fallback(self) -> None:
         """Slugs that don't match a specialized family (Pixverse, Wan-r2v,
-        Veo, Kling V2.1) fall through to the permissive fallback. The base
-        video surface (``cfg_scale`` alias, ``duration`` coercion) lives
-        on the fallback spec, not on a catch-all family."""
+        Veo, Kling V2.1, Seedance) fall through to the permissive fallback.
+        The base video surface (``cfg_scale`` alias, ``duration`` coercion)
+        lives on the fallback spec, not on a catch-all family."""
         provider = GMICloudVideoProvider(api_key="test")
         for slug in (
-            "seedance-1-0-pro-250528",
             "wan2.6-t2v",
             "luma-ray-2",
             # Newer Kling V2.5/V3 series uses lowercase; no dedicated
@@ -175,6 +174,23 @@ class TestVideoFamilyResolution:
             assert "cfg_scale" in spec.param_aliases.values()
             assert "duration" in spec.param_coercers
             assert "duration" in spec.param_schemas
+
+    def test_seedance_routes_to_seedance_family(self) -> None:
+        """Seedance (FLF2V + single-image I2V) gets its own family so
+        first/last-frame inputs map to GMI's documented ``first_frame`` /
+        ``last_frame`` slots instead of falling through to the fallback's
+        single ``image`` slot, which silently dropped the second frame
+        (#175)."""
+        provider = GMICloudVideoProvider(api_key="test")
+        for slug in ("seedance-2-0-260128", "seedance-1-0-pro-fast-251015"):
+            match = provider._models.match_family(slug)
+            assert match is not None, slug
+            assert match.family.name == "gmi-video-seedance", slug
+            allowlist = match.spec.param_allowlist or set()
+            assert "first_frame" in allowlist, slug
+            assert "last_frame" in allowlist, slug
+            # Same envelope convention as every other video family.
+            assert match.spec.extras.get("envelope_key") == "payload", slug
 
     def test_kling_v21_routes_to_dedicated_family(self) -> None:
         """Kling V2.1 (text2video + image2video) gets its own family
@@ -218,8 +234,8 @@ class TestUnstableExamples:
         """A slug that's neither in a family's ``unstable_examples`` nor
         in ``unstable_slugs`` should NOT carry the known_unstable detail."""
         provider = GMICloudVideoProvider(api_key="test")
-        # seedance — no family match, not in unstable_slugs
-        result = provider._models.validate("seedance-1-0-pro-250528")
+        # wan t2v — no family match, not in unstable_slugs
+        result = provider._models.validate("wan2.6-t2v")
         assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
         assert "known_unstable" not in (result.detail or "")
         # Veo3 — matches Veo family (canonical PascalCase form)

--- a/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
@@ -486,6 +486,65 @@ def test_prepare_payload_is_idempotent_for_normalized_params(provider):
     assert provider.prepare_payload(step2) == once
 
 
+# --- Seedance FLF2V / I2V (#175) ---
+
+
+def test_seedance_flf2v_maps_both_frames(provider):
+    """Both frames of a Seedance first/last-frame step must reach the wire
+    under GMI's documented ``first_frame``/``last_frame`` names — the
+    permissive fallback silently dropped the second frame (#175)."""
+    from genblaze_core.models.asset import Asset
+
+    step = Step(
+        provider="gmicloud",
+        model="seedance-2-0-260128",
+        prompt="bridge",
+        inputs=[
+            Asset(url="https://example.com/first.png", media_type="image/png"),
+            Asset(url="https://example.com/last.png", media_type="image/png"),
+        ],
+    )
+    result = provider.prepare_payload(step)
+    assert result == {
+        "prompt": "bridge",
+        "first_frame": "https://example.com/first.png",
+        "last_frame": "https://example.com/last.png",
+    }
+
+
+def test_seedance_single_image_maps_to_first_frame(provider):
+    """A single-image Seedance call (I2V, no last frame) still maps to
+    ``first_frame`` — GMI's documented I2V parameter for Seedance."""
+    from genblaze_core.models.asset import Asset
+
+    step = Step(
+        provider="gmicloud",
+        model="seedance-1-0-pro-fast-251015",
+        prompt="animate this",
+        inputs=[Asset(url="https://example.com/first.png", media_type="image/png")],
+    )
+    result = provider.prepare_payload(step)
+    assert result == {
+        "prompt": "animate this",
+        "first_frame": "https://example.com/first.png",
+    }
+
+
+def test_unknown_video_model_still_hits_fallback(provider):
+    """A genuinely-unknown video slug still routes through the permissive
+    fallback's single ``image`` slot — only Seedance was pulled out of it."""
+    from genblaze_core.models.asset import Asset
+
+    step = Step(
+        provider="gmicloud",
+        model="totally-unknown-video-slug-v9",
+        prompt="t",
+        inputs=[Asset(url="https://example.com/first.png", media_type="image/png")],
+    )
+    result = provider.prepare_payload(step)
+    assert result["image"] == "https://example.com/first.png"
+
+
 # --- Passthrough ---
 
 


### PR DESCRIPTION
Fixes silent data loss on Seedance first/last-frame (FLF2V) video steps in the gmicloud connector.

## Related
Closes #175

## Root cause
The gmicloud video registry shipped four families (pixverse, wan-r2v, veo, kling-v21). Seedance slugs (`seedance-2-0-260128`, `seedance-1-0-pro-fast-251015`) matched none, so they fell through to the permissive `_FALLBACK` spec's `route_images(slots=("image",))` mapping. That is wrong twice for FLF2V: it names the first frame `image` (not a documented Seedance param) and **silently drops the second frame** (`array_slot=None` discards images past the single slot). Net: a two-frame step degrades to one misnamed image param, no warning.

## Fix
Add a `gmi-video-seedance` family (`pattern=^seedance-`) with `route_images(slots=("first_frame", "last_frame"))` — GMI's documented native slot names. Follows the existing `ModelFamily` convention exactly (reuses `_VIDEO_BASE.extend(...)`, the shared `_ENVELOPE`, `_video_surface_fields`, and the standard probe). One family covers both FLF2V and single-image I2V (a lone image lands in `first_frame`, GMI's documented I2V param). The `_FALLBACK` path is unchanged for genuinely-unknown models.

## Before / after (issue repro, via `ModelRegistry.prepare_payload`)
- FLF2V before: `{'prompt': 'bridge', 'image': '<first>'}` (second frame lost)
- FLF2V after: `{'prompt': 'bridge', 'first_frame': '<first>', 'last_frame': '<last>'}`
- Single image after: `{'prompt': 'bridge', 'first_frame': '<first>'}`
- Unknown model after: still `{'...', 'image': '<first>'}` via `_FALLBACK`

## Tests
Four new tests driving the real `create_registry()` / `prepare_payload`: family routing, FLF2V both-frames-preserved, single-image → `first_frame`, and unknown-model → fallback. gmicloud suite: 242 passed, 8 skipped. `make lint`: pass.