### PR TITLE
fix(core): fall back to input char_count in per_input_chars pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sink and validator were already fixed; only the URL construction was
   release-lagged. POSIX behavior is unchanged (`as_uri()` already produced
   the same form there).
+- **Fixed** `per_input_chars()` silently returned `cost_usd=None` for
+  chain-input steps (#54). When a step is fed by an upstream step's output,
+  `Step.prompt` is typically `None` and the text lives on `Step.inputs`
+  instead — the strategy only read `ctx.step.prompt`, so TTS/analysis steps
+  chained off another step looked "free" instead of "unpriceable". It now
+  falls back to summing `metadata["char_count"]` across the step's input
+  assets when there's no prompt text, ignoring inputs with no/invalid
+  `char_count` (e.g. images). Returns `None` only when neither a prompt nor
+  any usable `char_count` exists; a genuinely-present `char_count` of `0`
+  still yields a real `0.0` cost rather than an "unknown" one.
 
 ### genblaze-cli
 

--- a/libs/core/genblaze_core/providers/pricing.py
+++ b/libs/core/genblaze_core/providers/pricing.py
@@ -84,7 +84,7 @@ def per_input_chars(rate: float, per: int = 1000) -> PricingStrategy:
         if text:
             return (len(text) / per) * rate
 
-        total_chars = 0
+        total_chars = 0.0
         found = False
         for asset in ctx.step.inputs:
             count = _float_or_none(asset.metadata.get("char_count"))

--- a/libs/core/genblaze_core/providers/pricing.py
+++ b/libs/core/genblaze_core/providers/pricing.py
@@ -68,13 +68,32 @@ def per_unit(rate: float) -> PricingStrategy:
 
 
 def per_input_chars(rate: float, per: int = 1000) -> PricingStrategy:
-    """Per-character pricing on the input prompt. ``per=1000`` → USD per 1K chars."""
+    """Per-character pricing on the input text. ``per=1000`` → USD per 1K chars.
+
+    Prefers ``step.prompt``. Chain-input steps (fed by an upstream step's
+    output) typically have ``prompt=None`` with the text living on
+    ``step.inputs`` instead — falls back to summing ``metadata["char_count"]``
+    across input assets so those steps aren't silently priced as "free".
+    Returns ``None`` only when no character source exists at all; a
+    genuinely-present ``char_count`` of ``0`` still yields a real (zero) cost
+    rather than an "unknown" one.
+    """
 
     def _strategy(ctx: PricingContext) -> float | None:
         text = ctx.step.prompt or ""
-        if not text:
+        if text:
+            return (len(text) / per) * rate
+
+        total_chars = 0
+        found = False
+        for asset in ctx.step.inputs:
+            count = _float_or_none(asset.metadata.get("char_count"))
+            if count is not None:
+                total_chars += count
+                found = True
+        if not found:
             return None
-        return (len(text) / per) * rate
+        return (total_chars / per) * rate
 
     return _strategy
 

--- a/libs/core/tests/unit/test_model_registry.py
+++ b/libs/core/tests/unit/test_model_registry.py
@@ -207,6 +207,77 @@ class TestPricing:
         ctx = PricingContext(step=step, assets=[], provider_payload={})
         assert per_input_chars(1.0, per=1000)(ctx) == pytest.approx(11 / 1000)
 
+    def test_per_input_chars_falls_back_to_input_asset_char_count(self):
+        """Chain-input step: prompt=None, text lives on the input asset instead."""
+        step = _step(
+            prompt=None,
+            inputs=[
+                Asset(
+                    url="file:///t.txt",
+                    media_type="text/plain",
+                    metadata={"char_count": 1234},
+                )
+            ],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) == pytest.approx(1234 / 1000)
+
+    def test_per_input_chars_sums_multiple_input_assets(self):
+        step = _step(
+            prompt=None,
+            inputs=[
+                Asset(url="a", media_type="text/plain", metadata={"char_count": 100}),
+                Asset(url="b", media_type="text/plain", metadata={"char_count": 50}),
+            ],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) == pytest.approx(150 / 1000)
+
+    def test_per_input_chars_ignores_non_text_inputs_without_char_count(self):
+        """Image/audio inputs with no char_count don't block the fallback."""
+        step = _step(
+            prompt=None,
+            inputs=[
+                Asset(url="img", media_type="image/png"),
+                Asset(url="txt", media_type="text/plain", metadata={"char_count": 42}),
+            ],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) == pytest.approx(42 / 1000)
+
+    def test_per_input_chars_zero_char_count_is_a_real_cost_not_unknown(self):
+        """char_count=0 is a known value — yields 0.0, not None."""
+        step = _step(
+            prompt=None,
+            inputs=[Asset(url="a", media_type="text/plain", metadata={"char_count": 0})],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) == 0.0
+
+    def test_per_input_chars_no_prompt_no_char_count_is_none(self):
+        """No prompt and no usable char_count anywhere: genuinely unknown."""
+        step = _step(
+            prompt=None,
+            inputs=[
+                Asset(url="img", media_type="image/png"),
+                Asset(url="txt", media_type="text/plain", metadata={"lang": "en"}),
+            ],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) is None
+
+    def test_per_input_chars_invalid_char_count_is_ignored(self):
+        """Non-numeric char_count on one asset doesn't poison a valid one on another."""
+        step = _step(
+            prompt=None,
+            inputs=[
+                Asset(url="a", media_type="text/plain", metadata={"char_count": "not-a-number"}),
+                Asset(url="b", media_type="text/plain", metadata={"char_count": 20}),
+            ],
+        )
+        ctx = PricingContext(step=step, assets=[], provider_payload={})
+        assert per_input_chars(1.0, per=1000)(ctx) == pytest.approx(20 / 1000)
+
     def test_per_output_second(self):
         assets = [Asset(url="a", media_type="audio/mp3", duration=3.5)]
         ctx = PricingContext(step=_step(), assets=assets, provider_payload={})


### PR DESCRIPTION
## Summary

`per_input_chars()` only read `ctx.step.prompt`. Chain-input steps (fed by an upstream step's output) typically have `prompt=None` with the text living on `Step.inputs` instead, so the strategy returned `None` even when the input asset's `metadata["char_count"]` made the cost computable — TTS/analysis steps chained off another step looked "free" rather than "unpriceable".

## Changes

- `libs/core/genblaze_core/providers/pricing.py`: `per_input_chars()` now falls back to summing `metadata["char_count"]` across `ctx.step.inputs` when there's no prompt text, reusing the file's existing `_float_or_none()` coercion helper. Non-numeric/missing `char_count` on an asset is ignored rather than poisoning the sum from other assets. Returns `None` only when neither a prompt nor any usable `char_count` exists anywhere; a genuinely-present `char_count` of `0` still yields a real `0.0` cost instead of an "unknown" one. Existing prompt-based behavior is unchanged.
- `libs/core/tests/unit/test_model_registry.py`: added `TestPricing` cases for the chain-input fallback (single asset, multiple assets summed, non-text inputs without `char_count` ignored, `char_count=0` yields `0.0` not `None`, no prompt + no `char_count` stays `None`, non-numeric `char_count` on one asset doesn't block a valid sibling).
- `CHANGELOG.md`: `[Unreleased]` bullet under `### genblaze-core`.

## Test plan

- [x] `make lint` passes (verified this session)
- [ ] `make test` — not fully green: 3 pre-existing failures in `tests/unit/test_pattern_safety.py::TestRedosGuardAlwaysRunsHeuristic` (re2 mocking, `AttributeError: module 'pattern_safety' has no attribute '_re2'`), unrelated to this change and reproduced identically on unmodified `origin/main`. All 1960 other tests pass, including the new/updated pricing tests (25/25 in `TestPricing`) run directly via `pytest tests/unit/test_model_registry.py -k Pricing -v`.
- [x] Docs updated (CHANGELOG only; no user-facing docs describe `per_input_chars()` behavior beyond its docstring, which was updated)

### Pre-PR triangulated review (3 independent sub-agent passes over the committed diff)
- **Correctness & tests**: resolves #54, no regression to prompt-based path, tests meaningful. No P0/P1. P2s (non-blocking): negative `char_count` isn't filtered like non-numeric values are; no explicit test pinning `prompt=""` vs `prompt=None` equivalence (already covered behaviorally via `ctx.step.prompt or ""`).
- **Security & invariants**: no `AGENTS.md` invariant affected — `cost_usd` is already excluded from the canonical hash (`_STEP_HASH_EXCLUDE`), so this only affects display/manifest cost, never provenance/hashing. No injection/SSRF/secrets risk (pure in-memory arithmetic). P2 (non-blocking): `_float_or_none` doesn't catch `OverflowError` or reject NaN/Infinity — pre-existing shared helper behavior (already used by `bucketed_by_duration`), safely contained by `compute_cost`'s existing exception boundary.
- **Architecture & DRY**: reuses the existing `_float_or_none` helper rather than duplicating coercion logic; fits the module's existing patterns; no scale concern given `step.inputs` is a small bounded list. No P0/P1.

No blocking findings — all P2s are non-blocking, documented above for follow-up if desired.

## Related

Closes #54