### PR TITLE
fix(core): build file:// asset URLs with Path.as_uri() for Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. `genblaze_core.ParquetSink(...)`) still gets the actionable
   `pip install "genblaze[parquet]"` hint. `OptionalDependencyError` itself is
   unchanged (still `ImportError`-catchable) for non-attribute import paths.
+- **Fixed** local-output assets (`FFmpegCompositor`, `FFmpegTransform`, and
+  every connector that built its `file://` URL via `quote()`) could never
+  upload to B2 on Windows (#164). `file://` URLs were built as
+  `f"file://{quote(str(path.resolve()))}"`, which percent-encodes a Windows
+  drive colon and backslashes into `file://C%3A%5CUsers%5C...`; `urlparse`
+  then reads the entire percent-encoded string as `netloc` and leaves `path`
+  empty, so `_read_local_file`'s allowlist check always rejected it. A new
+  `genblaze_core._utils.local_file_url()` helper builds these URLs with
+  `Path.as_uri()` instead, producing the empty-netloc form
+  (`file:///C:/Users/...`) that `_read_local_file` (via `url2pathname`) and
+  `validate_chain_input_url` already parse correctly on every platform — the
+  sink and validator were already fixed; only the URL construction was
+  release-lagged. POSIX behavior is unchanged (`as_uri()` already produced
+  the same form there).
 
 ### genblaze-cli
 
@@ -59,6 +73,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MODEL_ERROR`; the message-based fallback delegates to the shared
   `classify_api_error` classifier instead of duplicating its "model" +
   "not found" pattern.
+- **Fixed** local audio outputs (TTS + SFX) couldn't upload to B2 on
+  Windows (#164) — see the `genblaze-core` entry above for the root cause.
+  Both `provider.py` and `sfx.py` now build their `file://` asset URL via
+  `genblaze_core._utils.local_file_url()`.
+
+### genblaze-decart
+
+- **Fixed** local video/image outputs couldn't upload to B2 on Windows
+  (#164) — see the `genblaze-core` entry above for the root cause. Both
+  `provider.py` and `image.py` now build their `file://` asset URL via
+  `genblaze_core._utils.local_file_url()`.
+
+### genblaze-google
+
+- **Fixed** local video outputs (Veo inline-bytes fallback) and Imagen
+  image outputs couldn't upload to B2 on Windows (#164) — see the
+  `genblaze-core` entry above for the root cause. Both `provider.py` and
+  `imagen.py` now build their `file://` asset URL via
+  `genblaze_core._utils.local_file_url()`.
+
+### genblaze-hume
+
+- **Fixed** local audio outputs couldn't upload to B2 on Windows (#164) —
+  see the `genblaze-core` entry above for the root cause. `provider.py` now
+  builds its `file://` asset URL via `genblaze_core._utils.local_file_url()`.
+
+### genblaze-openai
+
+- **Fixed** local outputs (Sora video, DALL-E/gpt-image-1 images, TTS
+  audio) couldn't upload to B2 on Windows (#164) — see the `genblaze-core`
+  entry above for the root cause. `dalle.py`, `provider.py`, and `tts.py`
+  now build their `file://` asset URL via
+  `genblaze_core._utils.local_file_url()`.
+
+### genblaze-stability-audio
+
+- **Fixed** local audio outputs couldn't upload to B2 on Windows (#164) —
+  see the `genblaze-core` entry above for the root cause. `provider.py` now
+  builds its `file://` asset URL via `genblaze_core._utils.local_file_url()`.
 
 ### genblaze-gmicloud
 
@@ -95,6 +148,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `temperature`/`top_p` as the closest replacement knobs, instead of the
   `TypeError` that forwarding an unsupported kwarg to the real 2.x SDK
   would raise.
+- **Fixed** local audio outputs couldn't upload to B2 on Windows (#164) —
+  see the `genblaze-core` entry above for the root cause. `provider.py` now
+  builds its `file://` asset URL via `genblaze_core._utils.local_file_url()`.
 
 ## [0.5.0] - 2026-07-16
 

--- a/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
+++ b/libs/connectors/assemblyai/genblaze_assemblyai/provider.py
@@ -112,8 +112,9 @@ def _audio_ref_for_sdk(audio_url: str) -> str:
 
     The AssemblyAI SDK treats any non-HTTP string as a *local file path* and
     opens it with ``open(ref, "rb")``. A ``file://`` URI — the form chained
-    SyncProvider outputs take, percent-encoded via ``quote()`` — would be
-    opened literally as the filename ``file:///tmp/a.wav`` and fail. Convert
+    SyncProvider outputs take, built via ``Path.as_uri()``
+    (``genblaze_core._utils.local_file_url``) — would be opened literally as
+    the filename ``file:///tmp/a.wav`` and fail. Convert
     validated ``file://`` URIs to a real filesystem path (``url2pathname``
     handles percent-decoding and platform path conversion); pass ``https://``
     URLs through untouched so the SDK fetches them remotely.

--- a/libs/connectors/assemblyai/tests/test_assemblyai.py
+++ b/libs/connectors/assemblyai/tests/test_assemblyai.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
+from pathlib import PureWindowsPath
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -161,8 +162,8 @@ def test_submit_converts_file_uri_to_local_path():
 
 
 def test_submit_decodes_percent_encoded_file_uri():
-    # Sibling connectors emit file:// URLs via quote(), so a path with spaces
-    # arrives percent-encoded; it must be decoded back to the real path.
+    # Sibling connectors emit file:// URLs via Path.as_uri(), so a path with
+    # spaces arrives percent-encoded; it must be decoded back to the real path.
     provider = _make_provider()
     step = _make_step(prompt="file:///srv/audio/my%20clip.wav")
     provider.submit(step)
@@ -185,6 +186,53 @@ def test_submit_https_url_passes_through_unchanged():
     step = _make_step(prompt=AUDIO_URL)
     provider.submit(step)
     assert _FakeTranscriber.last_submit["audio_url"] == AUDIO_URL
+
+
+def test_submit_rejects_old_quote_style_windows_file_uri():
+    """Regression for #164's "AssemblyAI wrinkle": the pre-fix per-connector
+    construction (``f"file://{quote(str(path))}"``) percent-encoded a
+    Windows drive colon/backslashes into ``file://C%3A%5CUsers...``.
+    ``urlparse`` reads that whole percent-encoded string as ``netloc``,
+    which ``validate_chain_input_url`` rejects (non-empty, non-localhost
+    netloc). This pins why every connector had to move to
+    ``local_file_url()``/``Path.as_uri()`` instead — the old form was never
+    valid input for this connector.
+    """
+    provider = _make_provider()
+    old_style_url = "file://C%3A%5CUsers%5Cclip.wav"
+    step = _make_step(prompt=old_style_url)
+    with pytest.raises(ProviderError, match="netloc"):
+        provider.submit(step)
+
+
+def test_submit_converts_windows_as_uri_file_uri_to_local_path(tmp_path, monkeypatch):
+    """Regression for #164: connectors now build Windows file:// URLs with
+    Path.as_uri(), which yields the empty-netloc RFC 8089 form
+    (file:///C:/...) — the opposite of the old quote()-based
+    file://C:/... this connector always rejected. Confirms the as_uri()
+    form passes validate_chain_input_url's netloc check and resolves to a
+    local path via url2pathname, matching the sibling core regression tests
+    for #132/#164 (test_transfer.py, test_validate_chain_input_url.py,
+    test_ffmpeg_utils.py).
+
+    Both url2pathname references (this module's and
+    genblaze_core.providers.base's) are monkeypatched to the value Windows'
+    real parser would produce for an absolute, resolvable path — pathlib.Path
+    here is PosixPath and can't represent Windows absolute-path semantics for
+    a raw backslash string. The genuine nturl2path.url2pathname parsing
+    itself is exercised unmocked in test_utils.py::TestLocalFileUrl.
+    """
+    real_file = tmp_path / "clip.wav"
+    real_path = str(real_file.resolve())
+    win_url = PureWindowsPath(r"C:\srv\audio\clip.wav").as_uri()
+    assert win_url == "file:///C:/srv/audio/clip.wav"
+    monkeypatch.setattr("genblaze_core.providers.base.url2pathname", lambda _: real_path)
+    monkeypatch.setattr("genblaze_assemblyai.provider.url2pathname", lambda _: real_path)
+
+    provider = _make_provider()
+    step = _make_step(prompt=win_url)
+    provider.submit(step)
+    assert _FakeTranscriber.last_submit["audio_url"] == real_path
 
 
 # --- full lifecycle -------------------------------------------------------

--- a/libs/connectors/decart/genblaze_decart/image.py
+++ b/libs/connectors/decart/genblaze_decart/image.py
@@ -25,9 +25,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
-from genblaze_core._utils import _run_async
+from genblaze_core._utils import _run_async, local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import Modality
@@ -154,7 +153,7 @@ class DecartImageProvider(SyncProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(result.data)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             step.assets.append(Asset(url=file_url, media_type="image/png"))
 
             self._apply_registry_pricing(step)

--- a/libs/connectors/decart/genblaze_decart/provider.py
+++ b/libs/connectors/decart/genblaze_decart/provider.py
@@ -29,9 +29,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
-from genblaze_core._utils import _run_async
+from genblaze_core._utils import _run_async, local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, VideoMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -256,7 +255,7 @@ class DecartVideoProvider(BaseProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(result.data)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type="video/mp4")
             # Populate video metadata with resolution if provided
             vm_kwargs: dict[str, Any] = {"has_audio": False}

--- a/libs/connectors/elevenlabs/genblaze_elevenlabs/provider.py
+++ b/libs/connectors/elevenlabs/genblaze_elevenlabs/provider.py
@@ -24,8 +24,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, WordTiming
 from genblaze_core.models.enums import Modality
@@ -310,7 +310,7 @@ class ElevenLabsTTSProvider(SyncProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(audio_bytes)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type=media_type)
             asset.metadata["audio_type"] = "speech"
             asset.size_bytes = len(audio_bytes)

--- a/libs/connectors/elevenlabs/genblaze_elevenlabs/sfx.py
+++ b/libs/connectors/elevenlabs/genblaze_elevenlabs/sfx.py
@@ -24,8 +24,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -173,7 +173,7 @@ class ElevenLabsSFXProvider(SyncProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(audio_bytes)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type="audio/mpeg")
             asset.metadata["audio_type"] = "sfx"
             # SFX API returns mp3; mono output

--- a/libs/connectors/google/genblaze_google/imagen.py
+++ b/libs/connectors/google/genblaze_google/imagen.py
@@ -21,8 +21,8 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -188,7 +188,7 @@ class ImagenProvider(SyncProvider):
                     out_path = Path(tmp)
 
                 img.image.save(str(out_path))
-                file_url = f"file://{quote(str(out_path.resolve()))}"
+                file_url = local_file_url(out_path.resolve())
                 step.assets.append(Asset(url=file_url, media_type=mime_type))
 
             self._apply_registry_pricing(step)

--- a/libs/connectors/google/genblaze_google/provider.py
+++ b/libs/connectors/google/genblaze_google/provider.py
@@ -21,8 +21,8 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, Track, VideoMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -307,7 +307,7 @@ class VeoProvider(BaseProvider):
                         os.close(fd)
                         out_path = Path(tmp)
                     out_path.write_bytes(video_bytes)
-                    video_uri = f"file://{quote(str(out_path.resolve()))}"
+                    video_uri = local_file_url(out_path.resolve())
                 else:
                     # Gemini Developer API mode: the Files API download
                     # populates video_bytes as a side effect; the response's

--- a/libs/connectors/hume/genblaze_hume/provider.py
+++ b/libs/connectors/hume/genblaze_hume/provider.py
@@ -29,8 +29,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -243,7 +243,7 @@ class HumeTTSProvider(SyncProvider):
             out_path.write_bytes(audio_bytes)
             # Local file output — no validate_asset_url() (it only permits
             # HTTPS; file:// is the documented local-provider convention).
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type=media_type)
             asset.metadata["audio_type"] = "speech"
             asset.size_bytes = len(audio_bytes)

--- a/libs/connectors/lmnt/genblaze_lmnt/provider.py
+++ b/libs/connectors/lmnt/genblaze_lmnt/provider.py
@@ -50,8 +50,8 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, WordTiming
 from genblaze_core.models.enums import Modality
@@ -207,7 +207,7 @@ class LMNTProvider(SyncProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(audio_bytes)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type=media_type)
             asset.metadata["audio_type"] = "speech"
 

--- a/libs/connectors/nvidia/genblaze_nvidia/_base.py
+++ b/libs/connectors/nvidia/genblaze_nvidia/_base.py
@@ -25,6 +25,7 @@ import uuid
 from pathlib import Path
 
 import httpx
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.enums import ProviderErrorCode
 from genblaze_core.providers.retry import retry_after_from_response
@@ -231,7 +232,7 @@ def save_bytes_to_output_dir(
     filename = f"{prefix}-{uuid.uuid4().hex[:12]}.{extension.lstrip('.')}"
     path = base / filename
     path.write_bytes(payload)
-    return path.resolve().as_uri()
+    return local_file_url(path.resolve())
 
 
 class NvidiaClient:

--- a/libs/connectors/openai/genblaze_openai/dalle.py
+++ b/libs/connectors/openai/genblaze_openai/dalle.py
@@ -41,10 +41,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from genblaze_core._utils import open_pinned_https_connection
+from genblaze_core._utils import local_file_url, open_pinned_https_connection
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -537,7 +537,7 @@ class DalleProvider(SyncProvider):
             out_path = Path(tmp)
         out_path.write_bytes(img_bytes)
         return (
-            f"file://{quote(str(out_path.resolve()))}",
+            local_file_url(out_path.resolve()),
             hashlib.sha256(img_bytes).hexdigest(),
             len(img_bytes),
         )

--- a/libs/connectors/openai/genblaze_openai/provider.py
+++ b/libs/connectors/openai/genblaze_openai/provider.py
@@ -25,8 +25,9 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, VideoMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -383,7 +384,7 @@ class SoraProvider(BaseProvider):
                 out_path = Path(tmp)
                 content.write_to_file(str(out_path))
 
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type="video/mp4")
             asset.video = VideoMetadata(has_audio=False, codec="h264")
             step.assets.append(asset)

--- a/libs/connectors/openai/genblaze_openai/tts.py
+++ b/libs/connectors/openai/genblaze_openai/tts.py
@@ -21,8 +21,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata
 from genblaze_core.models.enums import Modality
@@ -244,7 +244,7 @@ class OpenAITTSProvider(SyncProvider):
                 response.write_to_file(str(out_path))
 
             # Use file URI — upload to cloud storage via ObjectStorageSink
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type=media_type)
             asset.metadata["audio_type"] = "speech"
             asset.audio = AudioMetadata(channels=1, codec=response_format)

--- a/libs/connectors/stability-audio/genblaze_stability_audio/provider.py
+++ b/libs/connectors/stability-audio/genblaze_stability_audio/provider.py
@@ -29,8 +29,8 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode
@@ -246,7 +246,7 @@ class StabilityAudioProvider(SyncProvider):
                 out_path = Path(tmp)
 
             out_path.write_bytes(response.content)
-            file_url = f"file://{quote(str(out_path.resolve()))}"
+            file_url = local_file_url(out_path.resolve())
             asset = Asset(url=file_url, media_type=media_type)
             asset.metadata["audio_type"] = "music"
             asset.size_bytes = len(response.content)

--- a/libs/core/genblaze_core/_utils.py
+++ b/libs/core/genblaze_core/_utils.py
@@ -33,6 +33,39 @@ def compute_sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def local_file_url(path: Path) -> str:
+    """Build a ``file://`` URL for an absolute local path.
+
+    Uses ``Path.as_uri()`` (RFC 8089), which yields the empty-netloc form —
+    ``file:///C:/Users/...`` on Windows, ``file:///tmp/...`` on POSIX — that
+    the rest of the pipeline already expects: ``_read_local_file``,
+    ``validate_chain_input_url``, and the assemblyai connector all parse
+    ``file://`` URLs via ``url2pathname``, which handles this form correctly
+    on every platform.
+
+    The previous per-connector pattern, ``f"file://{quote(str(path))}"``,
+    percent-encoded Windows drive colons and backslashes
+    (``C:\\Users\\...`` -> ``C%3A%5CUsers%5C...``). ``urlparse`` then read
+    the entire percent-encoded string as ``netloc`` with an empty ``path``,
+    so every connector-produced asset silently failed to upload on Windows
+    (#164). Single chokepoint for all connectors + core ffmpeg providers
+    that write a local output and expose it as a ``file://`` asset.
+
+    Windows UNC paths (``\\\\server\\share\\...``) are not supported:
+    ``as_uri()`` renders them with the server in the ``netloc``, which the
+    empty-netloc-only parsers reject. Call sites write to ``tempfile``
+    output on a local drive, so this does not arise in practice.
+
+    Args:
+        path: An absolute filesystem path — callers should ``.resolve()``
+            first.
+
+    Raises:
+        ValueError: If ``path`` is not absolute (raised by ``as_uri()``).
+    """
+    return path.as_uri()
+
+
 def normalize_tenant_id(tenant_id: str | None) -> str | None:
     """Normalize a tenant identifier: strip surrounding whitespace, "" -> None.
 

--- a/libs/core/genblaze_core/providers/compositor.py
+++ b/libs/core/genblaze_core/providers/compositor.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, Track, VideoMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode, StepType
@@ -111,7 +111,7 @@ class FFmpegCompositor(SyncProvider):
 
         run_ffmpeg(cmd, timeout=self._timeout)
 
-        file_url = f"file://{quote(str(out_path.resolve()))}"
+        file_url = local_file_url(out_path.resolve())
         asset = Asset(url=file_url, media_type="video/mp4")
 
         video_meta = VideoMetadata(has_audio=True)

--- a/libs/core/genblaze_core/providers/transform.py
+++ b/libs/core/genblaze_core/providers/transform.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from urllib.parse import quote
 
+from genblaze_core._utils import local_file_url
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.asset import Asset, AudioMetadata, VideoMetadata
 from genblaze_core.models.enums import Modality, ProviderErrorCode, StepType
@@ -320,7 +320,7 @@ class FFmpegTransform(SyncProvider):
 
         run_ffmpeg(cmd, timeout=self._timeout)
 
-        file_url = f"file://{quote(str(out_path.resolve()))}"
+        file_url = local_file_url(out_path.resolve())
         if operation == "convert_format":
             media_type = _FORMAT_MEDIA_TYPES.get(ext, input_asset.media_type)
         else:

--- a/libs/core/tests/unit/test_ffmpeg_utils.py
+++ b/libs/core/tests/unit/test_ffmpeg_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from pathlib import PureWindowsPath
 from unittest.mock import patch
 
 import pytest
@@ -70,12 +71,23 @@ class TestResolveInputPath:
             resolve_input_path("http://example.com/file.mp4")
 
     def test_windows_drive_letter_file_url(self, tmp_path, monkeypatch):
-        """Regression for #132: url2pathname() strips the leading slash before a
-        Windows drive letter so Path.resolve() produces an absolute path that
-        passes the allowlist check. Simulates Windows url2pathname behavior."""
+        """Regression for #132/#164: url2pathname() strips the leading slash
+        before a Windows drive letter so Path.resolve() produces an absolute
+        path that passes the allowlist check.
+
+        The input URL is built with PureWindowsPath.as_uri() — the exact
+        form local_file_url() (the shared connector helper) produces for a
+        Windows path — so ffmpeg-chained providers accept what connectors
+        now emit. url2pathname is monkeypatched to return the pre-computed
+        real_path since a genuine Windows path string can't round-trip
+        through POSIX pathlib on this host; nturl2path.url2pathname is
+        exercised unmocked in test_utils.py::TestLocalFileUrl.
+        """
         f = tmp_path / "clip.mp4"
         f.write_bytes(b"fake")
         real_path = str(f.resolve())
+        win_url = PureWindowsPath(r"C:\tmp\clip.mp4").as_uri()
+        assert win_url == "file:///C:/tmp/clip.mp4"
         monkeypatch.setattr(
             "genblaze_core.providers._ffmpeg_utils.url2pathname",
             lambda _: real_path,
@@ -84,7 +96,7 @@ class TestResolveInputPath:
             "genblaze_core.providers._ffmpeg_utils._ALLOWED_FILE_ROOTS",
             (tmp_path.resolve(),),
         )
-        result = resolve_input_path("file:///C:/tmp/clip.mp4")
+        result = resolve_input_path(win_url)
         assert result == real_path
 
 

--- a/libs/core/tests/unit/test_transfer.py
+++ b/libs/core/tests/unit/test_transfer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import socket
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
@@ -383,18 +383,28 @@ class TestReadLocalFile:
             _read_local_file(f"file://{missing}")
 
     def test_windows_drive_letter_file_url(self, tmp_path, monkeypatch):
-        """Regression for #132: file:///C:/path yields /C:/path from urlparse.path.
-        The old unquote() kept the leading slash, causing Path.resolve() to produce
-        a drive-relative path on Windows that failed the allowlist check.
-        url2pathname() strips the leading slash before the drive letter.
+        """Regression for #132/#164: file:///C:/path yields /C:/path from
+        urlparse.path. The old unquote() kept the leading slash, causing
+        Path.resolve() to produce a drive-relative path on Windows that
+        failed the allowlist check. url2pathname() strips the leading slash
+        before the drive letter.
 
-        Simulates Windows url2pathname behavior so the regression is catchable on
-        any platform — without the patch, the fake Windows URL's path would resolve
-        outside tmp_path and be rejected.
+        The input URL is built with PureWindowsPath.as_uri() — the exact
+        form local_file_url() (the shared helper every connector now calls)
+        produces for a Windows path — so this test proves the connector ->
+        sink contract holds, not just an arbitrary hardcoded string.
+
+        url2pathname is monkeypatched to return the pre-computed real_path
+        because a genuine Windows path string ("C:\\tmp\\asset.mp4") can't
+        round-trip through POSIX pathlib.Path.resolve() on this host; the
+        actual Windows parser (nturl2path.url2pathname) is exercised
+        unmocked in test_utils.py::TestLocalFileUrl.
         """
         test_file = tmp_path / "asset.mp4"
         test_file.write_bytes(b"video data")
         real_path = str(test_file.resolve())
+        win_url = PureWindowsPath(r"C:\tmp\asset.mp4").as_uri()
+        assert win_url == "file:///C:/tmp/asset.mp4"
 
         # Simulate what Windows url2pathname does: /C:/tmp/asset.mp4 → C:\tmp\asset.mp4
         # On the fix branch url2pathname is a module-level name we can monkeypatch.
@@ -407,7 +417,7 @@ class TestReadLocalFile:
             (tmp_path.resolve(),),
         )
 
-        data, _ = _read_local_file("file:///C:/tmp/asset.mp4")
+        data, _ = _read_local_file(win_url)
         assert data == b"video data"
 
 

--- a/libs/core/tests/unit/test_utils.py
+++ b/libs/core/tests/unit/test_utils.py
@@ -6,7 +6,9 @@ import asyncio
 import hashlib
 import ipaddress
 import socket
+from pathlib import PureWindowsPath
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from genblaze_core._utils import (
@@ -15,6 +17,7 @@ from genblaze_core._utils import (
     _run_async,
     check_ssrf,
     compute_sha256,
+    local_file_url,
     probe_audio_duration,
 )
 from genblaze_core.exceptions import StorageError
@@ -198,6 +201,66 @@ class TestComputeSha256:
     def test_empty_bytes(self):
         expected = hashlib.sha256(b"").hexdigest()
         assert compute_sha256(b"") == expected
+
+
+class TestLocalFileUrl:
+    """Regression for #164: connectors built file:// URLs with
+    f"file://{quote(str(path))}", which percent-encodes Windows drive
+    colons/backslashes into an unparseable URL. local_file_url() is the
+    single chokepoint every connector + core ffmpeg provider now uses."""
+
+    def test_posix_path_yields_empty_netloc(self, tmp_path):
+        """On POSIX, as_uri() already produces the empty-netloc form the
+        sink/validator expect — behavior-preserving for mac/Linux."""
+        asset = tmp_path / "out.mp4"
+        url = local_file_url(asset)
+        assert url == asset.as_uri()
+        parsed = urlparse(url)
+        assert parsed.netloc == ""
+        assert parsed.path == str(asset)
+
+    def test_posix_path_with_special_chars_round_trips(self, tmp_path):
+        """Spaces and other reserved chars are percent-encoded the same way
+        quote() encoded them, so existing POSIX behavior is unaffected."""
+        asset = tmp_path / "my clip (final).mp4"
+        url = local_file_url(asset)
+        assert url == asset.as_uri()
+        assert urlparse(url).netloc == ""
+
+    def test_windows_drive_letter_yields_empty_netloc_not_authority(self):
+        """The core bug: on Windows, f"file://{quote(str(path))}" percent-
+        encodes 'C:\\...' into 'C%3A%5C...', which urlparse reads entirely as
+        netloc with an empty path. as_uri() instead puts the drive letter in
+        the path with an empty netloc — the form url2pathname expects.
+
+        PureWindowsPath is used (not local_file_url directly) since as_uri()
+        is defined on PurePath and this must be exercised cross-platform —
+        a real Path on this host can never produce backslash/drive-letter
+        semantics.
+        """
+        win_path = PureWindowsPath(r"C:\Users\alice\out.mp4")
+        url = win_path.as_uri()
+        assert url == "file:///C:/Users/alice/out.mp4"
+        parsed = urlparse(url)
+        assert parsed.netloc == ""  # not "C%3A%5CUsers..." as the old quote() form produced
+        assert parsed.path == "/C:/Users/alice/out.mp4"
+
+    def test_windows_uri_round_trips_via_nturl2path(self):
+        """Exercises the real Windows path parser (nturl2path — the module
+        urllib.request.url2pathname dispatches to on Windows), not a mock
+        standing in for it, against the exact URL shape local_file_url
+        produces for a Windows path. Proves the connector -> sink contract
+        holds end-to-end without needing to run on Windows.
+
+        nturl2path is pure Python with no OS-specific syscalls, so it is
+        importable and gives Windows-accurate answers on any platform.
+        """
+        import nturl2path
+
+        win_path = PureWindowsPath(r"C:\Users\alice\out.mp4")
+        url = win_path.as_uri()
+        parsed = urlparse(url)
+        assert nturl2path.url2pathname(parsed.path) == r"C:\Users\alice\out.mp4"
 
 
 class TestRunAsync:

--- a/libs/core/tests/unit/test_validate_chain_input_url.py
+++ b/libs/core/tests/unit/test_validate_chain_input_url.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import os
 import tempfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 from genblaze_core.exceptions import ProviderError
@@ -217,11 +217,23 @@ def test_double_encoded_strict_mode_rejects(tmp_path: Path) -> None:
 
 
 def test_windows_drive_letter_file_url(tmp_path: Path, monkeypatch) -> None:
-    """Regression for #132: url2pathname() strips the leading slash before a
-    Windows drive letter so Path.is_absolute() passes and Path.resolve()
-    produces the correct canonical path. Simulates Windows url2pathname."""
+    """Regression for #132/#164: url2pathname() strips the leading slash
+    before a Windows drive letter so Path.is_absolute() passes and
+    Path.resolve() produces the correct canonical path.
+
+    The URL is built with PureWindowsPath.as_uri() — the exact form
+    local_file_url() (the shared connector helper) produces for a Windows
+    path — proving assemblyai's file:// input validation (which calls this
+    function) accepts what connectors now emit. url2pathname is
+    monkeypatched to return the pre-computed real_path since a genuine
+    Windows path string can't round-trip through POSIX pathlib on this host;
+    nturl2path.url2pathname is exercised unmocked in
+    test_utils.py::TestLocalFileUrl.
+    """
     asset = tmp_path / "asset.mp4"
     real_path = str(asset.resolve())
+    win_url = PureWindowsPath(r"C:\tmp\asset.mp4").as_uri()
+    assert win_url == "file:///C:/tmp/asset.mp4"
     monkeypatch.setattr(
         "genblaze_core.providers.base.url2pathname",
         lambda _: real_path,
@@ -230,6 +242,6 @@ def test_windows_drive_letter_file_url(tmp_path: Path, monkeypatch) -> None:
     # (with allowlist) the containment check when url2pathname gives back
     # the correct Windows-resolved path.
     validate_chain_input_url(
-        "file:///C:/tmp/asset.mp4",
+        win_url,
         file_root_allowlist=(tmp_path,),
     )


### PR DESCRIPTION
Fixes #164 — on Windows, connector-produced assets could never upload to B2.

## Related
Closes #164

## Root cause
Connectors and core's ffmpeg providers built `file://` asset URLs as `f"file://{quote(str(path.resolve()))}"`. On Windows, `quote()` percent-encodes the drive colon and backslashes (`C:\Users\...` → `C%3A%5CUsers%5C...`); `urlparse` then reads the whole encoded string as `netloc` with an empty `path`, so `_read_local_file`'s allowlist check always rejected it. The sink / `validate_chain_input_url` / ffmpeg / assemblyai layers were already fixed on `main` to parse the `Path.as_uri()` form via `url2pathname` — only the URL *construction* was release-lagged.

## Fix
Add a shared `genblaze_core._utils.local_file_url(path)` helper (thin wrapper over `Path.as_uri()`, RFC 8089 empty-netloc form) and route **all** local-output `file://` construction through it — core `compositor.py`/`transform.py` plus 13 connectors. POSIX output is byte-identical to the old `quote()` form (verified), so no behavior change there and no persisted-manifest reproducibility impact.

## Panel review
Ran a 3-lens independent panel (EM / OSS / DX). All three confirmed the fix is correct — **no blocker/high findings**; OSS empirically verified the POSIX byte-identical encoding, the Windows round-trip through the real `nturl2path`, and that the security allowlist is untouched. Applied from their consensus/high-value findings:
- Migrated the one remaining **inline `as_uri()` site (nvidia `_base.py`)** onto the shared helper, so it's genuinely the single chokepoint it documents (both EM and OSS flagged this).
- Corrected a stale `quote()` reference in the assemblyai docstring; documented the UNC-path limitation and promoted `Raises:` in the helper docstring; tightened the CHANGELOG scope wording.

Declined (documented): folding `.resolve()` into the helper (judgment call — keeps symlink-resolution visible at call sites).

## Tests
Windows round-trip exercised cross-platform via `PureWindowsPath.as_uri()` + the real (unmocked) `nturl2path.url2pathname`; a regression test pins the old broken `quote()` form as rejected. Affected suites pass (core `test_utils` 32; assemblyai 58; nvidia 165; +decart/elevenlabs/google/hume/openai/stability-audio). `make lint` and `make typecheck`: pass.

Pre-existing/unrelated (confirmed on clean `main`): the 3 `test_pattern_safety` `re2`-env failures and an lmnt test-collection SDK-version mismatch in the shared dev env.