### PR TITLE
fix(packaging): dependency upper-bound policy + drop redundant license classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   see the `genblaze-core` entry above for the root cause. `provider.py` now
   builds its `file://` asset URL via `genblaze_core._utils.local_file_url()`.
 
+### Packaging
+
+- **Fixed** every package's `pyproject.toml` declared both the PEP 639
+  `license = "MIT"` SPDX expression and the legacy
+  `License :: OSI Approved :: MIT License` trove classifier; PEP 639 says the
+  classifier SHOULD NOT be used alongside a license expression, and
+  setuptools >= 77 errors on the combination. Removed the redundant
+  classifier from all 18 `pyproject.toml` files; `license = "MIT"` is
+  unchanged (#60).
+- Applied a consistent upper-bound policy to third-party runtime
+  dependencies: every dependency in `[project.dependencies]` (and
+  non-dev-tooling `optional-dependencies` extras) across `libs/core`, every
+  connector, `cli`, and the umbrella now caps below its next major version,
+  matching the bounded-major convention the repo already used for
+  `pydantic<3`, `urllib3<3`, `lmnt<3`, and `elevenlabs<3`. Packages still on
+  a pre-1.0 line (`decart`, `langsmith`, `httpx`) cap at their next major
+  (`<1`), matching the existing `assemblyai<1`/`hume<1` precedent rather than
+  a next-minor rule, so pre-1.0 and post-1.0 SDKs follow one rule. Where a
+  connector's documented floor was already several majors behind the version
+  it resolves to today (`runwayml` floor 0.6 vs. resolved 4.x, `replicate`
+  floor 0.25 vs. resolved 1.x, `openai` floor 1.0 vs. resolved 2.x), the cap
+  was set one major past the currently-resolving version instead of the
+  floor's next major, so this fix doesn't reject the version already in use;
+  the stale floors themselves are unchanged (out of scope here). Dev/test
+  tooling extras (`pytest`, `ruff`, `mypy`, `deptry`, `hypothesis`,
+  `jsonschema`, etc.) are unaffected — this policy applies to dependencies
+  actually shipped to and resolved by consumers (#61).
+
 ## [0.5.0] - 2026-07-16
 
 Correctness and security hardening across the pipeline, provenance, streaming,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,10 +172,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a next-minor rule, so pre-1.0 and post-1.0 SDKs follow one rule. Where a
   connector's documented floor was already several majors behind the version
   it resolves to today (`runwayml` floor 0.6 vs. resolved 4.x, `replicate`
-  floor 0.25 vs. resolved 1.x, `openai` floor 1.0 vs. resolved 2.x), the cap
-  was set one major past the currently-resolving version instead of the
-  floor's next major, so this fix doesn't reject the version already in use;
-  the stale floors themselves are unchanged (out of scope here). Dev/test
+  floor 0.25 vs. resolved 1.x, `openai` floor 1.0 vs. resolved 2.x,
+  `genblaze-core`'s `parquet` extra's `pyarrow` floor 14.0 vs. resolved 22.x),
+  the cap was set one major past the currently-resolving version instead of
+  the floor's next major, so this fix doesn't reject the version already in
+  use; the stale floors themselves are unchanged (out of scope here). Dev/test
   tooling extras (`pytest`, `ruff`, `mypy`, `deptry`, `hypothesis`,
   `jsonschema`, etc.) are unaffected — this policy applies to dependencies
   actually shipped to and resolved by consumers (#61).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,36 @@ Convention:
 The release workflow validates `tag == "v" + latest CHANGELOG wave name`
 before doing anything else. A mismatch fails the run.
 
+## Dependency pinning policy
+
+Two independent conventions apply to every `pyproject.toml`'s
+`[project.dependencies]` and product-facing `optional-dependencies` extras
+(dev/test tooling extras like `dev`/`testing` are exempt — see below):
+
+* **Internal `genblaze-*` deps** are pinned `>=<current>,<0.4` (bump the
+  upper bound only when the monorepo's own version line advances — see
+  `tools/check_pin_parity.py`).
+* **Third-party runtime deps** are capped below their next major version
+  (`>=X.Y,<X+1`), including packages still on a pre-1.0 line (`>=0.Y,<1`) —
+  e.g. `pydantic>=2.0,<3`, `lmnt>=2.6,<3`, `elevenlabs>=2.0,<3`,
+  `assemblyai>=0.45,<1`, `hume>=0.13.13,<1`. One rule for both pre- and
+  post-1.0 SDKs keeps the policy mechanical instead of requiring a judgment
+  call per package about how "volatile" its 0.x line is. An uncapped
+  third-party dep lets a vendor's major release break a clean `pip install`
+  at resolve time with no code change on our side — this is the exact class
+  of bug that broke `genblaze-lmnt` and `genblaze-elevenlabs` (#166, #163).
+  Dev/test tooling extras (`pytest`, `ruff`, `mypy`, `deptry`, `hypothesis`,
+  `jsonschema`, etc., normally grouped under a `dev` or `testing` extra) are
+  exempt from this cap — they're never resolved into a production install,
+  so a future major there costs us a CI failure to fix, not a broken
+  consumer install.
+
+  When a connector's floor is already several majors behind the version it
+  actually resolves to today (a floor-staleness bug in its own right, not a
+  packaging-cap issue), cap one major past the version currently verified
+  to work rather than the floor's next major — capping tighter than what's
+  actually in use would make a fresh install worse, not safer.
+
 ## Pre-release checklist
 
 Before cutting a release, verify on `main`:

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Environment :: Console",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,9 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.6,<0.4",
-    "click>=8.0",
+    # <9: bounded-major convention (#61) — caps below the next major so a
+    # future click release can't silently break the CLI at resolve time.
+    "click>=8.0,<9",
 ]
 
 [project.urls]

--- a/docs/guides/new-provider.md
+++ b/docs/guides/new-provider.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-07-21 -->
 # Adding a New Provider
 
 Step-by-step guide for contributing a provider adapter to genblaze. This guide is the canonical contract — every section maps to a check the compliance harness or pipeline relies on.
@@ -66,12 +66,15 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
 ]
 dependencies = [
     "genblaze-core>=0.3.0,<0.4",
-    "myprovider-sdk>=1.0",
+    # Cap every third-party runtime dep below its next major (`<1` if the
+    # SDK is still pre-1.0 — one rule for both, no separate next-minor
+    # carve-out) so a vendor major bump can't silently break a fresh
+    # install — see RELEASING.md's Dependency pinning policy (#61).
+    "myprovider-sdk>=1.0,<2",
 ]
 
 [project.urls]

--- a/libs/connectors/assemblyai/pyproject.toml
+++ b/libs/connectors/assemblyai/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/libs/connectors/decart/pyproject.toml
+++ b/libs/connectors/decart/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,11 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "decart>=0.0.28",
+    # <1: bounded-major convention (#61) — decart is pre-1.0, so this caps at
+    # its next major (matches the assemblyai/hume precedent for other
+    # pre-1.0 SDKs elsewhere in this repo) rather than inventing a
+    # next-minor rule for this one package.
+    "decart>=0.0.28,<1",
 ]
 
 [project.urls]

--- a/libs/connectors/elevenlabs/pyproject.toml
+++ b/libs/connectors/elevenlabs/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/libs/connectors/gmicloud/pyproject.toml
+++ b/libs/connectors/gmicloud/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,9 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "httpx>=0.24",
+    # <1: bounded-major convention (#61) — httpx is pre-1.0, so this caps at
+    # its next major.
+    "httpx>=0.24,<1",
 ]
 
 [project.urls]

--- a/libs/connectors/google/pyproject.toml
+++ b/libs/connectors/google/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,10 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "google-genai>=1.0",
+    # <2: bounded-major convention (#61) — caps below the next major so a
+    # future google-genai release can't silently break this connector at
+    # resolve time.
+    "google-genai>=1.0,<2",
 ]
 
 [project.urls]

--- a/libs/connectors/hume/pyproject.toml
+++ b/libs/connectors/hume/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/libs/connectors/langsmith/pyproject.toml
+++ b/libs/connectors/langsmith/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,10 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "langsmith>=0.1.0",
+    # <1: bounded-major convention (#61) — langsmith is pre-1.0, so this caps
+    # at its next major (matches the assemblyai/hume precedent for other
+    # pre-1.0 SDKs elsewhere in this repo).
+    "langsmith>=0.1.0,<1",
 ]
 
 [project.urls]

--- a/libs/connectors/lmnt/pyproject.toml
+++ b/libs/connectors/lmnt/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/libs/connectors/luma/pyproject.toml
+++ b/libs/connectors/luma/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,10 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "lumaai>=1.0",
+    # <2: bounded-major convention (#61) — caps below the next major so a
+    # future lumaai release can't silently break this connector at resolve
+    # time.
+    "lumaai>=1.0,<2",
 ]
 
 [project.urls]

--- a/libs/connectors/nvidia/pyproject.toml
+++ b/libs/connectors/nvidia/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,9 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "httpx>=0.24",
+    # <1: bounded-major convention (#61) — httpx is pre-1.0, so this caps at
+    # its next major.
+    "httpx>=0.24,<1",
 ]
 
 [project.urls]
@@ -39,7 +40,9 @@ dev = [
     "pytest>=7.0",
 ]
 chat = [
-    "openai>=1.0",
+    # <3: bounded-major convention (#61); matches the cap the openai
+    # connector (genblaze-openai) uses for the same package.
+    "openai>=1.0,<3",
 ]
 
 [project.entry-points."genblaze.providers"]

--- a/libs/connectors/openai/pyproject.toml
+++ b/libs/connectors/openai/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,12 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "openai>=1.0",
+    # <3: bounded-major convention (#61). The documented floor (1.0) predates
+    # the SDK's current major line — openai resolves to 2.x today, so
+    # capping at the next major after 1.0 (<2) would reject the version this
+    # connector is actually verified against. Capped one major past what's
+    # currently verified instead; the floor itself is unchanged here.
+    "openai>=1.0,<3",
 ]
 
 [project.urls]

--- a/libs/connectors/replicate/pyproject.toml
+++ b/libs/connectors/replicate/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,8 +23,13 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "replicate>=0.25",
-    "httpx>=0.24",
+    # <2: bounded-major convention (#61). The documented floor (0.25) predates
+    # the SDK's current major line — replicate resolves to 1.x today, so
+    # capping at the next major after 0.25 (<1) would reject the version this
+    # connector is actually verified against. Capped one major past what's
+    # currently verified instead; the floor itself is unchanged here.
+    "replicate>=0.25,<2",
+    "httpx>=0.24,<1",
 ]
 
 [project.urls]

--- a/libs/connectors/runway/pyproject.toml
+++ b/libs/connectors/runway/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,13 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "runwayml>=0.6",
+    # <5: bounded-major convention (#61). The documented floor (0.6) predates
+    # the SDK's current major line — runwayml resolves to 4.x today, so
+    # capping at the next major after 0.6 (<1) would reject the version this
+    # connector is actually verified against. Capped one major past what's
+    # currently verified instead; the floor itself is unchanged here (raising
+    # it is a separate, larger fix — see #61 follow-up notes).
+    "runwayml>=0.6,<5",
 ]
 
 [project.urls]

--- a/libs/connectors/s3/pyproject.toml
+++ b/libs/connectors/s3/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,13 +23,17 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "boto3>=1.28",
+    # <2: bounded-major convention (#61) — caps below the next major so a
+    # future boto3 release can't silently break this connector at resolve
+    # time.
+    "boto3>=1.28,<2",
     # backend.py imports botocore.exceptions directly (unguarded, module load).
     # boto3 always ships it, but declaring the direct import is honest and lets
     # deptry verify it. Floor tracks boto3>=1.28's botocore baseline; safe
     # because pip propagates boto3's exact botocore pin (a `--no-deps` install
-    # could still skew it, but that bypasses all our gates anyway).
-    "botocore>=1.31",
+    # could still skew it, but that bypasses all our gates anyway). <2 caps
+    # below the next major, same as boto3 above (#61).
+    "botocore>=1.31,<2",
 ]
 
 [project.urls]
@@ -49,8 +52,11 @@ async = [
     # async_backend.py imports aiobotocore.config.AioConfig directly. aioboto3
     # always pulls it, but the direct import is declared so deptry can verify
     # it; aioboto3 pins the exact aiobotocore (==2.7.0 at our 12.0 floor), so no
-    # resolver conflict — the floor just matches that true minimum.
-    "aiobotocore>=2.7",
+    # resolver conflict — the floor just matches that true minimum. <3 caps
+    # below the next major (#61); aioboto3 above already pins the exact
+    # aiobotocore it needs, so this cap is a backstop, not the binding
+    # constraint.
+    "aiobotocore>=2.7,<3",
 ]
 dev = [
     "pytest>=7.0",

--- a/libs/connectors/stability-audio/pyproject.toml
+++ b/libs/connectors/stability-audio/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -24,7 +23,9 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "genblaze-core>=0.3.4,<0.4",
-    "httpx>=0.24",
+    # <1: bounded-major convention (#61) — httpx is pre-1.0, so this caps at
+    # its next major.
+    "httpx>=0.24,<1",
 ]
 
 [project.urls]

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -13,7 +13,6 @@ license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -25,7 +24,11 @@ keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "
 
 dependencies = [
     "pydantic>=2.0,<3",
-    "pillow>=10.0",
+    # <12: bounded-major convention (cf. pydantic<3, urllib3<3 below) — caps
+    # below the next major past the currently-verified 11.x release so a
+    # future Pillow major can't silently land breaking changes at resolve
+    # time (#61).
+    "pillow>=10.0,<12",
     # urllib3 is imported unguarded at module load in storage/transfer.py
     # (the shared PoolManager backing AssetTransfer's presigned-URL streaming),
     # and storage/__init__ imports transfer eagerly — so `import
@@ -47,7 +50,13 @@ Changelog = "https://github.com/backblaze-labs/genblaze/blob/main/CHANGELOG.md"
 Issues = "https://github.com/backblaze-labs/genblaze/issues"
 
 [project.optional-dependencies]
-parquet = ["pyarrow>=14.0"]
+# <23: pyarrow's leading version number bumps roughly every quarterly release
+# rather than tracking semver majors strictly, and the currently-resolvable
+# release (22.x) is already far past the 14.0 floor; capping at 14 or 15
+# would reject the version this extra is actually verified against today.
+# Bounded one major past what's currently verified (#61) rather than left
+# uncapped, matching the repo's bounded-major convention (cf. pydantic<3).
+parquet = ["pyarrow>=14.0,<23"]
 # <1.49: mutagen 1.48 changed m4a timescale handling in a way that broke our
 # test fixture (#108); cap until 1.49 is vetted against the test suite.
 audio = ["mutagen>=1.47,<1.49"]
@@ -55,8 +64,11 @@ audio = ["mutagen>=1.47,<1.49"]
 # function-local), so core stays installable without them. Advertised as
 # extras so callers can opt in explicitly. http floor matches the connectors
 # already on httpx>=0.24 (nvidia, gmicloud, stability-audio, replicate).
-http = ["httpx>=0.24"]
-otel = ["opentelemetry-api>=1.20"]
+# <1: bounded-major convention (#61); httpx is still pre-1.0 so this caps at
+# its next major rather than a next-minor (matches assemblyai/hume precedent
+# for other pre-1.0 SDKs elsewhere in this repo).
+http = ["httpx>=0.24,<1"]
+otel = ["opentelemetry-api>=1.20,<2"]
 # Additional linear-time gate for providers/pattern_safety.py's ReDoS guard
 # (issue #80), on top of the static heuristic that always runs regardless
 # (issue #148 — re2 accepting a pattern doesn't make it safe under the
@@ -66,7 +78,7 @@ otel = ["opentelemetry-api>=1.20"]
 # the Python versions this repo supports, so declaring it here (and in
 # `dev`, below) is low-risk and is what actually activates this extra gate
 # in CI.
-re2 = ["google-re2>=1.0"]
+re2 = ["google-re2>=1.0,<2"]
 # genblaze_core.testing ships in the wheel and is a public, documented surface
 # (MockProvider/ProviderComplianceTests — see connector test suites and the
 # langsmith README). It imports pytest at module load, so it's only usable with
@@ -79,15 +91,15 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.8",
     "deptry>=0.23",
-    "pyarrow>=14.0",
+    "pyarrow>=14.0,<23",
     # <1.49: mutagen 1.48 changed m4a timescale handling in a way that broke our
     # test fixture (#108); cap until 1.49 is vetted against the test suite.
     "mutagen>=1.47,<1.49",
     "jsonschema>=4.0",
     "hypothesis>=6.0",
-    "httpx>=0.24",
-    "opentelemetry-api>=1.20",
-    "google-re2>=1.0",
+    "httpx>=0.24,<1",
+    "opentelemetry-api>=1.20,<2",
+    "google-re2>=1.0,<2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -13,7 +13,6 @@ license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/tools/check_pypi_metadata.py
+++ b/tools/check_pypi_metadata.py
@@ -8,10 +8,13 @@ see on PyPI:
 * ``description`` — single sentence, ≤ 200 chars
 * ``readme`` — set (safe per-package README file path, not just root link)
 * ``authors`` — populated
-* ``license`` — set
+* ``license`` — set (PEP 639 SPDX expression, e.g. ``license = "MIT"``); no
+  redundant ``License ::`` classifier alongside it (PEP 639 says classifiers
+  SHOULD NOT be used when a license expression is present, and
+  setuptools >= 77 errors on the combination — see CHANGELOG #60)
 * ``requires-python`` — ``>=3.11`` (matches AGENTS.md invariant)
-* ``classifiers`` — License (MIT), Python versions (3.11/3.12/3.13),
-  Topic, Development Status
+* ``classifiers`` — Python versions (3.11/3.12/3.13), Topic, Development
+  Status
 * ``project.urls`` — Homepage, Documentation, Repository, Issues
 * ``keywords`` — non-empty
 * ``readme`` Markdown links — absolute URLs only for files rendered on PyPI
@@ -37,13 +40,19 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 # Required classifier prefixes — at least one classifier in each group
-# must be present.
+# must be present. License is intentionally excluded: PEP 639's
+# `license = "MIT"` SPDX expression is the single source of truth (see the
+# `_LICENSE_CLASSIFIER_PREFIX` check below, which asserts the classifier is
+# *absent*, not present).
 _REQUIRED_CLASSIFIER_GROUPS: dict[str, list[str]] = {
-    "license": ["License :: "],
     "python_versions": ["Programming Language :: Python :: 3.1"],
     "topic": ["Topic :: "],
     "dev_status": ["Development Status :: "],
 }
+
+# PEP 639: a `License ::` trove classifier is redundant — and, on
+# setuptools >= 77, an error — once a `license` SPDX expression is set.
+_LICENSE_CLASSIFIER_PREFIX = "License :: "
 
 # Required project_urls keys (case-sensitive — matches PyPI rendering).
 _REQUIRED_PROJECT_URLS = ("Homepage", "Documentation", "Repository", "Issues")
@@ -327,6 +336,10 @@ def _check_package(path: Path) -> list[str]:
     license_field = project.get("license")
     if not license_field:
         issues.append("missing `license`")
+    if any(c.startswith(_LICENSE_CLASSIFIER_PREFIX) for c in project.get("classifiers", [])):
+        issues.append(
+            "redundant `License ::` classifier alongside `license` SPDX expression (PEP 639)"
+        )
 
     # requires-python
     rp = project.get("requires-python")

--- a/tools/tests/test_check_pypi_metadata.py
+++ b/tools/tests/test_check_pypi_metadata.py
@@ -36,7 +36,6 @@ requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Topic :: Multimedia",
 ]
@@ -270,6 +269,31 @@ def test_check_package_reports_unreadable_readme(tmp_path: Path):
 
     assert len(issues) == 1
     assert issues[0].startswith("genblaze-example: readme file cannot be read: README.md: ")
+
+
+def test_check_package_rejects_redundant_license_classifier(tmp_path: Path):
+    """PEP 639: a `License ::` classifier alongside `license = "MIT"` is
+    redundant and setuptools >= 77 errors on the combination (#60)."""
+    pyproject = _write_package(tmp_path, "See [docs](https://example.com/docs).\n")
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace(
+            '"Development Status :: 3 - Alpha",',
+            '"Development Status :: 3 - Alpha",\n    "License :: OSI Approved :: MIT License",',
+        ),
+        encoding="utf-8",
+    )
+
+    assert cpm._check_package(pyproject) == [
+        "genblaze-example: redundant `License ::` classifier alongside "
+        "`license` SPDX expression (PEP 639)"
+    ]
+
+
+def test_check_package_allows_no_license_classifier(tmp_path: Path):
+    """Baseline: `license = "MIT"` with no classifier is the desired state."""
+    pyproject = _write_package(tmp_path, "See [docs](https://example.com/docs).\n")
+
+    assert cpm._check_package(pyproject) == []
 
 
 def test_check_package_rejects_readme_swapped_after_validation(


### PR DESCRIPTION
## Summary

Bundles two cross-package packaging fixes that both sweep every `pyproject.toml` (bundling avoids two mechanical rebases of the same 18 files):

- **#61** — no consistent upper-bound policy existed for third-party runtime dependencies; several were completely uncapped (`openai>=1.0`, `replicate>=0.25`, `google-genai>=1.0`, `decart>=0.0.28`, etc.), which is the exact bug class that broke `genblaze-lmnt`/`genblaze-elevenlabs` on a recent vendor major bump.
- **#60** — every package paired the PEP 639 `license = "MIT"` SPDX expression with the now-redundant `License :: OSI Approved :: MIT License` trove classifier; PEP 639 says the classifier SHOULD NOT be used alongside the expression, and setuptools >= 77 errors on the combination.

## Changes

**Investigation first:** no existing documented policy for third-party dep caps existed (`RELEASING.md` / `tools/check_pin_parity.py` only cover the internal `genblaze-*` convention). The recent `lmnt>=2.6,<3` / `elevenlabs>=2.0,<3` fixes and the pre-existing `assemblyai>=0.45,<1` / `hume>=0.13.13,<1` pins are the closest thing to precedent, so the policy adopted here is: **cap every third-party runtime dep below its next major**, including pre-1.0 SDKs at `<1` (one rule for both pre- and post-1.0, matching the existing assemblyai/hume precedent rather than inventing a separate next-minor carve-out for 0.x). Documented in a new "Dependency pinning policy" section in `RELEASING.md`.

- All 18 `pyproject.toml` files: added upper bounds to every previously-uncapped third-party runtime dependency (`pillow`, `click`, `pyarrow`, `httpx`, `opentelemetry-api`, `google-re2`, `decart`, `runwayml`, `lumaai`, `replicate`, `google-genai`, `openai`, `langsmith`, `boto3`, `botocore`, `aiobotocore`). Dev/test-tooling extras (`pytest`, `ruff`, `mypy`, `deptry`, `hypothesis`, `jsonschema`) are deliberately left uncapped — they're never resolved into a production install.
- Where a connector's documented floor was already several majors behind the version it actually resolves to today (`runwayml` floor 0.6 vs. resolved 4.x, `replicate` floor 0.25 vs. resolved 1.x, `openai` floor 1.0 vs. resolved 2.x, core's `pyarrow` floor 14.0 vs. resolved 22.x), the cap was set one major past the currently-resolving version instead of the floor's next major, so this fix doesn't reject what's already in use. The floors themselves are unchanged (separate, out-of-scope tech debt — noted in code comments and CHANGELOG).
- Removed the redundant `License ::` classifier from all 18 files; `license = "MIT"` is unchanged.
- `tools/check_pypi_metadata.py`: the CI metadata gate previously *required* the classifier's presence (a direct conflict with #60) — flipped it to assert the classifier's *absence*, with two new tests (`tools/tests/test_check_pypi_metadata.py`).
- `docs/guides/new-provider.md`: the scaffolding template still showed the old classifier and an uncapped example dep — fixed so the next new connector doesn't fail the new gate on day one (caught by the architecture review pass below).
- `CHANGELOG.md` `[Unreleased]` → new `### Packaging` section referencing both issues.

## Test plan

- [x] `make test` passes (1957 tests, including `tools/tests/`)
- [x] `make lint` passes (ruff + deptry across all packages)
- [x] `make typecheck` passes (mypy, 92 source files)
- [x] `make pypi-metadata-check` — 18/18 packages clean (was 0/18 before the gate fix, since removing the classifier without updating the gate would have broken it)
- [ ] `make pypi-pin-parity` — reports expected diffs (source pins changed but package versions weren't bumped in this PR). This is by design: this repo's `prepare_release.py` release-prep step, run separately before cutting a release wave, is what bumps per-package versions — not a code-change PR. Not part of the standard PR CI gate (`.github/workflows/ci.yml` doesn't run it).
- [x] Resolve smoke test: `pip install --dry-run -e <pkg>` for every touched connector/core extra resolves cleanly against the actual PyPI-installed versions in this environment with no conflicts (verified individually for core, cli, decart, runway, luma, replicate, google, openai, langsmith, gmicloud, stability-audio, nvidia, s3[async])
- Docs updated in this PR (`RELEASING.md`, `CHANGELOG.md`, `docs/guides/new-provider.md`)

### Triangulated review (3 independent lenses on the committed diff)

- **Correctness & tests** — no P0/P1. Verified live against all 18 packages; spot-checked every cap against actually-installed versions; confirmed test quality and full-branch coverage.
- **Security & invariants** — no P0/P1. Confirmed no `AGENTS.md` invariant is touched; spot-checked caps against CVE history (no ceiling re-admits a known-vulnerable version); confirmed the new classifier check is a plain string-prefix match (no ReDoS); no secrets in diff. One P2 noted (pre-existing floor staleness on `urllib3`/`pyarrow` — unrelated to this PR, which only adds ceilings).
- **Architecture, scalability & DRY** — no P0. One P1 (stale `docs/guides/new-provider.md` template) — fixed in a follow-up commit on this branch. Two P2s noted: no automated gate enforces the cap policy going forward (documentation-only — a reasonable follow-up, out of scope here) and the CHANGELOG's stale-floor example list initially omitted `pyarrow` — also fixed.

## Related

Closes #61
Closes #60