### PR TITLE
fix(s3): key_from_url skips network HeadBucket for foreign URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   see the `genblaze-core` entry above for the root cause. `provider.py` now
   builds its `file://` asset URL via `genblaze_core._utils.local_file_url()`.
 
+### genblaze-s3
+
+- **Fixed** `key_from_url` forced a network `HeadBucket` (via
+  `_ensure_region_verified()`) before comparing the URL's host to this
+  backend's endpoint, and raised `StorageError` instead of returning `None`
+  for a foreign URL on an unverified backend with bad credentials (#19) —
+  breaking the documented "`None` = not mine" contract that cross-backend
+  manifest routing (`read_manifest_for_asset`) relies on. `key_from_url` now
+  compares the URL's host against the already-resolved endpoint first (a
+  local attribute read, no network call) and returns `None` immediately for
+  a clear mismatch; region verification never runs on this path. A B2
+  bucket that migrated to a different region after this backend was last
+  verified is still recognized without a `HeadBucket`, since B2 bucket names
+  are globally unique — a B2-shaped host plus an exact bucket-name match is
+  sufficient proof of ownership on its own.
+
 ## [0.5.0] - 2026-07-16
 
 Correctness and security hardening across the pipeline, provenance, streaming,

--- a/libs/connectors/s3/genblaze_s3/backend.py
+++ b/libs/connectors/s3/genblaze_s3/backend.py
@@ -97,6 +97,17 @@ def _b2_endpoint(region: str) -> str:
     return f"https://s3.{region}.backblazeb2.com"
 
 
+def _is_b2_host(host: str) -> bool:
+    """True when ``host`` is a Backblaze B2 S3-compatible domain.
+
+    Shared by ``_is_b2`` (checks this backend's configured endpoint) and
+    ``key_from_url`` (checks an arbitrary URL's host) so both stay in sync
+    if the B2 hostname pattern ever changes.
+    """
+    host = host.lower()
+    return host == "backblazeb2.com" or host.endswith(".backblazeb2.com")
+
+
 def _data_size(data: bytes | BinaryIO) -> int | None:
     """Best-effort total-size determination for a put payload.
 
@@ -321,7 +332,7 @@ class S3StorageBackend(StorageBackend):
         # Parse the host so the check can't be fooled by the domain appearing
         # elsewhere in the URL (e.g. https://evil.example/backblazeb2.com).
         host = (urlparse(raw if "://" in raw else f"//{raw}").hostname or "").lower()
-        return host == "backblazeb2.com" or host.endswith(".backblazeb2.com")
+        return _is_b2_host(host)
 
     def _client_kwargs(self) -> dict[str, Any]:
         """Assemble boto3.client kwargs from current instance state."""
@@ -1314,7 +1325,12 @@ class S3StorageBackend(StorageBackend):
 
         Returns ``None`` for URLs that clearly belong elsewhere (different
         host, different bucket, malformed) so callers can route across
-        backends without try/except gymnastics.
+        backends without try/except gymnastics. This check is host/bucket
+        comparison only — it never triggers a network call (no
+        ``HeadBucket``), so it returns ``None`` for foreign URLs even on an
+        unverified backend with bad or placeholder credentials. Callers like
+        ``read_manifest_for_asset`` rely on that to probe multiple backends
+        cheaply.
         """
         from urllib.parse import unquote, urlparse
 
@@ -1327,10 +1343,28 @@ class S3StorageBackend(StorageBackend):
         parsed = urlparse(url)
         if not parsed.scheme or not parsed.netloc:
             return None
-        self._ensure_region_verified()
-        endpoint_host = urlparse(self._client.meta.endpoint_url or "").netloc
-        if parsed.netloc != endpoint_host:
-            return None
+
+        # Compare against the endpoint the client is *currently* configured
+        # for. Reading ``.meta.endpoint_url`` is a local attribute access —
+        # it reflects boto3's already-resolved endpoint (including the
+        # default AWS endpoint when no custom ``endpoint_url`` was passed)
+        # without triggering a network call, so a foreign host is rejected
+        # without ever touching the network.
+        current_host = urlparse(self._client.meta.endpoint_url or "").netloc
+        if parsed.netloc != current_host:
+            # Host doesn't match our current guess. Still might be ours: B2
+            # buckets can live in a different region than the one we were
+            # constructed/last-verified with (see _ensure_region_verified's
+            # 301-redirect auto-correct), so a URL minted after a region
+            # migration would carry a different B2 regional host. Recognize
+            # that case WITHOUT a network call — B2 bucket names are
+            # globally unique, so "B2-shaped host + our exact bucket name in
+            # the path" is sufficient proof of ownership on its own; a plain
+            # host mismatch against a non-B2 (or differently-branded) host
+            # is definitively foreign.
+            if not (self._is_b2 and _is_b2_host(parsed.netloc)):
+                return None
+
         path = parsed.path.lstrip("/")
         bucket_prefix = self._bucket + "/"
         if not path.startswith(bucket_prefix):

--- a/libs/connectors/s3/genblaze_s3/backend.py
+++ b/libs/connectors/s3/genblaze_s3/backend.py
@@ -1361,8 +1361,10 @@ class S3StorageBackend(StorageBackend):
             # globally unique, so "B2-shaped host + our exact bucket name in
             # the path" is sufficient proof of ownership on its own; a plain
             # host mismatch against a non-B2 (or differently-branded) host
-            # is definitively foreign.
-            if not (self._is_b2 and _is_b2_host(parsed.netloc)):
+            # is definitively foreign. Compare on ``.hostname`` (strips any
+            # userinfo/port) to match how ``_is_b2`` parses its own host, so
+            # the two checks can't silently diverge.
+            if not (self._is_b2 and _is_b2_host(parsed.hostname or "")):
                 return None
 
         path = parsed.path.lstrip("/")

--- a/libs/connectors/s3/tests/test_s3_backend.py
+++ b/libs/connectors/s3/tests/test_s3_backend.py
@@ -839,3 +839,68 @@ class TestKeyFromUrl:
         # A URL produced by get_durable_url WITHOUT public_url_base.
         raw_url = f"{self._ENDPOINT}/my-bucket/genblaze/manifests/old.json"
         assert backend.key_from_url(raw_url) == "genblaze/manifests/old.json"
+
+    def test_foreign_host_returns_none_without_network_call(self, mock_boto3):
+        """Regression for #19: a foreign host must be rejected by comparing
+        the URL against our already-configured endpoint — never by forcing
+        a HeadBucket. Region verification is unrelated to "is this URL
+        even a candidate", so it must not fire on this path.
+        """
+        backend = self._make_backend(mock_boto3)
+        backend._region_verified = False
+        assert backend.key_from_url("https://other-host.example.com/my-bucket/k") is None
+        backend._client.head_bucket.assert_not_called()
+
+    def test_foreign_host_on_unverified_backend_with_bad_creds_returns_none(self, mock_boto3):
+        """Regression for #19: on an unverified backend with bad
+        credentials, a foreign URL must still return None instead of
+        surfacing the HeadBucket StorageError — otherwise cross-backend
+        manifest routing (read_manifest_for_asset) breaks on the first
+        backend it tries that isn't the right one.
+        """
+        backend = self._make_backend(mock_boto3)
+        backend._region_verified = False
+        backend._client.head_bucket.side_effect = _FakeClientError(
+            {"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPHeaders": {}}},
+            "HeadBucket",
+        )
+        assert backend.key_from_url("https://other-host.example.com/my-bucket/k") is None
+        backend._client.head_bucket.assert_not_called()
+
+    def test_own_bucket_url_resolves_without_verification(self, mock_boto3):
+        """An own-bucket URL (host already matches the configured endpoint)
+        must still resolve to its key even before region verification has
+        run — no HeadBucket is needed to recognize it.
+        """
+        backend = self._make_backend(mock_boto3)
+        backend._region_verified = False
+        url = f"{self._ENDPOINT}/my-bucket/genblaze/manifests/abc.json"
+        assert backend.key_from_url(url) == "genblaze/manifests/abc.json"
+        backend._client.head_bucket.assert_not_called()
+
+    def test_b2_bucket_migrated_region_recognized_without_network_call(self, mock_boto3):
+        """A URL minted after this bucket migrated to a different B2 region
+        (see _ensure_region_verified's 301-redirect auto-correct) still
+        resolves — B2 bucket names are globally unique, so a B2-shaped host
+        plus an exact bucket-name match is proof of ownership on its own,
+        with no HeadBucket required.
+        """
+        backend = self._make_backend(mock_boto3)
+        backend._region_verified = False
+        url = "https://s3.eu-central-003.backblazeb2.com/my-bucket/genblaze/manifests/abc.json"
+        assert backend.key_from_url(url) == "genblaze/manifests/abc.json"
+        backend._client.head_bucket.assert_not_called()
+
+    def test_non_b2_host_mismatch_not_leniently_matched_by_bucket_name(self, mock_boto3):
+        """The bucket-name-only allowance is B2-specific (global bucket
+        name uniqueness). A non-B2 custom endpoint (e.g. MinIO) with a
+        mismatched host must still be treated as foreign even if the
+        bucket name happens to coincide — two MinIO deployments can
+        legitimately share a bucket name.
+        """
+        backend = self._make_backend(mock_boto3, endpoint_url="https://minio.example.com")
+        backend._client.meta.endpoint_url = "https://minio.example.com"
+        backend._region_verified = False
+        url = "https://minio-other.example.com/my-bucket/some/key.json"
+        assert backend.key_from_url(url) is None
+        backend._client.head_bucket.assert_not_called()


### PR DESCRIPTION
## Summary

`S3StorageBackend.key_from_url()` is documented to return `None` for a URL
that doesn't belong to this backend (the "not mine" signal
`read_manifest_for_asset` relies on for cross-backend manifest routing). It
instead called `_ensure_region_verified()` — a network `HeadBucket` — before
comparing the URL's host, so every call paid an avoidable network round-trip,
and on an unverified backend with bad/placeholder credentials it raised
`StorageError` instead of returning `None`, breaking that contract.

## Changes

- `libs/connectors/s3/genblaze_s3/backend.py`:
  - `key_from_url` now compares the URL's host against
    `self._client.meta.endpoint_url` (a local attribute read, no network call)
    *before* any bucket/path work, returning `None` immediately on a clear
    mismatch — `_ensure_region_verified()` is no longer called anywhere in
    this method.
  - Narrow allowance for B2: if this backend is B2 (`self._is_b2`) and the
    URL's host is also B2-shaped, the (pre-existing, unchanged) bucket-name
    check still runs before extracting a key. This handles a bucket that
    migrated to a different B2 region since this backend was last verified —
    B2 bucket names are globally unique, so a B2-shaped host plus an exact
    bucket-name match is sufficient proof of ownership without a network call.
  - Extracted `_is_b2_host(host)` as a module-level helper shared by the
    existing `_is_b2` property and the new `key_from_url` check, so both stay
    in sync if the B2 hostname pattern ever changes. Follow-up from review:
    compares on `.hostname` (not `.netloc`) to match `_is_b2`'s parsing and
    avoid a false-negative on a B2 host with an explicit port.
- `libs/connectors/s3/tests/test_s3_backend.py`: 5 new tests under
  `TestKeyFromUrl` — foreign host returns `None` with zero `head_bucket`
  calls; same on an unverified backend with bad credentials (`AccessDenied`);
  an own-bucket URL still resolves before verification; a B2 bucket URL for a
  migrated region still resolves without a network call; a non-B2 custom
  endpoint (MinIO-style) does NOT get the bucket-name-only leniency (host
  mismatch there is definitively foreign).
- `CHANGELOG.md`: `[Unreleased]` entry under `### genblaze-s3`.

## Test plan

- [x] `make lint` passes (ran this session: `ruff check`/`ruff format --check`
      across `libs/ cli/ examples/` plus `deptry` per-package, exit 0)
- [ ] `make test` — NOT fully green this session, but not due to this change:
      `libs/core/tests/unit/test_pattern_safety.py` has 3 pre-existing
      failures (`AttributeError: ... has no attribute '_re2'`) caused by the
      optional `re2` dependency not being installed in this dev environment —
      unrelated to `key_from_url`/S3 and reproducible on `origin/main` with
      zero changes applied. The actual scope of this fix,
      `cd libs/connectors/s3 && pytest -v`, passes clean: **252 passed**.
      `mypy libs/connectors/s3/genblaze_s3/ --ignore-missing-imports`: no
      issues.
- [x] Docs updated — `CHANGELOG.md` `[Unreleased]` entry added; the
      `key_from_url` docstring and `docs/features/object-storage.md`'s
      description of the "not mine" contract were already accurate and didn't
      need changes (this fix strengthens the implementation to match the
      already-documented contract, it doesn't change the contract).

### Pre-PR triangulated review (3 independent sub-agents)

- **Correctness & tests**: no P0/P1. Confirmed the fix resolves #19 end to
  end; the B2-region-migration allowance can't cause a wrong-bucket key
  extraction (the exact bucket-prefix check still runs unconditionally
  afterward). One informational P2 noted a pre-existing (not introduced by
  this diff) host case-sensitivity gap, out of scope for this fix.
- **Security & invariants**: no P0/P1. Traced every branch of `key_from_url`
  and confirmed no path makes a network call, leaks credentials/host info,
  logs a sensitive URL, or lets a crafted URL cause access outside the
  backend's own already-authenticated bucket/client. Two P2 follow-ups: align
  `.hostname` vs `.netloc` (applied in this PR) and a suggestion to document
  the residual "bucket name is a durable identity" assumption in a comment
  (left as a follow-up, not blocking).
- **Architecture, scalability & DRY**: no P0/P1. `_is_b2_host` consolidates
  the only two existing call sites (no third duplicate site found in
  `libs/connectors/s3/`); the new path is O(1) local string comparison with
  no lock/network reintroduction; the B2-migration allowance is proportionate
  to the edge case the issue explicitly asked to consider, not scope creep.

## Related

Closes #19