### PR TITLE
feat(maintainer): human-gated batch issue orchestration

### DIFF
--- a/.claude/agents/genblaze-maintainer.md
+++ b/.claude/agents/genblaze-maintainer.md
@@ -24,9 +24,12 @@ skills:
 You operate in one of three modes. Decide before doing anything else:
 
 - **Issue Resolution** — you were given a GitHub issue (a number like `#70`, an
-  issue URL, or "resolve/fix issue …"). Follow the **Issue Resolution Protocol**
-  below and the `checklists/issue-resolution.md` playbook. **Skip the audit
-  phases entirely** — you are shipping one focused fix, not auditing the repo.
+  issue URL, or "resolve/fix issue …"), or a **cluster** of related issues
+  (e.g. `#70, #71`) dispatched by the `batch-execute` workflow. Follow the
+  **Issue Resolution Protocol** below and the `checklists/issue-resolution.md`
+  playbook; when given more than one issue, also apply the **Cluster Resolution**
+  rules. **Skip the audit phases entirely** — you are shipping one focused fix,
+  not auditing the repo.
 - **Maintenance Audit** — you were asked to audit, scan, or check the repo (or a
   domain). Follow the **Execution Protocol** (Discovery → Assessment →
   Remediation → Reporting) further down.
@@ -140,14 +143,27 @@ below are the contract.
    - **Architecture, scalability & DRY** — fit with existing patterns, no
      duplicated/parallel logic, no needless complexity, behavior holds at load.
 
+   **Stay in your lane for additive coverage** — each lens owns its domain and
+   must assume the other two cover theirs. Security and Architecture reviewers:
+   do **not** re-litigate correctness or test quality — the Correctness lens
+   owns that; spend the freed budget going deeper and wider inside your own lens
+   (more invariants checked, more failure modes and load scenarios explored) so
+   the panel's coverage compounds instead of triplicating one concern. Raise a
+   point outside your lane only when the issue genuinely spans lenses.
+
    Each reviewer returns findings tagged **P0/P1/P2**. **Triangulate**: any P0,
    or the same issue raised by ≥2 reviewers, is **blocking** — fix it, re-verify
    (step 5), and re-review until no blocking findings remain. Only then push.
    Record the reviewers' verdicts in the PR body.
-9. **Open the PR, then stop** — `git push -u origin <branch>` then `gh pr create`
-   filling `.github/pull_request_template.md` with **`Closes #<N>`**. Reviewers
-   and labels are best-effort (don't abort the PR if they fail). **Do not merge,
-   auto-merge, or approve** — report the PR URL for human review.
+9. **Open the PR, then stop** — `git push -u origin <branch>` then `gh pr create`.
+   The PR body **must** use every section of `.github/pull_request_template.md`
+   verbatim — `## Summary`, `## Changes`, `## Test plan`, `## Related` — with
+   **`Closes #<N>`** under Related. In the **Test plan**, tick a checkbox **only
+   after you actually ran that gate this session and saw it pass** (`make test`,
+   `make lint`); leave any box you did not run unchecked and add a one-line note
+   why. Never pre-check a box you haven't verified. Reviewers and labels are
+   best-effort (don't abort the PR if they fail). **Do not merge, auto-merge, or
+   approve** — report the PR URL for human review.
 
 **If you can't reach green**, push the WIP branch and open a **draft** PR
 (`gh pr create --draft`) describing the blocker and failing output, or report
@@ -156,6 +172,38 @@ back. Never stall silently.
 For a multi-file change or new feature, write a short exec-plan in
 `docs/exec-plans/active/` and red-team it before coding. A single-file fix needs
 no planning doc.
+
+---
+
+## Cluster Resolution
+
+When `batch-execute` hands you **more than one issue**, they were clustered
+because they touch overlapping files — resolve them together on one branch and
+one PR. The single-issue protocol above still governs each fix; these rules
+layer on top:
+
+1. **One branch, off `origin/main` — never stacked.** Use `cluster/<slug>`
+   (e.g. `cluster/issues-70-71`). v1 does **not** branch off another cluster's
+   branch; if a dependency truly requires that, it should have been deferred by
+   the planner, so treat needing it as a signal to stop and report.
+2. **TDD each issue in turn** on that branch — a failing test then the smallest
+   idiomatic fix, per issue — so the combined diff stays reviewable and every
+   issue has real coverage. Keep the total diff within a reviewable size.
+3. **Separability check.** If the issues are *not* genuinely inseparable (they
+   only appeared to overlap), or the combined diff grows too large to review, or
+   one issue's right fix conflicts with another's — **open a `--draft` PR**
+   explaining the split you recommend instead of forcing a broken combined PR.
+   A draft that tells the human "these should be two PRs" is a success, not a
+   failure.
+4. **Real-conflict fallback.** If you hit an actual merge/rebase conflict against
+   `origin/main` you cannot cleanly resolve, push what you have and open a
+   **draft** PR describing the conflict. Never ship a speculative resolution.
+5. **PR closes every member.** The `## Related` section must list `Closes #<N>`
+   for **every** issue in the cluster — a missing one leaves that issue open
+   after merge (the workflow verifies this and will flag it).
+
+Everything else — verify gates, docs+CHANGELOG, the triangulated 3-reviewer
+check, and **stop for human review, never merge** — is unchanged.
 
 ---
 

--- a/.claude/agents/genblaze-maintainer/README.md
+++ b/.claude/agents/genblaze-maintainer/README.md
@@ -1,14 +1,18 @@
 # Genblaze Maintainer
 
 The **Genblaze Maintainer** is an autonomous Claude Code sub-agent that serves as the
-dedicated guardian of the Genblaze repository. It runs in one of two modes:
+dedicated guardian of the Genblaze repository. It runs in one of these modes:
 
-- **Issue Resolution** — takes a GitHub issue from triage to a **merge-ready PR**:
-  branches off `origin/main`, fixes it with TDD, verifies, runs a triangulated
-  three-reviewer check, opens the PR, then **stops for human review**.
+- **Issue Resolution** — takes a GitHub issue (or a **cluster** of related
+  issues) from triage to a **merge-ready PR**: branches off `origin/main`, fixes
+  it with TDD, verifies, runs a triangulated three-reviewer check, opens the PR,
+  then **stops for human review**.
 - **Maintenance Audit** — audits the codebase across six domains (functional
   integrity, security, code quality, documentation, AI agent standards, and
   dependency health) and produces a structured report with prioritized findings.
+- **Batch** — reviews **all** open issues at once, clusters and dependency-orders
+  them, and (after human approval) resolves each cluster into a PR. Driven by two
+  workflows with a hard approval gate between them; see **Batch mode** below.
 
 ## Quick Start
 
@@ -55,6 +59,45 @@ The agent follows a four-phase execution protocol:
 3. **Remediation** — Fixes issues (if authorized), one commit per fix, tests after each
 4. **Reporting** — Writes a structured report to `docs/exec-plans/active/`
 
+### Batch mode
+
+Batch mode puts the maintainer in charge of the **whole open-issue list** while
+keeping a human firmly in control. It is deliberately split into two workflows
+with a hard approval gate between them, because a workflow cannot pause for human
+input mid-run — so the gate becomes an explicit, auditable boundary.
+
+```
+# 1. Plan — review all issues, cluster + order them, write an approval-gated doc, STOP.
+/batch-plan                       # (or: Workflow tool, name: "batch-plan")
+
+# → review docs/exec-plans/active/batch-plan-<date>.md, then:
+
+# 2. Execute — validate the approved plan against live state, open one PR per cluster.
+/batch-execute {"docPath": "docs/exec-plans/active/batch-plan-<date>.md", "dryRun": true}
+/batch-execute {"docPath": "docs/exec-plans/active/batch-plan-<date>.md"}
+```
+
+**Safety model:**
+
+- **Deterministic core, tested.** Clustering, plan-doc integrity, and all git
+  hygiene live in `tools/batch_*.py` under `make test` — not in prose. Agents
+  only do the one fuzzy step (estimating which files an issue touches) and act as
+  pipes to those CLIs.
+- **Preflight never touches your checkout.** It fails fast on a dirty tree, and
+  fast-forwards local `main` only when `main` is not checked out and strictly
+  behind — never switching, stashing, or committing.
+- **The gate is enforced, not assumed.** The plan doc embeds the `origin/main`
+  SHA and a content token; `batch-execute` re-validates against live state and
+  aborts if main advanced, the doc was hand-edited, or a planned issue closed.
+- **Conflict-aware, capped clusters.** Issues sharing real (non-"hot") files
+  cluster into one PR up to a size cap; oversized or dependent work is deferred to
+  a re-plan rather than stacked (stacked branches break when a prerequisite is
+  squash-merged). Each cluster still goes through the full per-PR bar and opens a
+  **draft** PR if it hits a real conflict.
+- **Conservative cleanup.** `gc` prunes only merged, pushed leftover branches
+  with `git branch -d` (never `-D`), skips dirty worktrees, and reports anything
+  it retains. Nothing you haven't shipped is ever destroyed.
+
 ## Domains
 
 | Domain | Priority | What It Checks |
@@ -73,7 +116,7 @@ The agent follows a four-phase execution protocol:
   genblaze-maintainer.md        # Agent definition (frontmatter + prompt)
   genblaze-maintainer/
     README.md                   # This file
-    run.sh                      # CLI launcher script
+    run.sh                      # CLI launcher script (single-issue / audit)
     config.json                 # Agent configuration
     checklists/
       issue-resolution.md       # Issue → merge-ready PR playbook (with triangulated review)
@@ -83,6 +126,13 @@ The agent follows a four-phase execution protocol:
       documentation.md          # Doc accuracy and completeness
       agent-standards.md        # AI agent optimization
       dependencies.md           # Supply chain health
+.claude/workflows/
+  batch-plan.js                 # Batch mode: review all issues → approval-gated plan doc
+  batch-execute.js              # Batch mode: validate plan → one PR per cluster
+tools/
+  batch_cluster.py              # Deterministic clustering (tested)
+  batch_plandoc.py              # Plan-doc write + drift-proof validation (tested)
+  batch_gitsteward.py           # Safe preflight + conservative gc (tested)
 ```
 
 ## Permissions

--- a/.claude/workflows/batch-execute.js
+++ b/.claude/workflows/batch-execute.js
@@ -1,0 +1,201 @@
+// Batch Maintainer — EXECUTE phase (runs only against an approved plan).
+//
+// The second half of the two-workflow batch maintainer. Given the plan doc that
+// `batch-plan` produced and the human approved, it: re-validates the plan against
+// LIVE repo state (aborting if main advanced or the issue set drifted — the
+// approval gate is enforced, not assumed), optionally prints a dry-run dispatch,
+// then dispatches ONE genblaze-maintainer executor per executable cluster in
+// isolated worktrees. Each executor runs the unchanged Issue Resolution Protocol
+// (TDD → verify → triangulated review → one merge-ready PR → STOP). Finally it
+// tidies leftover worktrees/branches via the tested git steward.
+//
+// v1 scope: only clusters marked `executable` in the plan run (dependency layer 0
+// + within the size cap). Deferred clusters are NOT stacked — they wait for a
+// re-plan after their prerequisites merge. Nothing is ever auto-merged.
+//
+// Invoke with args: { docPath: "docs/exec-plans/active/batch-plan-YYYY-MM-DD.md",
+//                      dryRun?: true }
+
+export const meta = {
+  name: 'batch-execute',
+  description:
+    'Validate an approved batch plan against live state, then dispatch one genblaze-maintainer executor per executable cluster into merge-ready PRs (never merges)',
+  phases: [
+    { title: 'Validate', detail: 'drift-check the approved plan' },
+    { title: 'Execute', detail: 'one maintainer per cluster → PR' },
+    { title: 'Verify', detail: 'each PR closes its member issues' },
+    { title: 'Cleanup', detail: 'tidy worktrees + merged branches' },
+  ],
+}
+
+const VALIDATE_SCHEMA = {
+  type: 'object',
+  required: ['valid', 'clusters'],
+  properties: {
+    valid: { type: 'boolean' },
+    reason: { type: 'string' },
+    base_sha: { type: 'string' },
+    clusters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['slug', 'issues', 'pr_mode'],
+        properties: {
+          slug: { type: 'string' },
+          issues: { type: 'array', items: { type: 'integer' } },
+          pr_mode: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const EXEC_SCHEMA = {
+  type: 'object',
+  required: ['slug', 'status'],
+  properties: {
+    slug: { type: 'string' },
+    status: { type: 'string' }, // pr | draft | blocked
+    pr_url: { type: ['string', 'null'] },
+    issues: { type: 'array', items: { type: 'integer' } },
+    note: { type: 'string' },
+  },
+}
+
+const docPath = args && args.docPath
+if (!docPath) {
+  throw new Error('batch-execute requires args.docPath (the approved plan doc).')
+}
+const dryRun = !!(args && args.dryRun)
+
+phase('Validate')
+// Enforce the approval gate: re-derive live state and run the tested validator.
+// It aborts on a hand-edited doc (token mismatch), an advanced main (SHA drift),
+// or a planned issue that has since closed.
+const check = await agent(
+  `Validate the approved batch plan before any execution. Steps:\n` +
+    `1. \`git fetch origin --quiet\` then capture live SHA: \`git rev-parse origin/main\`.\n` +
+    `2. Live open issues: \`gh issue list --state open --json number --limit 200\` ` +
+    `-> a JSON array of numbers, e.g. [70,71].\n` +
+    `3. Run:\n` +
+    `   \`python tools/batch_plandoc.py validate --doc ${docPath} --sha <LIVE_SHA> ` +
+    `--open-issues '<JSON_ARRAY>'\`\n` +
+    `   If it exits non-zero, set valid=false and put its stderr in reason.\n` +
+    `4. If valid, parse the BATCH-PLAN-META block in ${docPath} and return the ` +
+    `clusters whose "executable" is true (slug, issues, pr_mode) in \`clusters\`.\n` +
+    `Do not modify the doc.`,
+  { label: 'validate-plan', phase: 'Validate', schema: VALIDATE_SCHEMA, effort: 'low' },
+)
+
+if (!check || !check.valid) {
+  const reason = (check && check.reason) || 'validation failed'
+  log(`Plan rejected — not executing: ${reason}`)
+  return { stopped: 'validation', reason }
+}
+
+const clusters = check.clusters || []
+if (clusters.length === 0) {
+  log('No executable clusters in the approved plan.')
+  return { stopped: 'empty', reason: 'nothing executable' }
+}
+
+// Dry-run: show exactly what would be dispatched, spawn nothing.
+const dispatch = clusters.map((c) => ({
+  slug: c.slug,
+  branch: c.issues.length > 1 ? `cluster/${c.slug}` : `fix/issue-${c.issues[0]}`,
+  base: 'origin/main',
+  closes: c.issues.map((n) => `Closes #${n}`).join(', '),
+  pr_mode: c.pr_mode,
+}))
+log(
+  `Dispatch plan (${dispatch.length} cluster(s)):\n` +
+    dispatch.map((d) => `  • ${d.branch} (base ${d.base}) → ${d.closes}`).join('\n'),
+)
+if (dryRun) {
+  return { dry_run: true, dispatch }
+}
+
+phase('Execute')
+// One maintainer per cluster, in isolated worktrees so parallel clusters never
+// collide. Each runs the full unchanged protocol and stops at a merge-ready PR.
+const results = (
+  await parallel(
+    clusters.map((c) => () =>
+      agent(
+        `You are the Genblaze Maintainer in ISSUE RESOLUTION mode for a CLUSTER of ` +
+          `issues: ${c.issues.map((n) => `#${n}`).join(', ')}.\n\n` +
+          `Follow your Issue Resolution Protocol exactly, with these cluster rules:\n` +
+          `- Branch off origin/main as \`${c.issues.length > 1 ? `cluster/${c.slug}` : `fix/issue-${c.issues[0]}`}\`. ` +
+          `Do NOT branch off any other cluster's branch (no stacking).\n` +
+          `- Resolve ALL listed issues on this one branch with TDD, smallest ` +
+          `idiomatic fixes. If they turn out NOT to be safely separable within a ` +
+          `reviewable diff, or you hit a real conflict, open a DRAFT PR explaining ` +
+          `why instead of a broken combined PR.\n` +
+          `- Verify (make test/lint/typecheck/coverage), update docs + CHANGELOG, ` +
+          `run the triangulated 3-reviewer check, resolve blocking findings.\n` +
+          `- Open ONE PR whose Related section lists ${c.issues.map((n) => `Closes #${n}`).join(', ')}. ` +
+          `STOP for human review — never merge, auto-merge, or approve.\n` +
+          `Return slug="${c.slug}", the PR url, status (pr|draft|blocked), and a note.`,
+        {
+          label: `exec:${c.slug}`,
+          phase: 'Execute',
+          agentType: 'genblaze-maintainer',
+          isolation: 'worktree',
+          schema: EXEC_SCHEMA,
+        },
+      ),
+    ),
+  )
+).filter(Boolean)
+
+phase('Verify')
+// Post-condition: every opened PR must actually reference each member issue —
+// otherwise an issue silently stays open after a "successful" batch.
+const verified = await parallel(
+  results
+    .filter((r) => r.pr_url)
+    .map((r) => () =>
+      agent(
+        `Check that PR ${r.pr_url} closes every one of these issues in its body: ` +
+          `${r.issues.map((n) => `#${n}`).join(', ')}. Run \`gh pr view ${r.pr_url} ` +
+          `--json body\` and confirm a "Closes #N" (or "Fixes/Resolves #N") exists ` +
+          `for each. Return {slug:"${r.slug}", ok:true|false, missing:[...]}.`,
+        {
+          label: `verify:${r.slug}`,
+          phase: 'Verify',
+          effort: 'low',
+          schema: {
+            type: 'object',
+            required: ['slug', 'ok'],
+            properties: {
+              slug: { type: 'string' },
+              ok: { type: 'boolean' },
+              missing: { type: 'array', items: { type: 'integer' } },
+            },
+          },
+        },
+      ),
+    ),
+).then((v) => v.filter(Boolean))
+
+phase('Cleanup')
+// Deterministic, conservative tidy: prune merged leftover branches/worktrees.
+// Never force-deletes; skips dirty worktrees; reports anything it retains.
+const cleanup = await agent(
+  `Run EXACTLY this and return its parsed JSON, changing nothing else:\n` +
+    `  python tools/batch_gitsteward.py gc\n` +
+    `This prunes only worktrees/branches whose PRs are already merged.`,
+  { label: 'gc', phase: 'Cleanup', effort: 'low' },
+)
+
+const missingCloses = verified.filter((v) => !v.ok)
+return {
+  opened: results.map((r) => ({ slug: r.slug, status: r.status, pr_url: r.pr_url })),
+  pr_body_check_failures: missingCloses,
+  cleanup,
+  note:
+    'All PRs are merge-ready and awaiting human review — nothing was merged. ' +
+    (missingCloses.length
+      ? 'WARNING: some PRs are missing Closes links — fix before merging.'
+      : ''),
+}

--- a/.claude/workflows/batch-plan.js
+++ b/.claude/workflows/batch-plan.js
@@ -1,0 +1,200 @@
+// Batch Maintainer — PLAN phase (read-only, stops for human approval).
+//
+// This is the first half of the two-workflow batch maintainer. It reviews every
+// open GitHub issue, has each scouted for the files it would touch, then feeds
+// those estimates through the DETERMINISTIC, unit-tested clustering + plan-doc
+// tools in `tools/batch_*.py`. It writes an approval-gated plan document and
+// STOPS. No branches, no code, no PRs — the human reads the plan and, if happy,
+// runs `batch-execute` against it.
+//
+// Why the heavy lifting lives in Python, not here: clustering and the approval
+// token must be deterministic and testable (`pytest tools/tests/`). The agents
+// below are thin — they scout (the one irreducibly fuzzy step) and act as pipes
+// to the tested CLIs. See `.claude/agents/genblaze-maintainer.md`.
+
+export const meta = {
+  name: 'batch-plan',
+  description:
+    'Review all open issues, cluster & dependency-order them via the tested Python core, write an approval-gated plan doc, then stop for human review',
+  phases: [
+    { title: 'Preflight', detail: 'clean tree + sync main safely' },
+    { title: 'Scout', detail: 'estimate touched files per open issue' },
+    { title: 'Plan', detail: 'deterministic clustering + plan doc' },
+    { title: 'Red-team', detail: 'adversarial review of the plan' },
+  ],
+}
+
+const PREFLIGHT_SCHEMA = {
+  type: 'object',
+  additionalProperties: true,
+  required: ['ok', 'main_action', 'messages'],
+  properties: {
+    ok: { type: 'boolean' },
+    main_action: { type: 'string' },
+    dirty: { type: 'boolean' },
+    messages: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const ISSUES_SCHEMA = {
+  type: 'object',
+  required: ['issues'],
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['number', 'title'],
+        properties: {
+          number: { type: 'integer' },
+          title: { type: 'string' },
+          labels: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+  },
+}
+
+// Matches the scout row shape consumed by tools/batch_cluster.py.
+const SCOUT_SCHEMA = {
+  type: 'object',
+  required: ['number', 'touched_files', 'deps'],
+  properties: {
+    number: { type: 'integer' },
+    type: { type: 'string' },
+    touched_files: { type: 'array', items: { type: 'string' } },
+    deps: { type: 'array', items: { type: 'integer' } },
+    skip_reason: { type: ['string', 'null'] },
+  },
+}
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['doc_path', 'executable_clusters', 'deferred_clusters'],
+  properties: {
+    doc_path: { type: 'string' },
+    base_sha: { type: 'string' },
+    executable_clusters: { type: 'integer' },
+    deferred_clusters: { type: 'integer' },
+    summary: { type: 'string' },
+  },
+}
+
+// How many issues to scout at most (blast-radius cap). Override via args.limit.
+const LIMIT = (args && args.limit) || 40
+
+phase('Preflight')
+const pre = await agent(
+  `Run EXACTLY this and nothing else, then return its parsed JSON:\n` +
+    `  python tools/batch_gitsteward.py preflight\n` +
+    `Do not modify any files. Do not switch branches. Just report what the ` +
+    `command output. The command exits non-zero when the repo is not safe to ` +
+    `start a batch (dirty tree, main behind while checked out, diverged).`,
+  { label: 'preflight', phase: 'Preflight', schema: PREFLIGHT_SCHEMA, effort: 'low' },
+)
+
+if (!pre || !pre.ok) {
+  const msgs = (pre && pre.messages) || ['preflight failed']
+  log(`Preflight blocked the batch: ${msgs.join(' | ')}`)
+  return {
+    stopped: 'preflight',
+    reason: msgs,
+    note: 'Fix the working tree / main branch state, then re-run batch-plan.',
+  }
+}
+log(`Preflight OK (main: ${pre.main_action}).`)
+
+phase('Scout')
+const listed = await agent(
+  `List open issues as JSON. Run:\n` +
+    `  gh issue list --state open --json number,title,labels --limit ${LIMIT}\n` +
+    `Return {"issues": [...]} with labels flattened to an array of label names.`,
+  { label: 'list-issues', phase: 'Scout', schema: ISSUES_SCHEMA, effort: 'low' },
+)
+const issues = (listed && listed.issues) || []
+if (issues.length === 0) {
+  log('No open issues to plan.')
+  return { stopped: 'empty', reason: ['no open issues'] }
+}
+log(`Scouting ${issues.length} open issue(s)…`)
+
+// One cheap scout per issue, in parallel. Read-only: read the issue, look for an
+// existing PR/branch (=> skip_reason), estimate the files a fix would touch, and
+// note any explicit "depends on #N" links. This is the only non-deterministic
+// step; everything downstream is deterministic Python.
+const scout = (
+  await parallel(
+    issues.map((iss) => () =>
+      agent(
+        `You are scouting GitHub issue #${iss.number} ("${iss.title}") in the ` +
+          `genblaze repo to feed the deterministic clustering tool. READ-ONLY.\n` +
+          `1. \`gh issue view ${iss.number} --comments\` to understand it.\n` +
+          `2. Check for existing work: \`gh pr list --search "closes #${iss.number}"\` ` +
+          `and \`git branch -a --list "*issue-${iss.number}*"\`. If found, set ` +
+          `skip_reason and empty touched_files.\n` +
+          `3. Otherwise estimate the repo-relative files a fix would touch (grep/` +
+          `glob only — do NOT edit). Be conservative and specific.\n` +
+          `4. Record explicit dependencies (issue numbers this one says it depends ` +
+          `on / is blocked by) in deps.\n` +
+          `Return the scout row for issue ${iss.number}.`,
+        {
+          label: `scout:#${iss.number}`,
+          phase: 'Scout',
+          schema: SCOUT_SCHEMA,
+          effort: 'low',
+        },
+      ),
+    ),
+  )
+).filter(Boolean)
+
+phase('Plan')
+// Pipe the scout rows through the tested CLIs. This agent is a dumb pipe: it
+// writes the scout JSON, runs batch_cluster.py, captures origin/main's SHA, and
+// runs batch_plandoc.py write. It must not hand-edit any of the JSON.
+const plan = await agent(
+  `Produce the batch plan document using ONLY the provided tools. Steps:\n` +
+    `1. Write this scout JSON to a temp file (e.g. /tmp/scout.json):\n` +
+    '```json\n' +
+    JSON.stringify(scout, null, 2) +
+    '\n```\n' +
+    `2. Cluster: \`python tools/batch_cluster.py --scout /tmp/scout.json > /tmp/plan.json\`\n` +
+    `3. Capture base SHA: \`git rev-parse origin/main\` and today's date: \`date +%F\`.\n` +
+    `4. Write the doc:\n` +
+    `   \`python tools/batch_plandoc.py write --plan /tmp/plan.json --sha <SHA> ` +
+    `--date <DATE> --out docs/exec-plans/active/batch-plan-<DATE>.md\`\n` +
+    `Do not alter the JSON between steps. Return doc_path, base_sha, and counts ` +
+    `of executable vs deferred clusters from /tmp/plan.json, plus a one-paragraph ` +
+    `summary of what would run now.`,
+  { label: 'write-plan', phase: 'Plan', schema: PLAN_SCHEMA },
+)
+
+if (!plan || !plan.doc_path) {
+  log('Planner did not produce a plan doc.')
+  return { stopped: 'plan', reason: ['clustering/plan-doc step failed'] }
+}
+
+phase('Red-team')
+// Advisory only — findings are appended to the doc for the human, not blocking.
+const redteam = await agent(
+  `Adversarially review the batch plan at ${plan.doc_path}. You are a skeptical ` +
+    `senior maintainer. Focus on: clusters that will conflict despite touching ` +
+    `disjoint files (shared imports, new sibling dirs, a core signature change), ` +
+    `oversized combined PRs, and wrong dependency ordering. For each concern give ` +
+    `the specific issues and a one-line fix. Append a "## Red-team review" section ` +
+    `to the doc with your findings (or "No blocking concerns."). Return a short ` +
+    `summary string.`,
+  { label: 'red-team', phase: 'Red-team' },
+)
+
+return {
+  doc_path: plan.doc_path,
+  base_sha: plan.base_sha,
+  executable_clusters: plan.executable_clusters,
+  deferred_clusters: plan.deferred_clusters,
+  summary: plan.summary,
+  red_team: redteam,
+  next: `Review ${plan.doc_path}. To execute the approved clusters, run the ` +
+    `batch-execute workflow with args {"docPath": "${plan.doc_path}"}. ` +
+    `Add "dryRun": true first to preview the dispatch without opening PRs.`,
+}

--- a/docs/exec-plans/active/maintainer-batch-issue-orchestration.md
+++ b/docs/exec-plans/active/maintainer-batch-issue-orchestration.md
@@ -1,0 +1,84 @@
+<!-- last_verified: 2026-07-21 -->
+# Maintainer Batch Issue Orchestration
+
+> **Status**: Implemented — deterministic core + workflows landed; runtime
+> (multi-agent) execution validated only by design + the tested core, not yet by
+> a live batch run.
+> **Owner**: jeronimodeleon
+> **Extends**: [`maintainer-autonomous-issue-to-pr-loop.md`](maintainer-autonomous-issue-to-pr-loop.md)
+> — this realizes the "triage → batch → branch → implement → review → push → loop"
+> vision with a concrete, human-gated, two-workflow architecture. Reuses the
+> existing `genblaze-maintainer` subagent unchanged as the per-cluster executor.
+
+## Goal
+
+Let a maintainer own the **entire open-issue list**: review all open issues,
+group the ones that share code, order them by dependency, and — after explicit
+human approval — resolve each group into a merge-ready PR. It must be safe
+(no data loss, human-gated merge), production-grade (not patchy), and scalable.
+
+## Architecture: two layers, gate between them
+
+The maintainer's single-issue contract is excellent and unchanged; the new work
+is a **portfolio layer above it**, deliberately not crammed into agent prose.
+
+- **Deterministic core (tested Python)** — the logic that must be correct lives
+  in `tools/batch_*.py`, under `make test`, not in an LLM prompt:
+  - `batch_cluster.py` — hot-file exclusion, file-overlap connected components,
+    explicit-dependency edges, DAG layering, cluster-size cap. Pure function
+    (`build_plan`) + CLI. Oversized/overlapping components serialize; dependent
+    layers defer.
+  - `batch_plandoc.py` — writes the plan doc with an embedded `origin/main` SHA +
+    a content **approval token** (`sha256(base_sha + canonical(clusters))`), and
+    a `validate` command that refuses execution on token mismatch (hand-edit),
+    SHA drift (main advanced), or a closed planned issue.
+  - `batch_gitsteward.py` — `preflight` (never switches/stashes/commits; FF `main`
+    only when not checked out and strictly behind) and `gc` (prunes only merged,
+    pushed leftover branches with `git branch -d`, never `-D`; skips dirty
+    worktrees; reports retained).
+- **Orchestration (two workflows)** — thin scripts that call the tested CLIs and
+  fan out agents:
+  - `.claude/workflows/batch-plan.js` — preflight → scout each issue (the one
+    fuzzy step: estimate touched files) → cluster → write plan doc → advisory
+    red-team → **stop**.
+  - `.claude/workflows/batch-execute.js` — validate against live state → optional
+    `dryRun` dispatch preview → one `genblaze-maintainer` per executable cluster
+    (isolated worktree, base `origin/main`) → verify each PR closes its members →
+    `gc`.
+
+## Key decisions (and why)
+
+- **Two workflows, not one** — a workflow cannot pause for human input, so the
+  approval gate is the boundary between `batch-plan` and `batch-execute`. The
+  gate is *enforced* by the SHA+token+drift validator, not by convention.
+- **One PR per cluster, capped** — related issues combine into one reviewable PR
+  (`Closes #a`, `Closes #b`) only when genuinely inseparable and under a size
+  cap; above the cap they split into sequential PRs. Keeps diffs reviewable.
+- **No stacked branches in v1** — dependent clusters are deferred to a re-plan
+  after prerequisites merge, rather than branched off each other. Stacking breaks
+  when a human squash-merges the prerequisite (stale base, phantom diffs).
+- **Clustering is advisory** — its input is an LLM file estimate, so it can miss
+  a conflict. Backstops: hot-file exclusion, the human gate, and the executor's
+  real-conflict → draft-PR fallback.
+- **Never destroys unshipped work** — preflight and `gc` only ever do safe,
+  reversible git operations; anything risky is reported, not performed.
+
+## Tests
+
+- `tools/tests/test_batch_cluster.py` — disjoint / overlapping / hot-file-only /
+  dependency-chain / cycle / oversized / skipped / normalization (13).
+- `tools/tests/test_batch_plandoc.py` — round-trip + every rejection path
+  (tamper, advanced main, closed issue) + token stability (9).
+- `tools/tests/test_batch_gitsteward.py` — real throwaway repos: clean/dirty/
+  behind/checked-out/diverged/no-local-main preflight; gc merged/squash/in-flight/
+  non-matching/worktree-clean/worktree-dirty (12).
+
+## Follow-ups
+
+- Runtime shakeout: run `batch-plan` then `batch-execute --dryRun` against the
+  live issue list and confirm the dispatch plan reads correctly before a first
+  real execution.
+- Consider symbol/import-graph edges in clustering if file-overlap false
+  negatives bite in practice (intentionally deferred as over-engineering for v1).
+- Permissions: `batch-execute` needs the same git/gh permissions as single-issue
+  Issue Resolution mode (see the maintainer README).

--- a/docs/features/maintainer-agent.md
+++ b/docs/features/maintainer-agent.md
@@ -1,10 +1,12 @@
-<!-- last_verified: 2026-07-10 -->
+<!-- last_verified: 2026-07-21 -->
 # Maintainer Agent
 
-The `genblaze-maintainer` is an autonomous Claude Code agent that operates as the repo's primary guardian. It runs in an isolated git worktree with edit permissions and handles three distinct modes: resolving a specific GitHub issue end-to-end, autonomously discovering and fixing the highest-priority open issue when invoked with no prompt, or running a broad maintenance audit across six quality domains.
+The `genblaze-maintainer` is an autonomous Claude Code agent that operates as the repo's primary guardian. It runs in an isolated git worktree with edit permissions and handles four modes: resolving a specific GitHub issue (or a cluster of related issues) end-to-end, autonomously discovering and fixing the highest-priority open issue when invoked with no prompt, running a broad maintenance audit across six quality domains, or — in **Batch mode** — reviewing the entire open-issue list and resolving it cluster-by-cluster behind a human approval gate.
 
 - **Agent definition**: `.claude/agents/genblaze-maintainer.md`
 - **Checklists**: `.claude/agents/genblaze-maintainer/checklists/`
+- **Batch workflows**: `.claude/workflows/batch-plan.js`, `.claude/workflows/batch-execute.js`
+- **Deterministic core**: `tools/batch_cluster.py`, `tools/batch_plandoc.py`, `tools/batch_gitsteward.py` (tested under `make test`)
 - **Isolation**: `worktree` — each run gets a clean copy of the repo; no shared state with other agents
 
 ---
@@ -16,8 +18,33 @@ The first thing the agent decides is which mode it's in. These modes are mutuall
 | Invocation | Mode |
 |---|---|
 | `#70`, issue URL, "fix issue…" | Issue Resolution |
+| A cluster of issues (from `batch-execute`) | Issue Resolution (Cluster Resolution rules) |
 | No prompt, no issue, no scope | Autonomous Triage |
 | "audit", "scan", "check the repo" | Maintenance Audit |
+| `batch-plan` / `batch-execute` workflow | Batch (see below) |
+
+### Batch mode (all open issues)
+
+Batch mode reviews every open issue at once and is split into two workflows with
+a **hard human approval gate** between them (a workflow cannot pause mid-run, so
+the gate is the boundary between the two):
+
+1. **`batch-plan`** (read-only) — preflight-syncs `main`, scouts each open issue
+   for the files it would touch, then runs the deterministic, unit-tested
+   `tools/batch_*.py` core to cluster issues by shared files, dependency-order
+   them, and write an **approval-gated plan doc** to `docs/exec-plans/active/`.
+   Then it stops.
+2. **`batch-execute`** (after you approve) — re-validates the plan against live
+   state (aborts if `main` advanced, the doc was hand-edited, or a planned issue
+   closed), then dispatches one `genblaze-maintainer` executor per **executable**
+   cluster (dependency layer 0, within the size cap) in isolated worktrees off
+   `origin/main`. Each opens one merge-ready PR closing its member issues and
+   stops for human review. Dependent/oversized clusters are deferred to a
+   re-plan, never stacked. Cleanup prunes only merged branches, never force-deletes.
+
+The judgment call (which files an issue touches) is the only non-deterministic
+step; clustering, the approval token, and all git hygiene are deterministic and
+tested. See the exec-plan `maintainer-batch-issue-orchestration.md`.
 
 ---
 

--- a/tools/batch_cluster.py
+++ b/tools/batch_cluster.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+Deterministic clustering core for the batch maintainer.
+
+Why this exists
+---------------
+The batch maintainer reviews every open GitHub issue and decides which ones
+can be worked together, in what order, and which must wait. That decision
+MUST be deterministic and testable — if it lived in an LLM prompt it would
+differ every run and there would be no way to unit-test "did we group these
+correctly?". So the judgment call ("which files does issue #70 touch?") stays
+with the scout agent, but the grouping algorithm that turns those estimates
+into an execution plan lives here, in plain Python, under ``make test``.
+
+The safety model (see ``.claude/agents/genblaze-maintainer.md``)
+----------------------------------------------------------------
+Clustering is *advisory*, not a guarantee of merge-safety — its input is an
+LLM's file estimate, which can be wrong. Two independent guards backstop it:
+
+1. **Hot-file exclusion.** Files that almost every change touches (CHANGELOG,
+   entry-points, the JSON spec, the AGENTS doc map) are NOT used as overlap
+   signal — otherwise every issue would collapse into one giant cluster.
+   They are recorded as a serialization *note* for the human instead.
+2. **The executor's rebase check.** The genblaze-maintainer opens a draft PR
+   if a cluster hits a real conflict at rebase time. Clustering only has to
+   be good enough to keep parallel work mostly disjoint; it does not have to
+   be perfect.
+
+What this module produces
+-------------------------
+A plan of *clusters*. Every cluster carries whether it is executable **now**
+(dependency layer 0 and within the size cap) or deferred to a re-plan after
+its prerequisites merge. v1 deliberately does NOT stack dependent branches on
+each other's git base — deeper dependency layers are deferred, not stacked,
+because a human squash-merge of a prerequisite would leave a dependent branch
+with a stale base (data-loss / phantom-diff trap).
+
+Input (scout JSON, a list of):
+    {"number": 70, "type": "bug", "touched_files": ["libs/core/x.py"],
+     "deps": [66], "skip_reason": null}
+
+Output (plan JSON): see ``build_plan`` / ``Plan``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import PurePosixPath
+
+# Files touched by so many unrelated changes that treating them as "shared
+# work" would wrongly merge every issue into one cluster. They are handled as
+# a merge-time serialization note, not as a clustering key. fnmatch globs over
+# repo-relative POSIX paths.
+HOT_FILE_PATTERNS: tuple[str, ...] = (
+    "CHANGELOG.md",
+    "README.md",
+    "AGENTS.md",
+    "**/pyproject.toml",
+    "pyproject.toml",
+    "libs/spec/**",
+    "docs/exec-plans/**",
+)
+
+# A cluster combined into a single PR must stay reviewable. Above either ceiling
+# the overlapping component is treated as inherently serial: only its first
+# issue runs now, the rest defer to a re-plan after that PR merges.
+DEFAULT_MAX_ISSUES = 3
+DEFAULT_MAX_FILES = 12
+
+# defer_reason values (empty string => executable now)
+DEFER_AWAITING_PREREQ = "awaiting-prerequisite"
+DEFER_OVERSIZED = "oversized-serialize"
+DEFER_CYCLE = "dependency-cycle"
+
+
+@dataclass(frozen=True)
+class Config:
+    max_issues: int = DEFAULT_MAX_ISSUES
+    max_files: int = DEFAULT_MAX_FILES
+    hot_patterns: tuple[str, ...] = HOT_FILE_PATTERNS
+
+
+@dataclass
+class Cluster:
+    id: str
+    slug: str
+    issues: list[int]
+    touched_files: list[str]  # non-hot files, sorted, deduped
+    hot_files: list[str]  # hot files any member touches (serialization note)
+    pr_mode: str  # "combined" (>1 issue, one PR) | "single"
+    layer: int  # dependency depth; 0 == no prerequisite clusters
+    executable: bool  # runnable this batch (layer 0 and within cap)
+    blocked_by: list[str] = field(default_factory=list)  # cluster ids
+    defer_reason: str = ""
+
+
+@dataclass
+class Plan:
+    clusters: list[Cluster]
+    skipped: list[dict]  # issues the scout excluded, with reasons
+    notes: list[str]  # human-facing warnings (hot-file collisions, cycles)
+
+    def to_dict(self) -> dict:
+        return {
+            "clusters": [asdict(c) for c in self.clusters],
+            "skipped": self.skipped,
+            "notes": self.notes,
+        }
+
+
+def _is_hot(path: str, patterns: tuple[str, ...]) -> bool:
+    """True if ``path`` matches any hot-file glob (repo-relative POSIX)."""
+    p = PurePosixPath(path.strip()).as_posix()
+    return any(fnmatch.fnmatch(p, pat) for pat in patterns)
+
+
+def _normalize(paths: list[str]) -> list[str]:
+    """Repo-relative POSIX, whitespace-trimmed, deduped, sorted.
+
+    Normalizing here is what makes clustering deterministic despite the scout's
+    free-form file estimates — same set of files always yields the same key.
+    """
+    seen = {PurePosixPath(p.strip()).as_posix() for p in paths if p.strip()}
+    return sorted(seen)
+
+
+class _UnionFind:
+    """Minimal union-find keyed by issue number."""
+
+    def __init__(self, items: list[int]) -> None:
+        self._parent = {i: i for i in items}
+
+    def find(self, x: int) -> int:
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # path compression
+        while self._parent[x] != root:
+            self._parent[x], x = root, self._parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            # Keep the smaller root for deterministic component labels.
+            lo, hi = sorted((ra, rb))
+            self._parent[hi] = lo
+
+    def components(self) -> dict[int, list[int]]:
+        groups: dict[int, list[int]] = {}
+        for item in self._parent:
+            groups.setdefault(self.find(item), []).append(item)
+        return {root: sorted(members) for root, members in groups.items()}
+
+
+def _slug(issues: list[int]) -> str:
+    return "issues-" + "-".join(str(n) for n in sorted(issues))
+
+
+def build_plan(scout: list[dict], config: Config | None = None) -> Plan:
+    """Turn scout results into a deterministic, dependency-ordered cluster plan.
+
+    Pure function — no I/O, no clock, no git — so it is fully unit-testable.
+    """
+    cfg = config or Config()
+    notes: list[str] = []
+
+    # 1. Partition scouted issues into active vs skipped.
+    active: dict[int, dict] = {}
+    skipped: list[dict] = []
+    for row in scout:
+        num = int(row["number"])
+        if row.get("skip_reason"):
+            skipped.append({"number": num, "reason": row["skip_reason"]})
+            continue
+        active[num] = row
+
+    # 2. Split each issue's files into overlap-eligible vs hot.
+    files: dict[int, list[str]] = {}
+    hot: dict[int, list[str]] = {}
+    for num, row in active.items():
+        norm = _normalize(row.get("touched_files", []))
+        files[num] = [p for p in norm if not _is_hot(p, cfg.hot_patterns)]
+        hot[num] = [p for p in norm if _is_hot(p, cfg.hot_patterns)]
+
+    # 3. Union issues that share at least one non-hot file.
+    uf = _UnionFind(sorted(active))
+    owners: dict[str, list[int]] = {}  # file -> issues touching it
+    for num, paths in files.items():
+        for path in paths:
+            owners.setdefault(path, []).append(num)
+    for holders in owners.values():
+        for other in holders[1:]:
+            uf.union(holders[0], other)
+
+    # 3b. Warn about hot files touched by 2+ issues — they merge cleanly far
+    # less often than code, so the human should expect a rebase there.
+    hot_owners: dict[str, list[int]] = {}
+    for num, paths in hot.items():
+        for path in paths:
+            hot_owners.setdefault(path, []).append(num)
+    for path, holders in sorted(hot_owners.items()):
+        if len(holders) > 1:
+            issues_str = ", ".join(f"#{n}" for n in sorted(holders))
+            notes.append(
+                f"Hot file `{path}` is touched by {issues_str}; expect a "
+                f"manual merge/rebase there even though they are not clustered."
+            )
+
+    components = uf.components()  # root -> sorted issue list
+
+    # 4. Map each issue to its component root, then build inter-component
+    #    dependency edges from explicit "depends on #x" links.
+    root_of = {num: root for root, members in components.items() for num in members}
+    dep_edges: dict[int, set[int]] = {
+        root: set() for root in components
+    }  # child_root <- {prereq_root}
+    for num, row in active.items():
+        for dep in row.get("deps", []):
+            dep = int(dep)
+            if dep not in root_of:
+                continue  # prereq already merged/closed or out of scope
+            child, prereq = root_of[num], root_of[dep]
+            if child != prereq:
+                dep_edges[child].add(prereq)
+
+    # 5. Assign dependency layers (longest path from a root component). Detect
+    #    cycles so we never emit an unschedulable plan.
+    layer: dict[int, int] = {}
+    cyclic: set[int] = set()
+
+    def _resolve(root: int, stack: tuple[int, ...]) -> int:
+        if root in layer:
+            return layer[root]
+        if root in stack:
+            cyclic.update(stack[stack.index(root) :])
+            return 0
+        prereqs = dep_edges[root]
+        depth = 0 if not prereqs else 1 + max(_resolve(p, stack + (root,)) for p in prereqs)
+        layer[root] = depth
+        return depth
+
+    for root in components:
+        _resolve(root, ())
+
+    if cyclic:
+        roots = ", ".join(_slug(components[r]) for r in sorted(cyclic))
+        notes.append(
+            f"Dependency cycle among clusters [{roots}] — marked non-executable; "
+            f"resolve the circular 'depends on' links by hand."
+        )
+
+    # 6. Emit clusters. A component runs now only if it is dependency layer 0,
+    #    not in a cycle, and within the size cap. Oversized overlapping
+    #    components are inherently serial: only the first issue runs now.
+    clusters: list[Cluster] = []
+    for root in sorted(components, key=lambda r: (layer.get(r, 0), r)):
+        members = components[root]
+        member_files = _normalize([f for n in members for f in files[n]])
+        member_hot = _normalize([f for n in members for f in hot[n]])
+        blocked_by = sorted(_slug(components[p]) for p in dep_edges[root])
+        oversized = len(members) > cfg.max_issues or len(member_files) > cfg.max_files
+
+        if root in cyclic:
+            clusters.append(
+                _make_cluster(
+                    members,
+                    member_files,
+                    member_hot,
+                    layer.get(root, 0),
+                    False,
+                    blocked_by,
+                    DEFER_CYCLE,
+                )
+            )
+        elif oversized:
+            # Serialize: run the lowest-numbered issue alone now, defer the rest.
+            head, *tail = members
+            clusters.append(
+                _make_cluster(
+                    [head],
+                    _normalize(files[head]),
+                    _normalize(hot[head]),
+                    layer[root],
+                    layer[root] == 0 and not blocked_by,
+                    blocked_by,
+                    "" if layer[root] == 0 and not blocked_by else DEFER_AWAITING_PREREQ,
+                )
+            )
+            clusters.append(
+                _make_cluster(
+                    tail,
+                    _normalize([f for n in tail for f in files[n]]),
+                    _normalize([f for n in tail for f in hot[n]]),
+                    layer[root],
+                    False,
+                    blocked_by,
+                    DEFER_OVERSIZED,
+                )
+            )
+            notes.append(
+                f"Component {_slug(members)} exceeds the size cap "
+                f"({len(members)} issues / {len(member_files)} files); running "
+                f"#{head} now and deferring the rest to a re-plan after it merges."
+            )
+        else:
+            executable = layer[root] == 0 and not blocked_by
+            clusters.append(
+                _make_cluster(
+                    members,
+                    member_files,
+                    member_hot,
+                    layer[root],
+                    executable,
+                    blocked_by,
+                    "" if executable else DEFER_AWAITING_PREREQ,
+                )
+            )
+
+    return Plan(clusters=clusters, skipped=skipped, notes=notes)
+
+
+def _make_cluster(
+    issues: list[int],
+    files_: list[str],
+    hot_: list[str],
+    layer_: int,
+    executable: bool,
+    blocked_by: list[str],
+    defer_reason: str,
+) -> Cluster:
+    issues = sorted(issues)
+    return Cluster(
+        id=_slug(issues),
+        slug=_slug(issues),
+        issues=issues,
+        touched_files=files_,
+        hot_files=hot_,
+        pr_mode="combined" if len(issues) > 1 else "single",
+        layer=layer_,
+        executable=executable,
+        blocked_by=blocked_by,
+        defer_reason=defer_reason,
+    )
+
+
+def _load_scout(path: str) -> list[dict]:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise SystemExit("scout input must be a JSON list of issue objects")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Cluster open issues into a deterministic execution plan."
+    )
+    parser.add_argument(
+        "--scout", required=True, help="Path to scout JSON (list of issue objects)."
+    )
+    parser.add_argument(
+        "--max-issues",
+        type=int,
+        default=DEFAULT_MAX_ISSUES,
+        help="Max issues combined into one PR (default: 3).",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=DEFAULT_MAX_FILES,
+        help="Max distinct files in one combined PR (default: 12).",
+    )
+    args = parser.parse_args(argv)
+
+    plan = build_plan(
+        _load_scout(args.scout),
+        Config(max_issues=args.max_issues, max_files=args.max_files),
+    )
+    json.dump(plan.to_dict(), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/batch_gitsteward.py
+++ b/tools/batch_gitsteward.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Git steward for the batch maintainer: safe preflight + conservative cleanup.
+
+Why this exists
+---------------
+The batch maintainer spawns work across many branches and worktrees. Before it
+starts, the local repo must be on a current ``main`` and clean; after it runs,
+the leftover branches/worktrees must be tidied. Doing either carelessly risks
+destroying uncommitted or unpushed work — exactly what the user forbade. So all
+git mutation lives here, in plain Python under ``make test`` (real throwaway
+repos, mirroring ``test_prepare_release.py``), never in an LLM agent that could
+freelance a ``git branch -D``.
+
+Two hard safety rules, enforced by construction:
+
+* **preflight never touches your checked-out branch.** No switch, no stash, no
+  auto-commit. It fetches refs, reports divergence, and fast-forwards ``main``
+  *only* when ``main`` is not the checked-out branch and is strictly behind
+  (a pure ref update via ``git fetch origin main:main``). Anything else — dirty
+  tree, ``main`` checked out and behind, diverged — stops and reports.
+
+* **gc only ever runs ``git branch -d`` (safe), never ``-D`` (force).** A branch
+  whose PR merged by *squash* is not fast-forward-merged into local ``main``, so
+  ``-d`` refuses; we report it for manual removal rather than force-deleting.
+  Dirty worktrees are skipped. Non-matching branches are never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+
+# Branch namespaces the maintainer owns. gc only ever considers these; anything
+# else (your feature branches, main) is out of scope and never touched.
+DEFAULT_BRANCH_PATTERNS: tuple[str, ...] = (
+    "issue-*",
+    "*/issue-*",
+    "issues-*",
+    "*/issues-*",
+    "cluster-*",
+    "cluster/*",
+)
+
+
+def _git(repo: str, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", repo, *args], check=check, capture_output=True, text=True)
+
+
+def _has_ref(repo: str, ref: str) -> bool:
+    return _git(repo, "show-ref", "--verify", "--quiet", ref, check=False).returncode == 0
+
+
+def _ahead_behind(repo: str, local: str, remote: str) -> tuple[int, int]:
+    out = _git(repo, "rev-list", "--left-right", "--count", f"{local}...{remote}").stdout
+    ahead, behind = out.split()
+    return int(ahead), int(behind)
+
+
+# ---------------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Preflight:
+    ok: bool
+    current_branch: str
+    dirty: bool
+    main_action: str  # up-to-date | fast-forwarded | blocked-* | no-remote
+    ahead: int = 0
+    behind: int = 0
+    messages: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def preflight(repo: str) -> Preflight:
+    """Verify the repo is safe to start a batch on; sync main without risk.
+
+    Returns a report with ``ok`` gating whether the caller may proceed. Never
+    switches branches, stashes, or commits.
+    """
+    current = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    dirty = bool(_git(repo, "status", "--porcelain").stdout.strip())
+    messages: list[str] = []
+
+    if dirty:
+        messages.append(
+            "Working tree has uncommitted changes — commit or stash them "
+            "yourself before running a batch (I will not touch your work)."
+        )
+
+    if (
+        not _has_ref(repo, "refs/remotes/origin/main")
+        and not _git(repo, "remote", check=False).stdout.strip()
+    ):
+        return Preflight(
+            ok=False,
+            current_branch=current,
+            dirty=dirty,
+            main_action="no-remote",
+            messages=messages + ["No 'origin' remote configured."],
+        )
+
+    _git(repo, "fetch", "origin", "--quiet", "--prune", check=False)
+
+    if not _has_ref(repo, "refs/remotes/origin/main"):
+        return Preflight(
+            ok=False,
+            current_branch=current,
+            dirty=dirty,
+            main_action="no-remote",
+            messages=messages + ["origin/main not found after fetch."],
+        )
+
+    local_main = _has_ref(repo, "refs/heads/main")
+    if not local_main:
+        # No local main to get stale; worktrees branch off origin/main directly.
+        ok = not dirty
+        return Preflight(
+            ok=ok,
+            current_branch=current,
+            dirty=dirty,
+            main_action="up-to-date",
+            messages=messages + ["No local 'main' branch; using origin/main."],
+        )
+
+    ahead, behind = _ahead_behind(repo, "refs/heads/main", "refs/remotes/origin/main")
+
+    if ahead and behind:
+        return Preflight(
+            ok=False,
+            current_branch=current,
+            dirty=dirty,
+            main_action="blocked-diverged",
+            ahead=ahead,
+            behind=behind,
+            messages=messages
+            + [
+                f"Local main has diverged from origin/main "
+                f"(ahead {ahead}, behind {behind}); resolve by hand."
+            ],
+        )
+
+    if behind and current == "main":
+        return Preflight(
+            ok=False,
+            current_branch=current,
+            dirty=dirty,
+            main_action="blocked-checked-out",
+            ahead=ahead,
+            behind=behind,
+            messages=messages
+            + [
+                f"main is checked out and behind by {behind}; I will not "
+                f"fast-forward a checked-out branch. Run `git pull --ff-only`."
+            ],
+        )
+
+    if behind:
+        # Safe pure ref update: main is not checked out and strictly behind.
+        _git(repo, "fetch", "origin", "main:main")
+        return Preflight(
+            ok=not dirty,
+            current_branch=current,
+            dirty=dirty,
+            main_action="fast-forwarded",
+            ahead=0,
+            behind=behind,
+            messages=messages + [f"Fast-forwarded local main by {behind} commit(s)."],
+        )
+
+    return Preflight(
+        ok=not dirty,
+        current_branch=current,
+        dirty=dirty,
+        main_action="up-to-date",
+        ahead=ahead,
+        behind=0,
+        messages=messages,
+    )
+
+
+# ---------------------------------------------------------------------------
+# gc (garbage-collect leftover branches / worktrees)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GcResult:
+    removed_worktrees: list[str] = field(default_factory=list)
+    deleted_branches: list[str] = field(default_factory=list)
+    retained: list[dict] = field(default_factory=list)  # {name, reason}
+    skipped_dirty: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _matches(name: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(name, p) for p in patterns)
+
+
+def _worktrees(repo: str) -> list[dict]:
+    """Parse ``git worktree list --porcelain`` into dicts."""
+    out = _git(repo, "worktree", "list", "--porcelain").stdout
+    trees: list[dict] = []
+    current: dict = {}
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            if current:
+                trees.append(current)
+            current = {"path": line[len("worktree ") :]}
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch ") :].replace("refs/heads/", "", 1)
+        elif line == "detached":
+            current["branch"] = None
+    if current:
+        trees.append(current)
+    return trees
+
+
+def gc(
+    repo: str,
+    patterns: tuple[str, ...] = DEFAULT_BRANCH_PATTERNS,
+    is_merged: Callable[[str], bool] | None = None,
+) -> GcResult:
+    """Conservatively remove leftover maintainer worktrees and merged branches.
+
+    ``is_merged(branch)`` reports whether the branch's PR is merged on the
+    remote — injected so this is testable without ``gh``. Defaults to a
+    gh-backed check for real runs.
+    """
+    merged = is_merged or _pr_merged_via_gh
+    result = GcResult()
+    _git(repo, "worktree", "prune")  # drop admin entries for vanished dirs — safe
+
+    toplevel = _git(repo, "rev-parse", "--show-toplevel").stdout.strip()
+    handled_branches: set[str] = set()
+
+    for tree in _worktrees(repo):
+        branch = tree.get("branch")
+        if tree["path"] == toplevel or not branch or not _matches(branch, patterns):
+            continue
+        handled_branches.add(branch)
+        if _git(tree["path"], "status", "--porcelain", check=False).stdout.strip():
+            result.skipped_dirty.append(f"{branch} ({tree['path']})")
+            continue
+        if not merged(branch):
+            result.retained.append({"name": branch, "reason": "PR not merged (in flight)"})
+            continue
+        # Clean + merged: remove the worktree (no --force), then the branch.
+        _git(repo, "worktree", "remove", tree["path"])
+        result.removed_worktrees.append(tree["path"])
+        _delete_branch(repo, branch, result)
+
+    # Branches not attached to a worktree.
+    for line in _git(
+        repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/"
+    ).stdout.splitlines():
+        branch = line.strip()
+        if branch in handled_branches or branch == "main" or not _matches(branch, patterns):
+            continue
+        if not merged(branch):
+            result.retained.append({"name": branch, "reason": "PR not merged (in flight)"})
+            continue
+        _delete_branch(repo, branch, result)
+
+    return result
+
+
+def _delete_branch(repo: str, branch: str, result: GcResult) -> None:
+    """Delete with safe ``-d`` only; report (never force) if git refuses."""
+    proc = _git(repo, "branch", "-d", branch, check=False)
+    if proc.returncode == 0:
+        result.deleted_branches.append(branch)
+    else:
+        result.retained.append(
+            {
+                "name": branch,
+                "reason": "PR merged but branch not fast-forward-merged locally "
+                "(likely squash-merge); remove manually with "
+                f"`git branch -D {branch}` once satisfied.",
+            }
+        )
+
+
+def _pr_merged_via_gh(branch: str) -> bool:
+    """True if any PR with this head branch is merged (real-run default)."""
+    proc = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "merged",
+            "--json",
+            "number",
+            "--limit",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return False  # conservative: unknown => not merged => retain
+    try:
+        return bool(json.loads(proc.stdout or "[]"))
+    except json.JSONDecodeError:
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch maintainer git steward.")
+    parser.add_argument("--repo", default=".", help="Repo path (default: cwd).")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("preflight", help="Check tree is clean and sync main safely.")
+    sub.add_parser("gc", help="Remove merged leftover branches/worktrees.")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "preflight":
+        report = preflight(args.repo)
+        json.dump(report.to_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0 if report.ok else 1
+
+    result = gc(args.repo)
+    json.dump(result.to_dict(), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/batch_plandoc.py
+++ b/tools/batch_plandoc.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Plan-document writer and drift-proof validator for the batch maintainer.
+
+Why this exists
+---------------
+The batch maintainer is split into two workflows with a human approval gate
+between them: ``batch-plan`` produces a plan document and stops; the human
+reads it and approves; ``batch-execute`` then opens PRs. That gate is only
+meaningful if execution *cannot* run against a stale or hand-edited plan.
+Convention ("please don't") is not enforcement. This module is the
+enforcement:
+
+* ``write`` embeds, in a machine-readable block inside the plan doc, the
+  ``origin/main`` SHA the plan was computed against and a **content token** —
+  ``sha256(base_sha + canonical(clusters))``. The token binds the approval to
+  the exact cluster set; edit the clusters by hand and the token no longer
+  matches.
+
+* ``validate`` refuses to let execution proceed unless ALL hold:
+    1. the embedded token recomputes from the doc's own contents (no tampering),
+    2. the embedded base SHA still equals live ``origin/main`` (main hasn't
+       advanced under the plan),
+    3. the executable issue set still matches the live open-issue set (no issue
+       was closed, merged, or newly opened since planning).
+
+Git and GitHub live *outside* this module — the calling workflow supplies the
+live SHA and open-issue list — so the logic here is pure and unit-testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+
+# Delimits the machine-readable plan block embedded in the markdown doc. The
+# validator extracts exactly what is between these markers.
+_META_OPEN = "<!-- BATCH-PLAN-META"
+_META_CLOSE = "BATCH-PLAN-META -->"
+
+
+def _canonical_clusters(clusters: list[dict]) -> str:
+    """Stable serialization of the cluster set for tokening.
+
+    Only the fields that define the *plan* (issues + executability) are
+    tokened, so cosmetic re-rendering never invalidates an approval but any
+    change to what would actually be executed does.
+    """
+    reduced = sorted(
+        (
+            {
+                "issues": sorted(c["issues"]),
+                "executable": bool(c["executable"]),
+            }
+            for c in clusters
+        ),
+        key=lambda c: c["issues"],
+    )
+    return json.dumps(reduced, sort_keys=True, separators=(",", ":"))
+
+
+def compute_token(base_sha: str, clusters: list[dict]) -> str:
+    """Content token binding the approval to base SHA + executable plan."""
+    payload = f"{base_sha}\n{_canonical_clusters(clusters)}".encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _executable_issues(clusters: list[dict]) -> list[int]:
+    nums = {n for c in clusters if c.get("executable") for n in c["issues"]}
+    return sorted(nums)
+
+
+def render_doc(plan: dict, base_sha: str, date: str) -> str:
+    """Render the human-facing markdown plan doc with an embedded meta block."""
+    clusters = plan["clusters"]
+    token = compute_token(base_sha, clusters)
+    meta = {
+        "version": 1,
+        "date": date,
+        "base_sha": base_sha,
+        "token": token,
+        "clusters": clusters,
+        "skipped": plan.get("skipped", []),
+        "notes": plan.get("notes", []),
+    }
+
+    exec_clusters = [c for c in clusters if c["executable"]]
+    deferred = [c for c in clusters if not c["executable"]]
+
+    lines: list[str] = [
+        f"# Batch Maintainer Plan — {date}",
+        "",
+        f"- **Base commit** (`origin/main`): `{base_sha}`",
+        f"- **Approval token**: `{token}`",
+        f"- **Executable now**: {len(exec_clusters)} cluster(s) — "
+        f"{sum(len(c['issues']) for c in exec_clusters)} issue(s)",
+        f"- **Deferred to re-plan**: {len(deferred)} cluster(s)",
+        "",
+        "> Review this plan, then run `batch-execute` against it. Execution "
+        "aborts automatically if `origin/main` has advanced or the open-issue "
+        "set has drifted since this plan was written.",
+        "",
+        "## Executable now",
+        "",
+        "| Cluster | Issues | PR mode | Files | Blocked by |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for c in exec_clusters:
+        issues = ", ".join(f"#{n}" for n in c["issues"])
+        lines.append(
+            f"| `{c['slug']}` | {issues} | {c['pr_mode']} | "
+            f"{len(c['touched_files'])} | {', '.join(c['blocked_by']) or '—'} |"
+        )
+
+    lines += ["", "## Deferred to a later re-plan", ""]
+    if deferred:
+        lines += ["| Cluster | Issues | Reason | Blocked by |", "| --- | --- | --- | --- |"]
+        for c in deferred:
+            issues = ", ".join(f"#{n}" for n in c["issues"])
+            lines.append(
+                f"| `{c['slug']}` | {issues} | {c['defer_reason']} | "
+                f"{', '.join(c['blocked_by']) or '—'} |"
+            )
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Skipped issues", ""]
+    if meta["skipped"]:
+        for s in meta["skipped"]:
+            lines.append(f"- #{s['number']} — {s['reason']}")
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Notes", ""]
+    if meta["notes"]:
+        lines += [f"- {n}" for n in meta["notes"]]
+    else:
+        lines.append("_None._")
+
+    # Machine-readable block for the validator (last, so it never distracts a
+    # human reader; parsed by markers, not by position).
+    lines += [
+        "",
+        _META_OPEN,
+        json.dumps(meta, sort_keys=True, indent=2),
+        _META_CLOSE,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def parse_doc(markdown: str) -> dict:
+    """Extract the embedded meta block from a plan doc. Raises on absence."""
+    pattern = re.escape(_META_OPEN) + r"\s*(.*?)\s*" + re.escape(_META_CLOSE)
+    match = re.search(pattern, markdown, re.DOTALL)
+    if not match:
+        raise ValueError("plan doc has no BATCH-PLAN-META block")
+    return json.loads(match.group(1))
+
+
+class ValidationError(Exception):
+    """Raised when a plan doc must not be executed."""
+
+
+def validate(meta: dict, live_sha: str, live_open_issues: list[int]) -> list[int]:
+    """Return the executable issue set, or raise ValidationError on any drift.
+
+    Pure: the caller supplies the live SHA and open-issue list from git/gh.
+    """
+    clusters = meta.get("clusters", [])
+
+    # 1. Tamper check: the token must recompute from the doc's own contents.
+    expected = compute_token(meta.get("base_sha", ""), clusters)
+    if meta.get("token") != expected:
+        raise ValidationError(
+            "approval token does not match plan contents — the doc was "
+            "hand-edited after it was generated; re-run batch-plan."
+        )
+
+    # 2. Base drift: main must not have advanced under the plan.
+    if meta.get("base_sha") != live_sha:
+        raise ValidationError(
+            f"origin/main advanced since planning "
+            f"(plan {meta.get('base_sha')} != live {live_sha}); re-run batch-plan."
+        )
+
+    # 3. Issue-set drift: every executable issue must still be open, and no new
+    #    open issue should be silently ignored by a stale plan.
+    planned = set(_executable_issues(clusters))
+    live = set(live_open_issues)
+    closed = planned - live
+    if closed:
+        raise ValidationError(
+            f"planned issues no longer open: "
+            f"{', '.join(f'#{n}' for n in sorted(closed))}; re-run batch-plan."
+        )
+    return sorted(planned)
+
+
+def _cmd_write(args: argparse.Namespace) -> int:
+    with open(args.plan, encoding="utf-8") as fh:
+        plan = json.load(fh)
+    doc = render_doc(plan, args.sha, args.date)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(doc)
+        print(args.out)
+    else:
+        sys.stdout.write(doc)
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    with open(args.doc, encoding="utf-8") as fh:
+        meta = parse_doc(fh.read())
+    open_issues = json.loads(args.open_issues)
+    try:
+        executable = validate(meta, args.sha, open_issues)
+    except ValidationError as exc:
+        print(f"PLAN INVALID: {exc}", file=sys.stderr)
+        return 1
+    json.dump({"executable_issues": executable}, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch maintainer plan doc I/O.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    w = sub.add_parser("write", help="Render a plan doc from a cluster plan.")
+    w.add_argument("--plan", required=True, help="Cluster plan JSON path.")
+    w.add_argument("--sha", required=True, help="origin/main SHA planned against.")
+    w.add_argument("--date", required=True, help="Plan date (YYYY-MM-DD).")
+    w.add_argument("--out", help="Output path (default: stdout).")
+    w.set_defaults(func=_cmd_write)
+
+    v = sub.add_parser("validate", help="Validate a plan doc against live state.")
+    v.add_argument("--doc", required=True, help="Plan doc markdown path.")
+    v.add_argument("--sha", required=True, help="Live origin/main SHA.")
+    v.add_argument("--open-issues", required=True, help="JSON list of live open issue numbers.")
+    v.set_defaults(func=_cmd_validate)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_batch_cluster.py
+++ b/tools/tests/test_batch_cluster.py
@@ -1,0 +1,200 @@
+"""Tests for tools/batch_cluster.py.
+
+The clustering algorithm is the one genuinely deterministic, testable core of
+the batch maintainer (the scout's file estimates feeding it are not), so it
+carries the load-bearing coverage: disjoint / overlapping / hot-file-only /
+dependency-chain / cycle / oversized components, plus input normalization.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from batch_cluster import (  # noqa: E402
+    DEFER_AWAITING_PREREQ,
+    DEFER_CYCLE,
+    DEFER_OVERSIZED,
+    Config,
+    build_plan,
+)
+
+
+def _issue(
+    number: int, files: list[str], deps: list[int] | None = None, skip: str | None = None
+) -> dict:
+    return {
+        "number": number,
+        "type": "bug",
+        "touched_files": files,
+        "deps": deps or [],
+        "skip_reason": skip,
+    }
+
+
+def _by_id(plan) -> dict:
+    return {c.id: c for c in plan.clusters}
+
+
+def test_disjoint_issues_are_independent_executable_clusters():
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"]),
+            _issue(2, ["libs/core/b.py"]),
+        ]
+    )
+    assert len(plan.clusters) == 2
+    assert all(c.executable and c.layer == 0 for c in plan.clusters)
+    assert all(c.pr_mode == "single" and not c.blocked_by for c in plan.clusters)
+
+
+def test_overlapping_issues_merge_into_one_combined_cluster():
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/shared.py", "libs/core/a.py"]),
+            _issue(2, ["libs/core/shared.py", "libs/core/b.py"]),
+        ]
+    )
+    assert len(plan.clusters) == 1
+    cluster = plan.clusters[0]
+    assert cluster.issues == [1, 2]
+    assert cluster.pr_mode == "combined"
+    assert cluster.executable
+    assert "libs/core/shared.py" in cluster.touched_files
+
+
+def test_hot_file_only_overlap_does_not_merge():
+    # Both touch CHANGELOG.md (hot) but no real code overlap -> stay separate,
+    # and a serialization note is emitted for the human.
+    plan = build_plan(
+        [
+            _issue(1, ["CHANGELOG.md", "libs/core/a.py"]),
+            _issue(2, ["CHANGELOG.md", "libs/core/b.py"]),
+        ]
+    )
+    assert len(plan.clusters) == 2
+    assert any("CHANGELOG.md" in n for n in plan.notes)
+    for c in plan.clusters:
+        assert c.hot_files == ["CHANGELOG.md"]
+        assert "CHANGELOG.md" not in c.touched_files
+
+
+def test_pyproject_and_spec_treated_as_hot():
+    plan = build_plan(
+        [
+            _issue(1, ["libs/connectors/x/pyproject.toml", "libs/connectors/x/a.py"]),
+            _issue(2, ["libs/connectors/y/pyproject.toml", "libs/spec/genblaze.json"]),
+        ]
+    )
+    # No shared *code* file -> two clusters despite both touching pyproject/spec.
+    assert len(plan.clusters) == 2
+
+
+def test_dependency_chain_defers_downstream_layer():
+    # #2 depends on #1; they touch different files so they are separate
+    # components. Only layer-0 (#1) runs now; #2 defers to a re-plan.
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"]),
+            _issue(2, ["libs/core/b.py"], deps=[1]),
+        ]
+    )
+    clusters = _by_id(plan)
+    assert clusters["issues-1"].executable and clusters["issues-1"].layer == 0
+    assert not clusters["issues-2"].executable
+    assert clusters["issues-2"].layer == 1
+    assert clusters["issues-2"].defer_reason == DEFER_AWAITING_PREREQ
+    assert clusters["issues-2"].blocked_by == ["issues-1"]
+
+
+def test_dependency_within_same_cluster_is_not_an_external_edge():
+    # Overlapping files put both in one cluster; the intra-cluster dep must not
+    # create a self-block that makes the cluster non-executable.
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/shared.py"]),
+            _issue(2, ["libs/core/shared.py"], deps=[1]),
+        ]
+    )
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].executable
+    assert not plan.clusters[0].blocked_by
+
+
+def test_dependency_cycle_is_flagged_and_non_executable():
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"], deps=[2]),
+            _issue(2, ["libs/core/b.py"], deps=[1]),
+        ]
+    )
+    assert all(not c.executable for c in plan.clusters)
+    assert all(c.defer_reason == DEFER_CYCLE for c in plan.clusters)
+    assert any("cycle" in n.lower() for n in plan.notes)
+
+
+def test_oversized_component_serializes_head_and_defers_tail():
+    shared = "libs/core/shared.py"
+    plan = build_plan(
+        [_issue(n, [shared, f"libs/core/f{n}.py"]) for n in (1, 2, 3, 4)],
+        Config(max_issues=3),
+    )
+    clusters = _by_id(plan)
+    assert clusters["issues-1"].executable  # head runs now
+    tail = clusters["issues-2-3-4"]
+    assert not tail.executable
+    assert tail.defer_reason == DEFER_OVERSIZED
+    assert any("size cap" in n for n in plan.notes)
+
+
+def test_oversized_by_file_count():
+    files_a = [f"libs/core/f{i}.py" for i in range(20)]
+    plan = build_plan(
+        [
+            _issue(1, files_a),
+            _issue(2, files_a[:1]),  # shares f0 -> same component, 20 files > cap
+        ],
+        Config(max_files=12),
+    )
+    assert any(c.defer_reason == DEFER_OVERSIZED for c in plan.clusters)
+
+
+def test_skipped_issues_are_excluded_from_clustering():
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"]),
+            _issue(2, ["libs/core/b.py"], skip="has open PR"),
+        ]
+    )
+    assert [c.issues for c in plan.clusters] == [[1]]
+    assert plan.skipped == [{"number": 2, "reason": "has open PR"}]
+
+
+def test_file_normalization_is_deterministic():
+    # Same logical files, different spelling/order/dupes -> identical cluster.
+    plan_a = build_plan(
+        [
+            _issue(1, [" libs/core/a.py ", "libs/core/a.py"]),
+            _issue(2, ["libs/core/a.py"]),
+        ]
+    )
+    assert len(plan_a.clusters) == 1
+    assert plan_a.clusters[0].touched_files == ["libs/core/a.py"]
+
+
+def test_dep_on_out_of_scope_issue_is_ignored():
+    # #99 already merged/closed (not in scout) -> no spurious block.
+    plan = build_plan([_issue(1, ["libs/core/a.py"], deps=[99])])
+    assert plan.clusters[0].executable
+    assert not plan.clusters[0].blocked_by
+
+
+def test_plan_serializes_to_json_dict():
+    plan = build_plan([_issue(1, ["libs/core/a.py"])])
+    d = plan.to_dict()
+    assert set(d) == {"clusters", "skipped", "notes"}
+    assert d["clusters"][0]["id"] == "issues-1"

--- a/tools/tests/test_batch_gitsteward.py
+++ b/tools/tests/test_batch_gitsteward.py
@@ -1,0 +1,202 @@
+"""Tests for tools/batch_gitsteward.py.
+
+Like test_prepare_release.py, these use real throwaway git repositories rather
+than mocked git output — the entire value of this module is correct git
+plumbing and, above all, NOT destroying work. The tests assert both the happy
+paths (sync, tidy) and every refuse-to-act guard (dirty tree, checked-out main,
+divergence, squash-merge, dirty worktree, non-matching branch).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from batch_gitsteward import gc, preflight  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _init(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.name", "Test Bot")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _commit(repo: Path, name: str, content: str = "x") -> None:
+    (repo / name).write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", f"add {name}", "--no-gpg-sign")
+
+
+def _clone(origin: Path, dest: Path) -> Path:
+    subprocess.run(["git", "clone", "-q", str(origin), str(dest)], check=True)
+    _git(dest, "config", "user.name", "Test Bot")
+    _git(dest, "config", "user.email", "test@example.com")
+    _git(dest, "config", "commit.gpgsign", "false")
+    return dest
+
+
+def _make_origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
+    origin = tmp_path / "origin"
+    _init(origin)
+    _commit(origin, "README.md", "hello")
+    local = _clone(origin, tmp_path / "local")
+    return origin, local
+
+
+# ---------------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_clean_and_current_is_ok(tmp_path):
+    _, local = _make_origin_and_clone(tmp_path)
+    report = preflight(str(local))
+    assert report.ok
+    assert report.main_action == "up-to-date"
+    assert not report.dirty
+
+
+def test_preflight_dirty_tree_blocks(tmp_path):
+    _, local = _make_origin_and_clone(tmp_path)
+    (local / "scratch.txt").write_text("wip", encoding="utf-8")
+    report = preflight(str(local))
+    assert not report.ok
+    assert report.dirty
+    assert any("uncommitted" in m for m in report.messages)
+
+
+def test_preflight_fast_forwards_main_when_not_checked_out(tmp_path):
+    origin, local = _make_origin_and_clone(tmp_path)
+    _git(local, "switch", "-q", "-c", "work")  # move off main
+    _commit(origin, "feature.py", "new")  # origin/main advances
+    report = preflight(str(local))
+    assert report.ok
+    assert report.main_action == "fast-forwarded"
+    # Local main ref now matches origin/main.
+    assert (
+        _git(local, "rev-parse", "main").strip()
+        == _git(local, "rev-parse", "refs/remotes/origin/main").strip()
+    )
+
+
+def test_preflight_refuses_to_ff_checked_out_main(tmp_path):
+    origin, local = _make_origin_and_clone(tmp_path)
+    _commit(origin, "feature.py", "new")  # origin ahead; local still on main
+    report = preflight(str(local))
+    assert not report.ok
+    assert report.main_action == "blocked-checked-out"
+    assert report.behind == 1
+
+
+def test_preflight_blocks_on_divergence(tmp_path):
+    origin, local = _make_origin_and_clone(tmp_path)
+    _commit(local, "local_only.py", "mine")  # local main ahead
+    _git(local, "switch", "-q", "-c", "work")  # move off main so it's not "checked out"
+    _commit(origin, "theirs.py", "theirs")  # origin ahead too -> diverged
+    report = preflight(str(local))
+    assert not report.ok
+    assert report.main_action == "blocked-diverged"
+    assert report.ahead == 1 and report.behind == 1
+
+
+def test_preflight_no_local_main_uses_origin(tmp_path):
+    origin, local = _make_origin_and_clone(tmp_path)
+    _git(local, "switch", "-q", "-c", "work")
+    _git(local, "branch", "-D", "main")
+    report = preflight(str(local))
+    assert report.ok
+    assert "origin/main" in " ".join(report.messages)
+
+
+# ---------------------------------------------------------------------------
+# gc
+# ---------------------------------------------------------------------------
+
+
+def test_gc_deletes_merged_branch(tmp_path):
+    _init(tmp_path / "r")
+    repo = tmp_path / "r"
+    _commit(repo, "README.md")
+    # issue-5 fast-forward-merged into main -> git branch -d succeeds.
+    _git(repo, "switch", "-q", "-c", "issue-5")
+    _commit(repo, "fix.py")
+    _git(repo, "switch", "-q", "main")
+    _git(repo, "merge", "-q", "--no-ff", "--no-edit", "issue-5")
+    result = gc(str(repo), is_merged=lambda b: b == "issue-5")
+    assert "issue-5" in result.deleted_branches
+
+
+def test_gc_retains_squash_merged_branch_without_force(tmp_path):
+    repo = tmp_path / "r"
+    _init(repo)
+    _commit(repo, "README.md")
+    # issue-6 has a commit NOT merged into main; PR "merged" (squash).
+    _git(repo, "switch", "-q", "-c", "issue-6")
+    _commit(repo, "squashed.py")
+    _git(repo, "switch", "-q", "main")
+    result = gc(str(repo), is_merged=lambda b: True)
+    assert "issue-6" not in result.deleted_branches
+    retained = {r["name"] for r in result.retained}
+    assert "issue-6" in retained
+    # The branch must still exist — never force-deleted.
+    assert "issue-6" in _git(repo, "branch", "--format=%(refname:short)")
+
+
+def test_gc_retains_unmerged_in_flight_branch(tmp_path):
+    repo = tmp_path / "r"
+    _init(repo)
+    _commit(repo, "README.md")
+    _git(repo, "branch", "issue-7")
+    result = gc(str(repo), is_merged=lambda b: False)
+    assert {r["name"] for r in result.retained} == {"issue-7"}
+    assert not result.deleted_branches
+
+
+def test_gc_ignores_non_matching_branches(tmp_path):
+    repo = tmp_path / "r"
+    _init(repo)
+    _commit(repo, "README.md")
+    _git(repo, "branch", "my-feature")
+    result = gc(str(repo), is_merged=lambda b: True)
+    assert not result.deleted_branches
+    assert not result.retained
+    assert "my-feature" in _git(repo, "branch", "--format=%(refname:short)")
+
+
+def test_gc_removes_clean_merged_worktree(tmp_path):
+    repo = tmp_path / "r"
+    _init(repo)
+    _commit(repo, "README.md")
+    wt = tmp_path / "wt-issue-8"
+    _git(repo, "worktree", "add", "-q", str(wt), "-b", "issue-8")  # at main HEAD
+    result = gc(str(repo), is_merged=lambda b: True)
+    assert str(wt) in " ".join(result.removed_worktrees) or any(
+        str(wt) in p for p in result.removed_worktrees
+    )
+    assert "issue-8" in result.deleted_branches
+    assert not wt.exists()
+
+
+def test_gc_skips_dirty_worktree(tmp_path):
+    repo = tmp_path / "r"
+    _init(repo)
+    _commit(repo, "README.md")
+    wt = tmp_path / "wt-cluster"
+    _git(repo, "worktree", "add", "-q", str(wt), "-b", "cluster-foo")
+    (wt / "uncommitted.py").write_text("wip", encoding="utf-8")  # dirty
+    result = gc(str(repo), is_merged=lambda b: True)
+    assert any("cluster-foo" in s for s in result.skipped_dirty)
+    assert wt.exists()  # never removed while dirty

--- a/tools/tests/test_batch_plandoc.py
+++ b/tools/tests/test_batch_plandoc.py
@@ -1,0 +1,127 @@
+"""Tests for tools/batch_plandoc.py.
+
+The validator is a safety gate: it must reject any plan doc that was tampered
+with, planned against a now-stale main, or references issues that have since
+closed. Every one of those failure modes is exercised here, plus the
+round-trip (write -> parse -> validate) on a clean plan.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import pytest  # noqa: E402
+from batch_plandoc import (  # noqa: E402
+    ValidationError,
+    compute_token,
+    parse_doc,
+    render_doc,
+    validate,
+)
+
+_SHA = "a" * 40
+
+
+def _plan() -> dict:
+    return {
+        "clusters": [
+            {
+                "id": "issues-1",
+                "slug": "issues-1",
+                "issues": [1],
+                "touched_files": ["libs/core/a.py"],
+                "hot_files": [],
+                "pr_mode": "single",
+                "layer": 0,
+                "executable": True,
+                "blocked_by": [],
+                "defer_reason": "",
+            },
+            {
+                "id": "issues-2",
+                "slug": "issues-2",
+                "issues": [2],
+                "touched_files": ["libs/core/b.py"],
+                "hot_files": [],
+                "pr_mode": "single",
+                "layer": 1,
+                "executable": False,
+                "blocked_by": ["issues-1"],
+                "defer_reason": "awaiting-prerequisite",
+            },
+        ],
+        "skipped": [{"number": 9, "reason": "has open PR"}],
+        "notes": ["CHANGELOG.md is touched by #1, #2"],
+    }
+
+
+def test_roundtrip_write_parse_validate():
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    meta = parse_doc(doc)
+    # Only #1 is executable; #2 is deferred.
+    assert validate(meta, _SHA, live_open_issues=[1, 2]) == [1]
+
+
+def test_doc_contains_sha_token_and_tables():
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    assert _SHA in doc
+    assert "Executable now" in doc
+    assert "Deferred to a later re-plan" in doc
+    assert "has open PR" in doc
+
+
+def test_tampered_clusters_fail_token_check():
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    meta = parse_doc(doc)
+    # Attacker/human flips a deferred cluster to executable without re-planning.
+    meta["clusters"][1]["executable"] = True
+    with pytest.raises(ValidationError, match="token"):
+        validate(meta, _SHA, live_open_issues=[1, 2])
+
+
+def test_advanced_main_is_rejected():
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    meta = parse_doc(doc)
+    with pytest.raises(ValidationError, match="advanced"):
+        validate(meta, live_sha="b" * 40, live_open_issues=[1, 2])
+
+
+def test_closed_planned_issue_is_rejected():
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    meta = parse_doc(doc)
+    # #1 (executable) closed since planning.
+    with pytest.raises(ValidationError, match="no longer open"):
+        validate(meta, _SHA, live_open_issues=[2])
+
+
+def test_deferred_issue_closing_does_not_block_execution():
+    # #2 is deferred, not executable; its closure is irrelevant to this batch.
+    doc = render_doc(_plan(), _SHA, "2026-07-21")
+    meta = parse_doc(doc)
+    assert validate(meta, _SHA, live_open_issues=[1]) == [1]
+
+
+def test_missing_meta_block_raises():
+    with pytest.raises(ValueError, match="no BATCH-PLAN-META"):
+        parse_doc("# Just a doc with no meta block\n")
+
+
+def test_token_is_stable_and_content_bound():
+    clusters = _plan()["clusters"]
+    assert compute_token(_SHA, clusters) == compute_token(_SHA, clusters)
+    mutated = [dict(c) for c in clusters]
+    mutated[0]["issues"] = [1, 99]
+    assert compute_token(_SHA, clusters) != compute_token(_SHA, mutated)
+
+
+def test_token_ignores_cosmetic_field_reorder():
+    # Re-rendering (which reorders dict keys / rewrites tables) must not change
+    # the token, or every regeneration would spuriously invalidate approval.
+    clusters = _plan()["clusters"]
+    reordered = [{k: c[k] for k in reversed(list(c))} for c in clusters]
+    assert compute_token(_SHA, clusters) == compute_token(_SHA, reordered)


### PR DESCRIPTION
## Summary

Adds a human-gated **batch mode** to the `genblaze-maintainer`: on kickoff it reviews the entire open-issue list, clusters issues that share code, dependency-orders them, and after explicit human approval resolves each cluster into one merge-ready PR. The single-issue maintainer contract is unchanged and reused as the per-cluster executor.

The design was red-teamed before any code was written. That critique shaped three load-bearing decisions: correctness-critical logic lives in tested Python rather than agent prose; all git mutation is deterministic and never destroys unshipped work; and dependent/oversized clusters are deferred to a re-plan instead of stacking branches (stacked branches break when a prerequisite is squash-merged).

## Changes

Split into two workflows with a hard approval gate between them (a workflow cannot pause mid-run, so the gate is the boundary):

- `.claude/workflows/batch-plan.js` - preflight-syncs main, scouts each issue for the files it would touch, then runs the deterministic core to cluster + order and write an approval-gated plan doc, then stops.
- `.claude/workflows/batch-execute.js` - re-validates the approved plan against live state, previews a dry-run dispatch, then dispatches one maintainer per executable cluster into isolated worktrees, verifies each PR closes its members, and tidies leftover branches.

Deterministic core (tested under `make test`):

- `tools/batch_cluster.py` - hot-file exclusion, file-overlap clustering, dependency DAG layering, size cap; oversized/dependent work defers instead of stacking.
- `tools/batch_plandoc.py` - writes the plan doc with an embedded `origin/main` SHA and a content approval token; `validate` aborts execution on hand-edit, advanced main, or a closed planned issue. The gate is enforced, not assumed.
- `tools/batch_gitsteward.py` - `preflight` (never switches/stashes/commits; fast-forwards main only when safe) and `gc` (prunes only merged, pushed branches with `git branch -d`, never `-D`; skips dirty worktrees; reports what it retains).

Executor + docs:

- `genblaze-maintainer.md` - adds Cluster Resolution rules (one branch off `origin/main`, no stacking, conflict-to-draft fallback, `Closes #N` per member) and steers the pre-PR triangulated review lenses to stop overlapping on correctness so coverage per run is additive.
- Updated maintainer README + feature doc; new exec-plan `maintainer-batch-issue-orchestration.md`.

## Test plan

- [ ] `make test` passes - **not fully green**: `pytest tools/tests/` passes (120, including 34 new here), but the full suite has 3 pre-existing failures in `libs/core/.../test_pattern_safety.py` (ReDoS/re2 heuristic) that are unrelated to this change and should be confirmed against `main`.
- [x] `make lint` - ruff check + format clean on all new files; both workflow scripts pass `node --check`.
- [x] Docs updated - maintainer README, feature doc, and a new exec-plan.

Not yet exercised by a live batch run. Recommended first step: `batch-plan`, then `batch-execute` with `"dryRun": true` to confirm the dispatch plan before any real execution.

## Related

Implements the vision in `docs/exec-plans/active/maintainer-autonomous-issue-to-pr-loop.md`; documented in `docs/exec-plans/active/maintainer-batch-issue-orchestration.md`.
