### PR TITLE
fix(core): normalize CAS key extension case for dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Fixed** `CONTENT_ADDRESSABLE` storage keys did not normalize the source
+  extension's case, so byte-identical content fetched via a differently-cased
+  extension (e.g. `IMG.PNG` vs `img.png`) hashed to the same sha256 but landed
+  at different keys — defeating dedup and storing the bytes twice (#20).
+  `_build_key` now lowercases the extension only for the CAS branch (the key
+  is content-addressed, so casing is a pure accident of the origin URL);
+  `HIERARCHICAL` keys are asset_id-based, not content-hash-based, so their
+  extension casing is left untouched. Objects already stored under an
+  upper-case-extension CAS key are unaffected by this change and remain
+  reachable at their existing key — only *future* uploads of that content
+  will resolve to the lowercase key, so a pre-existing upper-case duplicate
+  won't retroactively merge with it.
 - **Fixed** `hasattr(genblaze_core, "ParquetSink")` (and
   `getattr(module, name, default)`, `inspect`/IDE attribute probing) raised
   `OptionalDependencyError` instead of returning `False`/the default when the

--- a/libs/core/genblaze_core/storage/transfer.py
+++ b/libs/core/genblaze_core/storage/transfer.py
@@ -261,7 +261,13 @@ def _build_key(
     just supplies the per-strategy segments.
     """
     if strategy == KeyStrategy.CONTENT_ADDRESSABLE:
-        return key_builder.build(sha256[:2], sha256[2:4], f"{sha256}{ext}")
+        # Lowercase only here: the CAS key must depend on content (sha256),
+        # not on the source URL's incidental extension casing (.PNG vs .png).
+        # Without this, byte-identical content dedups or doesn't dedup purely
+        # based on how the origin server happened to case the path — HIERARCHICAL
+        # keys are asset_id-based (no dedup semantics), so their extension casing
+        # is left untouched.
+        return key_builder.build(sha256[:2], sha256[2:4], f"{sha256}{ext.lower()}")
     # HIERARCHICAL — group assets under run folder
     parts: list[str] = []
     if tenant:

--- a/libs/core/tests/unit/test_transfer.py
+++ b/libs/core/tests/unit/test_transfer.py
@@ -276,6 +276,47 @@ class TestAssetTransfer:
         transfer.transfer(asset2)
         assert len(put_called) == 0  # Should have skipped
 
+    @patch("genblaze_core._utils.socket.getaddrinfo", return_value=_FAKE_ADDRINFO)
+    @patch("genblaze_core.storage.transfer._http_get_stream")
+    def test_content_addressable_dedup_ignores_extension_case(self, mock_urlopen, _mock_dns):
+        """End-to-end regression test for #20: byte-identical content fetched
+        via a differently-cased source extension (.PNG vs .png) must dedup —
+        the second transfer skips the upload rather than storing a duplicate.
+        """
+        mock_resp = MagicMock()
+        mock_resp.read.side_effect = [b"data", b""]
+        mock_resp.headers = {"Content-Type": "image/png"}
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        backend = FakeBackend()
+        transfer = AssetTransfer(backend, prefix="assets")
+
+        # First transfer via an upper-case extension.
+        asset = Asset(url="https://cdn.example.com/IMG.PNG", media_type="image/png")
+        key = transfer.transfer(asset)
+        assert key in backend.store
+
+        # Second transfer, same bytes, lower-case extension — must resolve to
+        # the same CAS key and skip the upload (dedup hit).
+        mock_resp.read.side_effect = [b"data", b""]
+        mock_urlopen.return_value = mock_resp
+        asset2 = Asset(url="https://cdn.example.com/img.png", media_type="image/png")
+
+        original_put = backend.put
+        put_called = []
+
+        def tracking_put(*args, **kwargs):
+            put_called.append(True)
+            return original_put(*args, **kwargs)
+
+        backend.put = tracking_put
+
+        key2 = transfer.transfer(asset2)
+        assert key2 == key
+        assert len(put_called) == 0  # Should have skipped — dedup hit
+
     def test_http_url_rejected(self):
         transfer, _ = self._make_transfer()
         asset = Asset(url="http://insecure.example.com/img.png", media_type="image/png")

--- a/libs/core/tests/unit/test_transfer.py
+++ b/libs/core/tests/unit/test_transfer.py
@@ -139,6 +139,28 @@ class TestBuildKey:
         )
         assert key == "assets/ab/cd/abcdef1234.png"
 
+    def test_content_addressable_normalizes_uppercase_extension(self):
+        """Byte-identical content with a differently-cased source extension
+        (e.g. .PNG vs .png) must dedup to the same CAS key — the extension
+        casing is an accident of the origin URL, not part of the content hash.
+        """
+        asset = Asset(url="https://x.com/IMG.PNG", media_type="image/png")
+        key_upper = _build_key(
+            KeyStrategy.CONTENT_ADDRESSABLE,
+            KeyBuilder.from_prefix("assets"),
+            asset,
+            "abcdef1234",
+            ".PNG",
+        )
+        key_lower = _build_key(
+            KeyStrategy.CONTENT_ADDRESSABLE,
+            KeyBuilder.from_prefix("assets"),
+            asset,
+            "abcdef1234",
+            ".png",
+        )
+        assert key_upper == key_lower == "assets/ab/cd/abcdef1234.png"
+
     def test_hierarchical(self):
         asset = Asset(url="https://x.com/img.png", media_type="image/png")
         key = _build_key(
@@ -171,6 +193,23 @@ class TestBuildKey:
         )
         assert key == f"pfx/2026-03-11/run-123/assets/{asset.asset_id}.png"
         assert "None" not in key
+
+    def test_hierarchical_preserves_extension_case(self):
+        """HIERARCHICAL keys are asset_id-based, not content-hash-based, so
+        there's no dedup collision to fix — extension casing is left as-is.
+        """
+        asset = Asset(url="https://x.com/IMG.PNG", media_type="image/png")
+        key = _build_key(
+            KeyStrategy.HIERARCHICAL,
+            KeyBuilder.from_prefix("assets"),
+            asset,
+            "abcdef1234",
+            ".PNG",
+            tenant=None,
+            date_str="2026-03-11",
+            run_id="run-123",
+        )
+        assert key == f"assets/2026-03-11/run-123/assets/{asset.asset_id}.PNG"
 
 
 class TestAssetTransfer:


### PR DESCRIPTION
## Summary

Content-addressable (`CONTENT_ADDRESSABLE`) storage keys embedded the source URL's extension verbatim, including its case. Byte-identical content fetched via a differently-cased extension (e.g. `IMG.PNG` vs `img.png`) hashed to the same sha256 but produced a different storage key, so it was stored twice — defeating dedup and billing for duplicate storage.

## Changes

- `libs/core/genblaze_core/storage/transfer.py`: `_build_key`'s `CONTENT_ADDRESSABLE` branch now lowercases the extension before building the key (`f"{sha256}{ext.lower()}"`). The `HIERARCHICAL` branch is untouched — those keys are `asset_id`-based, not content-hash-based, so there's no dedup collision to fix, and preserving the original extension casing there has no downside.
- `libs/core/tests/unit/test_transfer.py`: added a `_build_key`-level test proving `.PNG` and `.png` produce the same CAS key, a companion test proving `HIERARCHICAL` casing is preserved, and an end-to-end `AssetTransfer.transfer()` test proving the second transfer of the same bytes (differently-cased extension) is a dedup hit (no second `put()` call).
- `CHANGELOG.md`: `[Unreleased]` entry under `### genblaze-core`, including a note that pre-existing objects already stored under an upper-case-extension CAS key remain reachable at their old key and are not retroactively merged — this fix is forward-only.

## Test plan

- [x] `make test` (core suite: `cd libs/core && pytest tests/` — 1962 passed, 7 skipped; 3 pre-existing failures in `test_pattern_safety.py` unrelated to this change and present on `origin/main` before this branch, root cause is a `_re2` attribute missing in this env, not touched by this PR)
- [x] `make lint` passes (ruff check + format + deptry, full repo)
- [x] Docs updated — CHANGELOG `[Unreleased]` entry added

Reviewed by three independent sub-agent passes prior to push:
- **Correctness & tests**: no P0s; confirmed the fix applies consistently across all three CAS call sites and `mimetypes.guess_extension` never introduces the bug (its map is already lowercase); flagged missing end-to-end coverage (P1) — addressed by adding `test_content_addressable_dedup_ignores_extension_case`.
- **Security & invariants**: no P0s; `.lower()` is a no-op on an already-narrowed `.suffix`-derived string (no new injection surface), no interaction with canonical-hash/manifest/EmbedPolicy invariants, and the "no retroactive merge for old objects" CHANGELOG claim was verified against the code.
- **Architecture & DRY**: no P0/P1s; confirmed normalizing at the `_build_key` CAS branch (rather than in the shared `_guess_extension`) is the correct choke point since casing normalization is a CAS-dedup concern, not a general extension-guessing concern; confirmed no hot-loop cost and no existing duplicate normalization logic.

## Related

Closes #20
