### PR TITLE
fix(security): close ReDoS heuristic gaps for overlapping alternation and delimiter-separated groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Security** the ReDoS pattern-safety heuristic (`pattern_safety.py`) missed
   two catastrophic-backtracking shapes: a quantified alternation with
-  overlapping-but-not-identical branches (`(a|aa)+`), and adjacent
+  overlapping (not just byte-identical or textually-prefixed) branches, e.g.
+  `(a|aa)+` or the character-class overlap `(?:[a-c]|[a-z]{2})+`; and adjacent
   unbounded-quantified groups separated by a nullable delimiter like `-?` or
-  `\s*` (`(a+)-?(a+)`) (#157). Both are now rejected by `assert_safe()`. This
-  is hardening, not a fix for an active exploit — the shipped connector
-  catalog contains no pattern of either shape; the exposure was a
+  `\s*` (`(a+)-?(a+)`) (#157). Both are now rejected by `assert_safe()` — the
+  alternation check adds a character-set overlap test (on top of the existing
+  textual-prefix check) for branches that reduce to a flat sequence of simple
+  atoms. This is hardening, not a fix for an active exploit — the shipped
+  connector catalog contains no pattern of either shape; the exposure was a
   future/third-party connector pattern letting an attacker-influenced value
   reach `ModelFamily.matches()` and hang the worker. Residual gaps (documented
-  in the module docstring): overlapping branches with no prefix relationship,
-  and a mandatory delimiter whose own characters coincide with a flanking
-  group's quantified content.
+  in the module docstring): a branch containing a nested group isn't reduced
+  to a character set, so overlap there still relies on the textual-prefix
+  check only (e.g. `a(?:b)?` vs `aa`); a mandatory delimiter whose own
+  characters coincide with a flanking group's quantified content (e.g.
+  `(a+)a(a+)`); and backreferences, which the static heuristic doesn't model
+  at all (pre-existing, masked by `google-re2` when installed).
 - **Fixed** `CONTENT_ADDRESSABLE` storage keys did not normalize the source
   extension's case, so byte-identical content fetched via a differently-cased
   extension (e.g. `IMG.PNG` vs `img.png`) hashed to the same sha256 but landed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### genblaze-core
 
+- **Security** the ReDoS pattern-safety heuristic (`pattern_safety.py`) missed
+  two catastrophic-backtracking shapes: a quantified alternation with
+  overlapping-but-not-identical branches (`(a|aa)+`), and adjacent
+  unbounded-quantified groups separated by a nullable delimiter like `-?` or
+  `\s*` (`(a+)-?(a+)`) (#157). Both are now rejected by `assert_safe()`. This
+  is hardening, not a fix for an active exploit — the shipped connector
+  catalog contains no pattern of either shape; the exposure was a
+  future/third-party connector pattern letting an attacker-influenced value
+  reach `ModelFamily.matches()` and hang the worker. Residual gaps (documented
+  in the module docstring): overlapping branches with no prefix relationship,
+  and a mandatory delimiter whose own characters coincide with a flanking
+  group's quantified content.
 - **Fixed** `CONTENT_ADDRESSABLE` storage keys did not normalize the source
   extension's case, so byte-identical content fetched via a differently-cased
   extension (e.g. `IMG.PNG` vs `img.png`) hashed to the same sha256 but landed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to a character set, so overlap there still relies on the textual-prefix
   check only (e.g. `a(?:b)?` vs `aa`); a mandatory delimiter whose own
   characters coincide with a flanking group's quantified content (e.g.
-  `(a+)a(a+)`); and backreferences, which the static heuristic doesn't model
-  at all (pre-existing, masked by `google-re2` when installed).
+  `(a+)a(a+)`); a nullable *group* between unbounded groups
+  (`(a+)(?:x)?(a+)`); and backreferences, which the static heuristic doesn't
+  model at all (pre-existing, masked by `google-re2` when installed). The
+  alternation character-set check is a deliberate conservative
+  over-approximation — two branches sharing any character are flagged, so a
+  few non-ambiguous alternations (`(?:v1|v2)+`) are rejected too. On rejection,
+  `assert_safe()` now names the specific shape and gives remediation that
+  actually clears the check (rather than a generic list including fixes, like
+  possessive quantifiers, that don't apply to every shape). A top-level
+  alternation of two unbounded groups (`(a+)|(b+)`) is correctly treated as
+  safe — the groups are in different branches, not adjacent.
 - **Fixed** `CONTENT_ADDRESSABLE` storage keys did not normalize the source
   extension's case, so byte-identical content fetched via a differently-cased
   extension (e.g. `IMG.PNG` vs `img.png`) hashed to the same sha256 but landed

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -29,11 +29,13 @@ regardless of whether ``re2`` is installed. Two gates are applied:
 * The static heuristic always runs and flags the most common
   catastrophic-backtracking shapes: nested unbounded quantifiers (bare
   ``+``/``*`` or an open-ended ``{n,}`` brace quantifier, at any nesting
-  depth), alternations of identical branches, runs of the same atom
-  quantified back-to-back (``a+a+a+``), and 2+ adjacent parenthesized
-  groups each carrying an unbounded quantifier (``(a+)(a+)``) — the
-  ambiguous-partitioning shape, distinct from ``(a+)+``'s outer-quantifier
-  shape.
+  depth), a quantified alternation with overlapping branches — not just
+  byte-identical ones, e.g. ``(a|aa)+`` (issue #157) — runs of the same
+  atom quantified back-to-back (``a+a+a+``), and 2+ adjacent parenthesized
+  groups each carrying an unbounded quantifier, optionally separated by a
+  nullable delimiter such as ``-?`` or ``\\s*`` (``(a+)(a+)``,
+  ``(a+)-?(a+)`` — issue #157) — the ambiguous-partitioning shape, distinct
+  from ``(a+)+``'s outer-quantifier shape.
 
 The heuristic is conservative on purpose. It rejects clearly-bad patterns;
 it does not pretend to detect every pathological case. Connector authors
@@ -41,6 +43,18 @@ who hit a false positive can rewrite the pattern (typically by anchoring
 or making quantifiers possessive). Authors who write subtly-bad patterns
 that slip past the heuristic are caught by the perf gate in
 ``tests/perf/test_registry_perf.py`` (P99 < 100 µs on adversarial inputs).
+
+Known residual gaps (not detected): overlapping alternation branches where
+neither is a prefix of the other (e.g. shared suffix or interior overlap,
+as opposed to ``a``/``aa``'s prefix relationship); a mandatory (non-
+nullable) delimiter whose own characters overlap with a flanking group's
+quantified content (e.g. ``(a+)a(a+)`` — the separator "a" isn't nullable,
+so ``_is_nullable_separator`` doesn't flag it, but it can still coincide
+with the groups' own matched text). Both are true ReDoS shapes in
+principle; they're narrower and rarer than the patterns above, and are left
+as future hardening rather than blocking this heuristic on a full
+regex-language-equivalence analysis, which is out of scope for a
+lightweight static check.
 """
 
 from __future__ import annotations
@@ -86,12 +100,15 @@ _UNBOUNDED_QUANT: Final[str] = r"(?:[+*]|\{\d*,\})"
 _NESTED_QUANTIFIER: Final[re.Pattern[str]] = re.compile(
     rf"\([^)]*{_UNBOUNDED_QUANT}[^)]*\)\s*{_UNBOUNDED_QUANT}"
 )
-_DUPLICATE_ALTERNATION: Final[re.Pattern[str]] = re.compile(
-    rf"\(([^)|]+)\|\1\)\s*{_UNBOUNDED_QUANT}"
-)
 _ADJACENT_QUANTIFIED_ATOM: Final[re.Pattern[str]] = re.compile(
     rf"(\\.|\[[^\]]*\]|.){_UNBOUNDED_QUANT}(?:\1{_UNBOUNDED_QUANT}){{2,}}"
 )
+
+# A leading capturing-group marker to strip before splitting an alternation's
+# branches: non-capturing (`?:`) or named (`?P<name>`). Lookaround markers
+# (`?=`, `?!`, `?<=`, `?<!`) intentionally don't match here — see
+# ``_has_ambiguous_quantified_alternation``.
+_GROUP_MARKER: Final[re.Pattern[str]] = re.compile(r"^\?(?::|P<[^>]*>)")
 
 
 def _iter_group_spans(src: str) -> list[tuple[int, int]]:
@@ -151,10 +168,40 @@ def _has_nested_unbounded_quantifier(src: str) -> bool:
     return False
 
 
+def _is_nullable_separator(fragment: str) -> bool:
+    """True if ``fragment`` — the raw text sitting between two top-level
+    groups — can itself match the empty string, e.g. ``-?``, ``\\s*``,
+    ``(?:foo)?``, or the empty string itself.
+
+    A separator that can vanish doesn't break adjacency: on the adversarial
+    input that makes the two flanking groups ambiguous, the regex engine
+    also tries the zero-length match for the separator, so the groups are
+    effectively adjacent on that backtracking path too (issue #157 — the
+    original adjacency check required the separator to be literally empty,
+    which a bare ``-?`` between ``(a+)`` groups evades while preserving the
+    exponential blowup). Checked by actually compiling the fragment and
+    matching it against ``""`` rather than pattern-matching its syntax,
+    since that generalizes to any nullable construct without needing to
+    enumerate them.
+    """
+    if fragment == "":
+        return True
+    try:
+        return re.fullmatch(fragment, "") is not None
+    except re.error:
+        # The fragment isn't valid as a standalone pattern (e.g. it contains
+        # a backreference to a group defined outside it). Can't prove it's
+        # nullable, but per this module's conservative bias (false positives
+        # over false negatives — see module docstring), don't rule it out
+        # either: treat it as a nullable/unsafe separator.
+        return True
+
+
 def _has_adjacent_unbounded_groups(src: str) -> bool:
     """True if 2+ top-level ``(...)`` groups, each containing an unbounded
-    quantifier, appear back-to-back with nothing between them — the
-    ``(a+)(a+)(a+)`` shape.
+    quantifier, appear back-to-back — separated by nothing, or only by text
+    that can match the empty string — the ``(a+)(a+)(a+)`` /
+    ``(a+)-?(a+)-?(a+)`` shape.
 
     Unlike ``(a+)+`` (an outer quantifier repeating one ambiguous group),
     this has *no* outer quantifier at all — the ambiguity comes purely from
@@ -164,7 +211,10 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
     100-character adversarial string under stdlib ``re``) — a real bypass
     of both ``_has_nested_unbounded_quantifier`` (no group is *itself*
     followed by a quantifier) and ``_ADJACENT_QUANTIFIED_ATOM`` (a
-    parenthesized group isn't a single "atom" that regex matches).
+    parenthesized group isn't a single "atom" that regex matches). A
+    *mandatory* (non-nullable) separator between the groups — a literal
+    character the group's own quantifier can't also match away — remains a
+    real anchor and isn't flagged (see ``_is_nullable_separator``).
     """
     spans = _iter_group_spans(src)
     # Only top-level groups matter for this shape — a group nested inside
@@ -177,11 +227,96 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
     prev_end: int | None = None
     for start, end in top_level:
         unbounded = bool(re.search(_UNBOUNDED_QUANT, src[start + 1 : end]))
-        adjacent = prev_end is not None and start == prev_end + 1
+        adjacent = prev_end is not None and _is_nullable_separator(src[prev_end + 1 : start])
         run = run + 1 if (adjacent and unbounded and run) else int(unbounded)
         if run >= 2:
             return True
         prev_end = end
+    return False
+
+
+def _split_top_level_alternatives(body: str) -> list[str]:
+    """Split ``body`` on ``|`` characters at nesting depth 0, treating
+    nested ``(...)`` groups and ``[...]`` classes as opaque so a branch
+    boundary inside a nested alternation (``(?:a|(?:b|c))``) isn't mistaken
+    for one of ``body``'s own top-level branches.
+    """
+    branches: list[str] = []
+    depth = 0
+    in_class = False
+    start = 0
+    i = 0
+    n = len(body)
+    while i < n:
+        ch = body[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if in_class:
+            if ch == "]":
+                in_class = False
+            i += 1
+            continue
+        if ch == "[":
+            in_class = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "|" and depth == 0:
+            branches.append(body[start:i])
+            start = i + 1
+        i += 1
+    branches.append(body[start:])
+    return branches
+
+
+def _has_ambiguous_quantified_alternation(src: str) -> bool:
+    """True if some ``(...)`` group is a 2+-branch alternation where one
+    branch is a prefix of another (including byte-identical branches), and
+    the group itself is immediately followed by an unbounded quantifier —
+    the ``(a|aa)+`` shape.
+
+    A quantified group doesn't need byte-identical branches to be
+    ambiguous under repetition: a strict prefix relationship (``a`` /
+    ``aa``) is just as dangerous, since a run of the shared prefix
+    character(s) can always be re-partitioned as one long branch match or
+    several short ones, giving the backtracker exponentially many
+    equivalent splits (issue #157 — the previous check matched only
+    literally-identical branches). Supersedes the old ``_DUPLICATE_ALTERNATION``
+    regex (2-branch, no-nesting-in-branch only): walking ``_iter_group_spans``
+    also covers 3+ branches and alternations containing nested groups.
+
+    Scoped to plain and non-capturing groups. Lookaround groups (``(?=...)``,
+    ``(?!...)``, ``(?<=...)``, ``(?<!...)``) are zero-width and quantifying
+    one is unusual; skipped rather than risk misreading unfamiliar syntax.
+    An empty branch (``(a|)+``) is also skipped — Python's ``re`` special-
+    cases zero-width alternatives in a loop to avoid infinite looping, so it
+    isn't the same exponential-backtracking shape as a genuine prefix
+    overlap.
+    """
+    for start, end in _iter_group_spans(src):
+        if not re.match(_UNBOUNDED_QUANT, src[end + 1 :]):
+            continue
+        body = src[start + 1 : end]
+        marker = _GROUP_MARKER.match(body)
+        if body.startswith("?") and not marker:
+            continue
+        if marker:
+            body = body[marker.end() :]
+        if "|" not in body:
+            continue
+        branches = _split_top_level_alternatives(body)
+        for i, branch_a in enumerate(branches):
+            for branch_b in branches[i + 1 :]:
+                if not branch_a or not branch_b:
+                    continue
+                if (
+                    branch_a == branch_b
+                    or branch_a.startswith(branch_b)
+                    or branch_b.startswith(branch_a)
+                ):
+                    return True
     return False
 
 
@@ -198,10 +333,10 @@ def _heuristic_unsafe(src: str) -> bool:
     """
     return bool(
         _NESTED_QUANTIFIER.search(src)
-        or _DUPLICATE_ALTERNATION.search(src)
         or _ADJACENT_QUANTIFIED_ATOM.search(src)
         or _has_nested_unbounded_quantifier(src)
         or _has_adjacent_unbounded_groups(src)
+        or _has_ambiguous_quantified_alternation(src)
     )
 
 
@@ -230,14 +365,15 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
 
     if _heuristic_unsafe(src):
         raise ValueError(
-            f"Pattern {src!r} has nested unbounded quantifiers, duplicate "
-            f"alternation branches, adjacent unbounded-quantified atoms, or "
-            f"adjacent unbounded-quantified groups, and is rejected to "
-            f"prevent catastrophic backtracking on adversarial input. "
-            f"Rewrite the pattern (anchor it, use non-capturing groups, or "
-            f"make quantifiers possessive) — installing google-re2 does not "
-            f"bypass this check, since runtime matching always uses stdlib "
-            f"re, which this heuristic protects."
+            f"Pattern {src!r} has nested unbounded quantifiers, an ambiguous "
+            f"(overlapping or duplicate) alternation under a quantifier, "
+            f"adjacent unbounded-quantified atoms, or adjacent (optionally "
+            f"delimiter-separated) unbounded-quantified groups, and is "
+            f"rejected to prevent catastrophic backtracking on adversarial "
+            f"input. Rewrite the pattern (anchor it, use non-capturing "
+            f"groups, or make quantifiers possessive) — installing "
+            f"google-re2 does not bypass this check, since runtime matching "
+            f"always uses stdlib re, which this heuristic protects."
         )
 
 

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -65,11 +65,27 @@ Known residual gaps (not detected):
   gate than this heuristic — see above); without the ``re2``/``dev``
   extra, a backreference-shaped pattern has no heuristic coverage. Not
   introduced by this change; pre-existing and out of scope for #157.
+* A nullable *group* between two unbounded groups (``(a+)(?:x)?(a+)`` or
+  ``(a+)(x?)(a+)``) evades the adjacency check: ``_has_adjacent_unbounded_groups``
+  treats a nullable *separator* (``-?``) as adjacency-preserving, but the
+  optional element here is itself a top-level group, so it resets the
+  run counter rather than being read as a separator. Same nullable-adjacency
+  shape ``_is_nullable_separator`` was added to catch, just wrapped in
+  parens.
 
-All three are true ReDoS shapes in principle; they're narrower than the
-patterns this module actively detects, and are left as future hardening
-rather than blocking this heuristic on a full regex-language-equivalence
-analysis, which is out of scope for a lightweight static check.
+These are all true ReDoS shapes — the same exponential class this module
+detects elsewhere, differing only in that *detecting* them requires
+reasoning the lightweight static check deliberately doesn't attempt (full
+regex-language equivalence). They're left as documented future hardening
+rather than blocking on that analysis.
+
+Deliberate over-rejection (conservative false positives): the alternation
+check treats *any* shared character between two branches as ambiguity, so
+some non-ambiguous quantified alternations are rejected too (``(?:v1|v2)+``,
+``(?:ab|bc)+`` — the differing character actually disambiguates them). This
+is intentional per the false-positive-over-false-negative bias above; do not
+"fix" it by weakening the check. Authors hitting it can split the alternation
+out of the quantifier.
 """
 
 from __future__ import annotations
@@ -246,7 +262,16 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
     prev_end: int | None = None
     for start, end in top_level:
         unbounded = bool(re.search(_UNBOUNDED_QUANT, src[start + 1 : end]))
-        adjacent = prev_end is not None and _is_nullable_separator(src[prev_end + 1 : start])
+        # Two groups are "adjacent" only if the text between them can vanish
+        # (a nullable separator — see _is_nullable_separator). A top-level `|`
+        # in that gap is the exception: it puts the groups in DIFFERENT
+        # alternation branches (`(a+)|(b+)`), so they're never matched on the
+        # same path and can't partition a shared run — not this shape, and a
+        # linear-time pattern that must not be rejected (issue #157 follow-up).
+        adjacent = False
+        if prev_end is not None:
+            sep = src[prev_end + 1 : start]
+            adjacent = len(_split_top_level_alternatives(sep)) == 1 and _is_nullable_separator(sep)
         run = run + 1 if (adjacent and unbounded and run) else int(unbounded)
         if run >= 2:
             return True
@@ -438,6 +463,15 @@ def _branch_charset(branch: str) -> tuple[bool, frozenset[str] | None]:
         else:
             charset.update(atom_charset)
 
+        # A bare +/* (including lazy/possessive `+?`, `*+`) makes the atom
+        # unbounded, so the branch isn't the flat bounded shape this function
+        # characterizes — bail, matching the docstring. Without this, `+`/`*`
+        # fall through and get consumed as literal `+`/`*` characters, wrongly
+        # reporting the branch reducible; today that's masked only because the
+        # nested-quantifier check runs first, which is fragile to rely on.
+        if i < n and branch[i] in "+*":
+            return False, None
+
         # Skip a bounded quantifier on the atom just consumed — its exact
         # repeat count doesn't matter for a character-overlap check, only
         # that it IS bounded (an unbounded one still bails out below, since
@@ -459,6 +493,12 @@ def _charsets_overlap(a: frozenset[str] | None, b: frozenset[str] | None) -> boo
     (unknown/full — see :func:`_escape_charset`/:func:`_bracket_charset`) is
     treated as overlapping with anything, per this module's bias toward
     false positives over false negatives.
+
+    Note this is a deliberate over-approximation of true ambiguity — a single
+    shared character is enough to report overlap, so some non-ambiguous
+    alternations (``(?:v1|v2)+``) are rejected. That's intentional; see the
+    "Deliberate over-rejection" note in the module docstring before tightening
+    it.
     """
     return a is None or b is None or bool(a & b)
 
@@ -528,6 +568,44 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
     return False
 
 
+def _unsafe_reason(src: str) -> str | None:
+    """Return a short, shape-specific description of the first
+    catastrophic-backtracking construct found in ``src``, or ``None`` if the
+    heuristic considers it safe.
+
+    Drives both the boolean gate (:func:`_heuristic_unsafe`) and the rejection
+    message in :func:`assert_safe`, so the message can name *which* shape fired
+    and give remediation that actually clears the check — rather than a generic
+    list of every possible reason plus fixes that may not apply (issue #157).
+    """
+    if _NESTED_QUANTIFIER.search(src) or _has_nested_unbounded_quantifier(src):
+        return (
+            "nested unbounded quantifiers such as `(a+)+` (an unbounded "
+            "quantifier repeated by another) — rewrite so no unbounded "
+            "quantifier is itself repeated, e.g. `(a+)+` -> `a+`"
+        )
+    if _has_ambiguous_quantified_alternation(src):
+        return (
+            "a quantified alternation whose branches can match overlapping "
+            "text, such as `(a|aa)+` — remove the overlap so each run of input "
+            "matches exactly one branch (e.g. `(a|aa)+` -> `a+`); note that "
+            "making the quantifier possessive does not clear this"
+        )
+    if _ADJACENT_QUANTIFIED_ATOM.search(src):
+        return (
+            "the same atom quantified back-to-back, such as `a+a+a+` — collapse "
+            "the repeats into a single quantifier, e.g. `a+a+` -> `a+`"
+        )
+    if _has_adjacent_unbounded_groups(src):
+        return (
+            "two or more adjacent unbounded-quantified groups, optionally "
+            "separated by a nullable delimiter, such as `(a+)(a+)` or "
+            "`(a+)-?(a+)` — separate them with a mandatory delimiter the groups "
+            "cannot themselves match"
+        )
+    return None
+
+
 def _heuristic_unsafe(src: str) -> bool:
     """Static ReDoS heuristic that always runs, whether or not ``re2`` is
     installed.
@@ -537,15 +615,10 @@ def _heuristic_unsafe(src: str) -> bool:
     about that pattern's safety under the engine actually used at match
     time (#148). Factored out of :func:`assert_safe` so it can be
     unit-tested directly regardless of whether ``re2`` happens to be
-    importable in the current environment.
+    importable in the current environment. Thin boolean wrapper over
+    :func:`_unsafe_reason`.
     """
-    return bool(
-        _NESTED_QUANTIFIER.search(src)
-        or _ADJACENT_QUANTIFIED_ATOM.search(src)
-        or _has_nested_unbounded_quantifier(src)
-        or _has_adjacent_unbounded_groups(src)
-        or _has_ambiguous_quantified_alternation(src)
-    )
+    return _unsafe_reason(src) is not None
 
 
 def assert_safe(pattern: re.Pattern[str]) -> None:
@@ -571,15 +644,11 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
                 f"(linear-time guarantee unavailable): {exc}"
             ) from exc
 
-    if _heuristic_unsafe(src):
+    reason = _unsafe_reason(src)
+    if reason is not None:
         raise ValueError(
-            f"Pattern {src!r} has nested unbounded quantifiers, an ambiguous "
-            f"(overlapping or duplicate) alternation under a quantifier, "
-            f"adjacent unbounded-quantified atoms, or adjacent (optionally "
-            f"delimiter-separated) unbounded-quantified groups, and is "
-            f"rejected to prevent catastrophic backtracking on adversarial "
-            f"input. Rewrite the pattern (anchor it, use non-capturing "
-            f"groups, or make quantifiers possessive) — installing "
+            f"Pattern {src!r} is rejected to prevent catastrophic backtracking "
+            f"on adversarial input: it contains {reason}. Installing "
             f"google-re2 does not bypass this check, since runtime matching "
             f"always uses stdlib re, which this heuristic protects."
         )

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -44,17 +44,32 @@ or making quantifiers possessive). Authors who write subtly-bad patterns
 that slip past the heuristic are caught by the perf gate in
 ``tests/perf/test_registry_perf.py`` (P99 < 100 µs on adversarial inputs).
 
-Known residual gaps (not detected): overlapping alternation branches where
-neither is a prefix of the other (e.g. shared suffix or interior overlap,
-as opposed to ``a``/``aa``'s prefix relationship); a mandatory (non-
-nullable) delimiter whose own characters overlap with a flanking group's
-quantified content (e.g. ``(a+)a(a+)`` — the separator "a" isn't nullable,
-so ``_is_nullable_separator`` doesn't flag it, but it can still coincide
-with the groups' own matched text). Both are true ReDoS shapes in
-principle; they're narrower and rarer than the patterns above, and are left
-as future hardening rather than blocking this heuristic on a full
-regex-language-equivalence analysis, which is out of scope for a
-lightweight static check.
+Known residual gaps (not detected):
+
+* An alternation branch containing a nested group (``a(?:b)?`` vs. ``aa``)
+  isn't reduced to a character set — ``_branch_charset`` bails out on any
+  ``(``/``)``/``|`` inside a branch, so overlap between two such branches
+  falls back to the plain textual-prefix check, which won't catch this
+  case. Closing this fully means recursing into sub-groups (and their own
+  possible alternation) to compute a charset, i.e. re-implementing
+  regex-language equivalence — disproportionate for a lightweight static
+  check, so it's left as a documented gap rather than chased.
+* A mandatory (non-nullable) delimiter whose own characters overlap with a
+  flanking group's quantified content (e.g. ``(a+)a(a+)`` — the separator
+  "a" isn't nullable, so ``_is_nullable_separator`` doesn't flag it, but it
+  can still coincide with the groups' own matched text).
+* Backreferences (``(a+)\1+``) aren't modeled by the static heuristic at
+  all — no check here looks past a backreference to the group it repeats.
+  Today this is masked whenever ``google-re2`` is installed, since re2
+  rejects backreferences outright as an unsupported construct (a different
+  gate than this heuristic — see above); without the ``re2``/``dev``
+  extra, a backreference-shaped pattern has no heuristic coverage. Not
+  introduced by this change; pre-existing and out of scope for #157.
+
+All three are true ReDoS shapes in principle; they're narrower than the
+patterns this module actively detects, and are left as future hardening
+rather than blocking this heuristic on a full regex-language-equivalence
+analysis, which is out of scope for a lightweight static check.
 """
 
 from __future__ import annotations
@@ -188,12 +203,15 @@ def _is_nullable_separator(fragment: str) -> bool:
         return True
     try:
         return re.fullmatch(fragment, "") is not None
-    except re.error:
-        # The fragment isn't valid as a standalone pattern (e.g. it contains
-        # a backreference to a group defined outside it). Can't prove it's
-        # nullable, but per this module's conservative bias (false positives
-        # over false negatives — see module docstring), don't rule it out
-        # either: treat it as a nullable/unsafe separator.
+    except (re.error, OverflowError):
+        # re.error: the fragment isn't valid as a standalone pattern (e.g.
+        # it contains a backreference to a group defined outside it).
+        # OverflowError: an absurdly large `{n,m}` repeat count (e.g.
+        # `{0,4294967296}`) raises this instead of re.error. Either way we
+        # can't prove the fragment is nullable, but per this module's
+        # conservative bias (false positives over false negatives — see
+        # module docstring), don't rule it out either: treat it as a
+        # nullable/unsafe separator.
         return True
 
 
@@ -271,29 +289,184 @@ def _split_top_level_alternatives(body: str) -> list[str]:
     return branches
 
 
-def _has_ambiguous_quantified_alternation(src: str) -> bool:
-    """True if some ``(...)`` group is a 2+-branch alternation where one
-    branch is a prefix of another (including byte-identical branches), and
-    the group itself is immediately followed by an unbounded quantifier —
-    the ``(a|aa)+`` shape.
+#: Character sets for the shorthand escape classes that expand to a concrete,
+#: bounded alphabet. The negated forms (``\D``, ``\W``, ``\S``) are each
+#: "everything except a known set" — rather than compute the true (effectively
+#: unbounded, non-ASCII-aware) complement, ``_escape_charset`` treats them as
+#: unknown/full (see its docstring).
+_ESCAPE_CLASS_CHARS: Final[dict[str, str]] = {
+    "d": "0123456789",
+    "w": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_",
+    "s": " \t\n\r\f\v",
+}
 
-    A quantified group doesn't need byte-identical branches to be
-    ambiguous under repetition: a strict prefix relationship (``a`` /
-    ``aa``) is just as dangerous, since a run of the shared prefix
-    character(s) can always be re-partitioned as one long branch match or
-    several short ones, giving the backtracker exponentially many
-    equivalent splits (issue #157 — the previous check matched only
-    literally-identical branches). Supersedes the old ``_DUPLICATE_ALTERNATION``
-    regex (2-branch, no-nesting-in-branch only): walking ``_iter_group_spans``
-    also covers 3+ branches and alternations containing nested groups.
+
+def _escape_charset(escape_body: str) -> frozenset[str] | None:
+    """Return the set of characters an escape sequence matches, given the
+    text right after its backslash (``"d"`` for ``\\d``, ``"x61"`` for
+    ``\\x61``, ``"."`` for ``\\.``, etc.), or ``None`` (unknown/full,
+    meaning "treat as potentially overlapping with anything") when it can't
+    be resolved to a concrete bounded set.
+    """
+    if len(escape_body) == 1 and escape_body.lower() in _ESCAPE_CLASS_CHARS:
+        # Uppercase (\D, \W, \S) is the negated class — unknown/full.
+        return None if escape_body.isupper() else frozenset(_ESCAPE_CLASS_CHARS[escape_body])
+    if len(escape_body) == 3 and escape_body[0] == "x":
+        try:
+            return frozenset([chr(int(escape_body[1:], 16))])
+        except ValueError:
+            return None
+    if len(escape_body) == 1:
+        return frozenset([escape_body])  # a literal char escaped for safety, e.g. \., \-, \(
+    return None
+
+
+def _consume_escape(src: str, i: int) -> tuple[frozenset[str] | None, int]:
+    """Parse the escape sequence at ``src[i] == "\\\\"``. Returns its
+    charset (see :func:`_escape_charset`) and the index just past it.
+    """
+    if i + 1 >= len(src):
+        return None, i + 1
+    if src[i + 1] == "x" and i + 3 < len(src):
+        return _escape_charset(src[i + 1 : i + 4]), i + 4
+    return _escape_charset(src[i + 1]), i + 2
+
+
+def _bracket_charset(body: str) -> frozenset[str] | None:
+    """Return the set of characters a ``[...]`` class body (the text
+    between the brackets) matches, or ``None`` (unknown/full) for a negated
+    class (``[^...]``) or a range too unusual to expand confidently.
+    """
+    if body.startswith("^"):
+        return None
+    chars: set[str] = set()
+    i = 0
+    n = len(body)
+    while i < n:
+        if body[i] == "\\":
+            escaped, i = _consume_escape(body, i)
+            if escaped is None:
+                return None
+            chars.update(escaped)
+            continue
+        # A range like `a-z`: literal `-` not at the start/end of the class
+        # and not immediately after an escape (already consumed above).
+        if i + 2 < n and body[i + 1] == "-" and body[i + 2] != "]":
+            lo, hi = body[i], body[i + 2]
+            if ord(lo) > ord(hi) or ord(hi) - ord(lo) > 256:
+                return None  # malformed or suspiciously large — don't expand
+            chars.update(chr(c) for c in range(ord(lo), ord(hi) + 1))
+            i += 3
+            continue
+        chars.add(body[i])
+        i += 1
+    return frozenset(chars)
+
+
+def _branch_charset(branch: str) -> tuple[bool, frozenset[str] | None]:
+    """Return ``(reducible, charset)`` for ``branch``.
+
+    ``reducible`` is ``False`` if ``branch`` contains a nested group or an
+    atom with a genuinely unbounded quantifier — i.e. it isn't a flat
+    sequence of simple atoms (literal chars, escapes, bracket classes,
+    each with at most a *bounded* quantifier: ``?``, ``{n}``, ``{n,m}``)
+    this function can characterize. :func:`_has_ambiguous_quantified_alternation`
+    skips the semantic overlap check for such branches and relies on its
+    plain textual prefix check instead — catching byte-identical/prefix
+    overlaps for that shape, but not semantic ones. Recursing into nested
+    groups to close that gap fully would mean re-implementing regex-language
+    equivalence, disproportionate for this lightweight heuristic (see the
+    module's "Known residual gaps").
+
+    When ``reducible`` is ``True``, ``charset`` is the set of characters
+    the branch can match anywhere in its length, or ``None`` (unknown/full
+    — treated as overlapping with anything) when some atom couldn't be
+    resolved to a concrete set (e.g. a negated class like ``\\D``).
+    """
+    charset: set[str] = set()
+    unknown = False
+    i = 0
+    n = len(branch)
+    while i < n:
+        ch = branch[i]
+        if ch in "(|)":
+            return False, None
+        if ch == "\\":
+            atom_charset, i = _consume_escape(branch, i)
+        elif ch == "[":
+            close = branch.find("]", i + 1)
+            if close == -1:
+                return False, None
+            atom_charset = _bracket_charset(branch[i + 1 : close])
+            i = close + 1
+        else:
+            atom_charset = frozenset(ch)
+            i += 1
+        if atom_charset is None:
+            unknown = True
+        else:
+            charset.update(atom_charset)
+
+        # Skip a bounded quantifier on the atom just consumed — its exact
+        # repeat count doesn't matter for a character-overlap check, only
+        # that it IS bounded (an unbounded one still bails out below, since
+        # that shape is already handled by the other heuristic checks and
+        # complicates length reasoning this function doesn't attempt).
+        quant = re.match(r"\?|\{(\d*),?(\d*)\}", branch[i:])
+        if quant:
+            if quant.group() != "?" and (
+                not quant.group(1) or ("," in quant.group() and not quant.group(2))
+            ):
+                return False, None  # `{,m}` / `{n,}` — unbounded
+            i += quant.end()
+
+    return True, (None if unknown else frozenset(charset))
+
+
+def _charsets_overlap(a: frozenset[str] | None, b: frozenset[str] | None) -> bool:
+    """True if two atom charsets could match the same character. ``None``
+    (unknown/full — see :func:`_escape_charset`/:func:`_bracket_charset`) is
+    treated as overlapping with anything, per this module's bias toward
+    false positives over false negatives.
+    """
+    return a is None or b is None or bool(a & b)
+
+
+def _has_ambiguous_quantified_alternation(src: str) -> bool:
+    """True if some ``(...)`` group is a 2+-branch alternation where two
+    branches can match overlapping text, and the group itself is
+    immediately followed by an unbounded quantifier — the ``(a|aa)+`` shape.
+
+    A quantified group doesn't need byte-identical branches to be ambiguous
+    under repetition — any two branches that can match some of the same
+    characters give the backtracker multiple equivalent ways to attribute a
+    run of those characters to one branch or the other (issue #157 — the
+    previous check matched only literally-identical branches). Two
+    complementary checks catch this:
+
+    * A textual prefix relationship (``a`` / ``aa``) — cheap and catches
+      the byte-identical case plus any branch that's literally a prefix of
+      another, regardless of internal structure (nested groups included).
+    * For branches reducible to a flat sequence of simple atoms (no nested
+      groups — see :func:`_branch_charset`), a *semantic* check: their
+      matched-character sets overlap at all (:func:`_charsets_overlap`).
+      This catches shapes the textual check misses because the overlap
+      isn't a literal prefix, e.g. ``[a-c]`` vs. ``[a-z]{2}`` (overlapping
+      character ranges, different-length matches) or ``[a]`` vs. ``aa``
+      (a class and a literal expressing the same character differently).
+
+    Supersedes the old ``_DUPLICATE_ALTERNATION`` regex (2-branch,
+    byte-identical, no-nesting-in-branch only): walking
+    ``_iter_group_spans`` covers 3+ branches and alternations containing
+    nested groups for the textual check, and ``_branch_charset`` adds
+    semantic overlap for branches without nested groups.
 
     Scoped to plain and non-capturing groups. Lookaround groups (``(?=...)``,
     ``(?!...)``, ``(?<=...)``, ``(?<!...)``) are zero-width and quantifying
     one is unusual; skipped rather than risk misreading unfamiliar syntax.
     An empty branch (``(a|)+``) is also skipped — Python's ``re`` special-
     cases zero-width alternatives in a loop to avoid infinite looping, so it
-    isn't the same exponential-backtracking shape as a genuine prefix
-    overlap.
+    isn't the same exponential-backtracking shape as a genuine overlap.
     """
     for start, end in _iter_group_spans(src):
         if not re.match(_UNBOUNDED_QUANT, src[end + 1 :]):
@@ -316,6 +489,10 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
                     or branch_a.startswith(branch_b)
                     or branch_b.startswith(branch_a)
                 ):
+                    return True
+                reducible_a, charset_a = _branch_charset(branch_a)
+                reducible_b, charset_b = _branch_charset(branch_b)
+                if reducible_a and reducible_b and _charsets_overlap(charset_a, charset_b):
                     return True
     return False
 

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -203,15 +203,16 @@ def _is_nullable_separator(fragment: str) -> bool:
         return True
     try:
         return re.fullmatch(fragment, "") is not None
-    except (re.error, OverflowError):
+    except (re.error, OverflowError, RecursionError):
         # re.error: the fragment isn't valid as a standalone pattern (e.g.
         # it contains a backreference to a group defined outside it).
         # OverflowError: an absurdly large `{n,m}` repeat count (e.g.
-        # `{0,4294967296}`) raises this instead of re.error. Either way we
-        # can't prove the fragment is nullable, but per this module's
-        # conservative bias (false positives over false negatives — see
-        # module docstring), don't rule it out either: treat it as a
-        # nullable/unsafe separator.
+        # `{0,4294967296}`) raises this instead of re.error. RecursionError:
+        # extremely deep nesting can exceed the interpreter's recursion
+        # limit during compilation. None of these prove the fragment is
+        # nullable, but per this module's conservative bias (false
+        # positives over false negatives — see module docstring), don't
+        # rule it out either: treat it as a nullable/unsafe separator.
         return True
 
 
@@ -332,10 +333,40 @@ def _consume_escape(src: str, i: int) -> tuple[frozenset[str] | None, int]:
     return _escape_charset(src[i + 1]), i + 2
 
 
+def _find_bracket_class_end(src: str, open_idx: int) -> int:
+    """Return the index of the closing ``]`` for a ``[...]`` class starting
+    at ``src[open_idx] == "["``, or ``-1`` if unterminated.
+
+    Mirrors real ``re`` semantics for the two cases a naive
+    ``src.find("]", open_idx + 1)`` gets wrong: a ``]`` immediately after
+    ``[`` (or after ``[^``) is a *literal* member of the class, not the
+    closer (``[]a-y]`` matches ``]`` or ``a``-``y``); and a ``\\]`` inside
+    the class is an escaped literal, not the closer either. Getting this
+    wrong silently truncates the class and drops characters from the
+    computed charset — a confirmed false-negative bypass during review of
+    this fix (a truncated ``[]a-y]`` lost most of the ``a``-``y`` range).
+    """
+    i = open_idx + 1
+    n = len(src)
+    if i < n and src[i] == "^":
+        i += 1
+    if i < n and src[i] == "]":
+        i += 1  # leading `]` (post-negation, if any) is a literal member
+    while i < n:
+        if src[i] == "\\":
+            i += 2
+            continue
+        if src[i] == "]":
+            return i
+        i += 1
+    return -1
+
+
 def _bracket_charset(body: str) -> frozenset[str] | None:
     """Return the set of characters a ``[...]`` class body (the text
-    between the brackets) matches, or ``None`` (unknown/full) for a negated
-    class (``[^...]``) or a range too unusual to expand confidently.
+    between the brackets, as located by :func:`_find_bracket_class_end`)
+    matches, or ``None`` (unknown/full) for a negated class (``[^...]``)
+    or a range too unusual to expand confidently.
     """
     if body.startswith("^"):
         return None
@@ -394,7 +425,7 @@ def _branch_charset(branch: str) -> tuple[bool, frozenset[str] | None]:
         if ch == "\\":
             atom_charset, i = _consume_escape(branch, i)
         elif ch == "[":
-            close = branch.find("]", i + 1)
+            close = _find_bracket_class_end(branch, i)
             if close == -1:
                 return False, None
             atom_charset = _bracket_charset(branch[i + 1 : close])

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -59,6 +59,20 @@ class TestAssertSafe:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(r"(a|a)*"))
 
+    def test_overlapping_alternation_rejected(self) -> None:
+        # #157: branches need not be byte-identical to be ambiguous under a
+        # quantifier — "a" is a prefix of "aa", so repeated matching can
+        # always re-partition a run of "a"s combinatorially.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(a|aa)+$"))
+
+    def test_delimiter_separated_adjacent_groups_rejected(self) -> None:
+        # #157: an optional/nullable delimiter between adjacent
+        # unbounded-quantified groups doesn't break the ambiguous-
+        # partitioning shape — it just makes the adjacency conditional.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(a+)-?(a+)-?(a+)-?(a+)$"))
+
     def test_realistic_evil_pattern_rejected(self) -> None:
         # The classic "(x+x+)+y" shape. Heuristic flags the nested quantifier;
         # that's enough to fail closed. Assembled at runtime (this fixture is only
@@ -96,8 +110,20 @@ class TestRedosGuardAlwaysRunsHeuristic:
 
     @pytest.mark.parametrize(
         "src",
-        [r"(a+)+$", r"([a-z]+)+$", r"(v\d+)+.*"],
-        ids=["nested-plus-anchored", "nested-charclass-anchored", "version-prefix-catastrophic"],
+        [
+            r"(a+)+$",
+            r"([a-z]+)+$",
+            r"(v\d+)+.*",
+            r"(a|aa)+$",  # #157: overlapping (non-identical) alternation
+            r"(a+)-?(a+)-?(a+)-?(a+)$",  # #157: nullable-delimiter adjacent groups
+        ],
+        ids=[
+            "nested-plus-anchored",
+            "nested-charclass-anchored",
+            "version-prefix-catastrophic",
+            "overlapping-alternation",
+            "delimiter-separated-adjacent-groups",
+        ],
     )
     @pytest.mark.parametrize("has_re2_value", [True, False], ids=["re2-present", "re2-absent"])
     def test_rejected_regardless_of_has_re2(
@@ -137,6 +163,14 @@ class TestHeuristicUnsafe:
             f"({'x+' * 2})+y",
             r"(a+)(a+)",  # #80: adjacent parenthesized unbounded groups (min case)
             r"([a-z]+)([a-z]+)([a-z]+)([a-z]+)([a-z]+)([a-z]+)",  # confirmed ~10s @ 100 chars
+            r"(a|aa)+$",  # #157: overlapping (non-identical) alternation branches
+            r"(a|aa|aaa)*",  # #157: 3+ overlapping branches, not just a pair
+            r"(?:cat|category)+",  # #157: prefix overlap inside a non-capturing group
+            r"(a+)-?(a+)$",  # #157: minimal delimiter-separated adjacent groups
+            r"(a+)-?(a+)-?(a+)-?(a+)$",  # #157: issue's exact repro
+            r"(a+)\s*(a+)$",  # #157: whitespace-class nullable delimiter
+            r"(a\|b|a\|b)+",  # #157: escaped literal pipe inside a branch must not
+            # be mistaken for a branch delimiter by the top-level splitter
         ],
         ids=[
             "nested-plus",
@@ -149,6 +183,13 @@ class TestHeuristicUnsafe:
             "realistic-evil-xx",
             "adjacent-groups-minimal",
             "adjacent-groups-six",
+            "overlapping-alternation-pair",
+            "overlapping-alternation-triple",
+            "overlapping-alternation-noncapturing",
+            "delimiter-separated-groups-minimal",
+            "delimiter-separated-groups-issue-repro",
+            "delimiter-separated-groups-whitespace-class",
+            "alternation-escaped-pipe-duplicate",
         ],
     )
     def test_flags_known_bad_shapes(self, src: str) -> None:
@@ -166,6 +207,18 @@ class TestHeuristicUnsafe:
             r"^kling-(?:text2video|image2video)-v2\.1-master$",
             r"(a+)b(a+)",  # separated by a literal — not adjacent, not the ReDoS shape
             r"(a+)(b)",  # adjacent, but only one group is unbounded
+            # #157: prefix-overlapping branches are only dangerous when the
+            # group itself is quantified — an unquantified alternation, no
+            # matter how the branches overlap, is matched at most once.
+            r"^(?:dev|development)$",
+            r"^(?:cat|category)$",
+            # #157: a mandatory (non-nullable) delimiter between adjacent
+            # unbounded groups is a real anchor — it isn't the ambiguous-
+            # partitioning shape, same rationale as "(a+)b(a+)" above.
+            r"(a+)-(a+)$",
+            # #157: a quantified lookahead is zero-width and out of scope
+            # for the ambiguous-alternation check (skipped, not analyzed).
+            r"(?=a|aa)+",
         ],
     )
     def test_passes_known_good_shapes(self, src: str) -> None:

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -171,6 +171,12 @@ class TestHeuristicUnsafe:
             r"(a+)\s*(a+)$",  # #157: whitespace-class nullable delimiter
             r"(a\|b|a\|b)+",  # #157: escaped literal pipe inside a branch must not
             # be mistaken for a branch delimiter by the top-level splitter
+            r"([a]|aa)+$",  # #157 review: class vs. literal, same char — semantic,
+            # not textual, overlap
+            r"(\x61|aa)+$",  # #157 review: hex escape vs. literal, same char
+            r"(?:[a-c]|[a-z]{2})+",  # #157 review: overlapping character-class
+            # ranges at different match lengths — the confirmed live bypass
+            # from the security review of this fix
         ],
         ids=[
             "nested-plus",
@@ -190,6 +196,9 @@ class TestHeuristicUnsafe:
             "delimiter-separated-groups-issue-repro",
             "delimiter-separated-groups-whitespace-class",
             "alternation-escaped-pipe-duplicate",
+            "overlapping-alternation-class-vs-literal",
+            "overlapping-alternation-hex-escape",
+            "overlapping-alternation-class-range-different-lengths",
         ],
     )
     def test_flags_known_bad_shapes(self, src: str) -> None:
@@ -219,6 +228,17 @@ class TestHeuristicUnsafe:
             # #157: a quantified lookahead is zero-width and out of scope
             # for the ambiguous-alternation check (skipped, not analyzed).
             r"(?=a|aa)+",
+            # #157 review: disjoint character classes — no character can be
+            # attributed to either branch, so no partition ambiguity.
+            r"(?:[a-z]|[0-9])+",
+            r"(?:[a-z]|-)+",
+            # #157 review: documented residual gap, not a regression — a
+            # branch containing a nested group isn't reduced to a charset
+            # (see _branch_charset's docstring), so this specific semantic
+            # overlap ([a(?:b)?] vs "aa", both able to match "a") still
+            # isn't caught. Asserted here so a future attempt to close this
+            # gap updates this test rather than silently changing behavior.
+            r"(a(?:b)?|aa)+$",
         ],
     )
     def test_passes_known_good_shapes(self, src: str) -> None:

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -177,6 +177,11 @@ class TestHeuristicUnsafe:
             r"(?:[a-c]|[a-z]{2})+",  # #157 review: overlapping character-class
             # ranges at different match lengths — the confirmed live bypass
             # from the security review of this fix
+            r"(?:[]a-y]|qq)+$",  # #157 review round 2: a literal `]` as the
+            # first char of a bracket class (real re semantics: `[]a-y]`
+            # matches `]` or a-y) was mis-parsed as an empty class, silently
+            # dropping the whole a-y range (including `q`) from the computed
+            # charset — a confirmed false-negative bypass caught in re-review
         ],
         ids=[
             "nested-plus",
@@ -199,6 +204,7 @@ class TestHeuristicUnsafe:
             "overlapping-alternation-class-vs-literal",
             "overlapping-alternation-hex-escape",
             "overlapping-alternation-class-range-different-lengths",
+            "overlapping-alternation-leading-bracket-literal",
         ],
     )
     def test_flags_known_bad_shapes(self, src: str) -> None:

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -71,16 +71,20 @@ class TestAssertSafe:
     def test_overlapping_alternation_rejected(self) -> None:
         # #157: branches need not be byte-identical to be ambiguous under a
         # quantifier — "a" is a prefix of "aa", so repeated matching can
-        # always re-partition a run of "a"s combinatorially.
+        # always re-partition a run of "a"s combinatorially. Assembled at
+        # runtime (only analyzed by assert_safe, never matched) so the
+        # catastrophic literal isn't itself flagged by CodeQL's ReDoS scan.
         with pytest.raises(ValueError, match="catastrophic backtracking"):
-            assert_safe(re.compile(r"(a|aa)+$"))
+            assert_safe(re.compile(f"(a|{'a' * 2})+$"))
 
     def test_delimiter_separated_adjacent_groups_rejected(self) -> None:
         # #157: an optional/nullable delimiter between adjacent
         # unbounded-quantified groups doesn't break the ambiguous-
         # partitioning shape — it just makes the adjacency conditional.
+        # Assembled at runtime so the fixture isn't flagged as a static
+        # ReDoS literal by code scanning (see test_realistic_evil_pattern).
         with pytest.raises(ValueError, match="catastrophic backtracking"):
-            assert_safe(re.compile(r"(a+)-?(a+)-?(a+)-?(a+)$"))
+            assert_safe(re.compile(f"{'(a+)-?' * 3}(a+)$"))
 
     def test_realistic_evil_pattern_rejected(self) -> None:
         # The classic "(x+x+)+y" shape. Heuristic flags the nested quantifier;
@@ -316,7 +320,9 @@ class TestUnsafeReason:
         the always-on heuristic, so assert_safe raises the shape-specific
         message rather than a generic catch-all."""
         with pytest.raises(ValueError, match="overlapping text") as exc:
-            assert_safe(re.compile(r"(a|aa)+"))
+            # assembled at runtime so the catastrophic literal isn't flagged
+            # by CodeQL's ReDoS scan (see test_realistic_evil_pattern_rejected)
+            assert_safe(re.compile(f"(a|{'a' * 2})+"))
         msg = str(exc.value)
         assert "remove the overlap" in msg
         # The old generic message listed every reason + fixes that don't apply.

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -6,7 +6,16 @@ import re
 
 import pytest
 from genblaze_core.providers import pattern_safety
-from genblaze_core.providers.pattern_safety import _heuristic_unsafe, assert_safe, has_re2
+from genblaze_core.providers.pattern_safety import (
+    _bracket_charset,
+    _branch_charset,
+    _escape_charset,
+    _heuristic_unsafe,
+    _is_nullable_separator,
+    _unsafe_reason,
+    assert_safe,
+    has_re2,
+)
 
 
 class _FakeRe2:
@@ -238,6 +247,14 @@ class TestHeuristicUnsafe:
             # attributed to either branch, so no partition ambiguity.
             r"(?:[a-z]|[0-9])+",
             r"(?:[a-z]|-)+",
+            # #157 follow-up: two unbounded groups on opposite sides of a
+            # TOP-LEVEL `|` are in different alternation branches — never
+            # matched on the same path, so no adjacent-partitioning ambiguity.
+            # A regression here (treating `|` as a nullable separator) rejected
+            # these linear-time patterns.
+            r"(a+)|(b+)",
+            r"(?:a+)|(?:b+)",
+            r"^(openai/gpt-4\d*)|(anthropic/claude-\d+)$",
             # #157 review: documented residual gap, not a regression — a
             # branch containing a nested group isn't reduced to a charset
             # (see _branch_charset's docstring), so this specific semantic
@@ -249,6 +266,122 @@ class TestHeuristicUnsafe:
     )
     def test_passes_known_good_shapes(self, src: str) -> None:
         assert _heuristic_unsafe(src) is False
+
+    @pytest.mark.parametrize("src", [r"(?:v1|v2)+", r"(?:ab|bc)+", r"(?:foo|far)+"])
+    def test_conservative_over_rejection_is_intentional(self, src: str) -> None:
+        """The charset-overlap check is a deliberate over-approximation: two
+        branches sharing ANY character are flagged, so some non-ambiguous
+        alternations (the differing char actually disambiguates them) are
+        rejected too. This is intentional per the module's false-positive-over-
+        false-negative bias — pinned here so a future attempt to tighten the
+        check updates this test and the module docstring's "Deliberate
+        over-rejection" note deliberately, not silently."""
+        assert _heuristic_unsafe(src) is True
+
+
+class TestUnsafeReason:
+    """The rejection message names the specific shape and gives remediation
+    that actually clears the heuristic (#157) — not a generic list including
+    fixes that don't apply (e.g. making the quantifier possessive)."""
+
+    def test_reason_none_for_safe_pattern(self) -> None:
+        assert _unsafe_reason(r"^gpt-4o(?:-mini)?$") is None
+
+    @pytest.mark.parametrize(
+        ("src", "needle"),
+        [
+            (r"(a+)+", "nested unbounded"),
+            (r"(a|aa)+", "overlapping"),
+            (r"a+a+a+", "back-to-back"),
+            (r"(a+)(a+)", "adjacent unbounded-quantified groups"),
+        ],
+    )
+    def test_reason_names_the_specific_shape(self, src: str, needle: str) -> None:
+        reason = _unsafe_reason(src)
+        assert reason is not None and needle in reason
+
+    def test_possessive_alternation_message_does_not_advise_possessive(self) -> None:
+        """`(a|aa)++` is still (correctly) flagged — the possessive quantifier
+        doesn't remove the branch overlap. The reason must point at the overlap,
+        not send the author in a circle by advising possessive quantifiers.
+        Checked via _unsafe_reason directly: assert_safe's re2 gate would reject
+        the possessive `++` first in a re2-present env, for a different reason."""
+        reason = _unsafe_reason(r"(a|aa)++")
+        assert reason is not None
+        assert "remove the overlap" in reason
+        assert "possessive does not clear" in reason
+
+    def test_assert_safe_message_names_the_shape(self) -> None:
+        """End-to-end: `(a|aa)+` is accepted by re2 (linear-time) but flagged by
+        the always-on heuristic, so assert_safe raises the shape-specific
+        message rather than a generic catch-all."""
+        with pytest.raises(ValueError, match="overlapping text") as exc:
+            assert_safe(re.compile(r"(a|aa)+"))
+        msg = str(exc.value)
+        assert "remove the overlap" in msg
+        # The old generic message listed every reason + fixes that don't apply.
+        assert "nested unbounded quantifiers such as" not in msg
+
+
+class TestParserHelpers:
+    """Direct unit tests for the hand-rolled sub-parsers, which otherwise are
+    only exercised end-to-end through the heuristic — a regression in one would
+    surface as a subtle false positive/negative that's hard to localize."""
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            ("abc", frozenset("abc")),
+            ("a-c", frozenset("abc")),
+            (r"\d", frozenset("0123456789")),
+            ("]a-c", frozenset("]abc")),  # leading ] is a literal member
+        ],
+    )
+    def test_bracket_charset_concrete(self, body: str, expected: frozenset[str]) -> None:
+        assert _bracket_charset(body) == expected
+
+    def test_bracket_charset_negated_is_unknown(self) -> None:
+        assert _bracket_charset("^a") is None  # negated class -> unknown/full
+
+    @pytest.mark.parametrize(
+        ("escape_body", "expected"),
+        [("d", frozenset("0123456789")), ("x61", frozenset("a")), (".", frozenset("."))],
+    )
+    def test_escape_charset_concrete(self, escape_body: str, expected: frozenset[str]) -> None:
+        assert _escape_charset(escape_body) == expected
+
+    def test_escape_charset_negated_is_unknown(self) -> None:
+        assert _escape_charset("D") is None  # \D is "everything except digits"
+
+    @pytest.mark.parametrize(
+        ("branch", "reducible", "charset"),
+        [
+            ("abc", True, frozenset("abc")),
+            ("a?b", True, frozenset("ab")),  # bounded quantifier is fine
+            ("a+", False, None),  # unbounded -> not reducible (regression guard)
+            ("a*", False, None),
+            ("(?:x)", False, None),  # nested group -> not reducible
+            (r"\D", True, None),  # reducible but charset unknown/full
+        ],
+    )
+    def test_branch_charset(
+        self, branch: str, reducible: bool, charset: frozenset[str] | None
+    ) -> None:
+        assert _branch_charset(branch) == (reducible, charset)
+
+    @pytest.mark.parametrize("frag", ["", "-?", r"\s*", "(?:foo)?", "x*"])
+    def test_nullable_separator_true(self, frag: str) -> None:
+        assert _is_nullable_separator(frag) is True
+
+    @pytest.mark.parametrize("frag", ["-", "x", r"\s", "ab"])
+    def test_nullable_separator_false(self, frag: str) -> None:
+        assert _is_nullable_separator(frag) is False
+
+    def test_nullable_separator_uncompilable_fragment_biases_unsafe(self) -> None:
+        r"""A fragment that isn't a valid standalone pattern (e.g. a lone
+        backreference `\1`) can't be proven non-nullable, so the conservative
+        bias treats it as a nullable/unsafe separator."""
+        assert _is_nullable_separator(r"\1") is True
 
 
 class TestHasRe2:


### PR DESCRIPTION
## Summary

Extends the ReDoS pattern-safety heuristic (`libs/core/genblaze_core/providers/pattern_safety.py`) to catch two catastrophic-backtracking shapes it previously missed: a quantified alternation with overlapping (not just byte-identical) branches, and adjacent unbounded-quantified groups separated by a nullable delimiter. Hardening only — the shipped connector catalog contains no pattern of either shape today; the exposure is a future/third-party connector pattern letting an attacker-influenced value reach `ModelFamily.matches()` and hang the worker.

## Changes

- `_has_ambiguous_quantified_alternation()` replaces the old byte-identical-only `_DUPLICATE_ALTERNATION` regex. It keeps a textual prefix check (catches `(a|aa)+`, 3+ branches, nested-group branches) and adds a semantic character-set overlap check (`_branch_charset`, `_bracket_charset`, `_escape_charset`, `_consume_escape`, `_charsets_overlap`) for branches that reduce to a flat sequence of simple atoms — this catches shapes the textual check can't, e.g. `(?:[a-c]|[a-z]{2})+` (overlapping character-class ranges at different match lengths).
- `_has_adjacent_unbounded_groups()` now treats a *nullable* separator (`-?`, `\s*`, `(?:...)?`, etc. — anything matching empty via `_is_nullable_separator`) as adjacency, not just a literally-empty gap, closing `(a+)-?(a+)-?(a+)-?(a+)$`.
- Fixed a bracket-class parsing bug found during review: a `]` as the first literal character of a class (`[]a-y]`, valid regex meaning "`]` or a-y") was mis-parsed as the class terminator, silently truncating the computed charset and producing a false-negative bypass. Fixed with a proper close-scanner (`_find_bracket_class_end`) mirroring real `re` semantics.
- `_is_nullable_separator`'s exception handling widened from `except re.error` to also catch `OverflowError` (huge `{n,m}` counts) and `RecursionError` (deeply nested fragments), failing toward "treat as unsafe" per the module's conservative bias.
- Module docstring's "Known residual gaps" section documents what's still open: a branch containing a nested group isn't reduced to a charset (e.g. `a(?:b)?` vs `aa`); a mandatory delimiter whose own characters coincide with a flanking group's quantified content (`(a+)a(a+)`); and backreferences, which the static heuristic doesn't model at all (pre-existing, masked by `google-re2` when installed, out of scope for this issue).
- `libs/core/tests/unit/test_pattern_safety.py`: added failing-first regression tests for both originally-reported shapes, the three additional bypasses surfaced during the triangulated review (character-class overlap, class-vs-literal, hex-escape-vs-literal, and the bracket-parsing bug), plus negative tests proving legitimate patterns (disjoint character classes, unquantified overlapping alternation, mandatory delimiters, quantified lookarounds, the documented nested-group residual gap) still pass.
- `CHANGELOG.md`: `[Unreleased]` → `### genblaze-core`, security-hardening entry.

## Security review notes

This went through a triangulated review (correctness, security, architecture/DRY), and both the correctness and security reviewers independently surfaced the same P1 (the initial fix's overlap check was purely textual, missing semantic overlaps like character classes and escapes) — treated as blocking per the review protocol and fixed with the character-set overlap check described above. A follow-up focused re-review then found the bracket-parsing bug (also fixed) but confirmed no other regressions and that the three originally-demonstrated bypasses are now closed. Residual gaps are documented honestly in the module docstring and CHANGELOG rather than silently left implicit — closing them fully would mean recursing into nested-group branches (effectively regex-language equivalence), which is disproportionate scope for a lightweight static heuristic.

Worst pattern still getting through today: an alternation branch containing a nested group with a semantically-overlapping sibling branch (e.g. `(a(?:b)?|aa)+$`), or a mandatory delimiter whose own text coincides with a flanking group's matched characters (`(a+)a(a+)`). Both are documented, both are narrower/rarer than the shapes this fix closes.

## Test plan

- [x] `make test` passes — 1992 passed, 5 skipped (skips pre-exist on `origin/main`, unrelated to this change)
- [x] `make lint` passes — ruff check + format clean across `libs/`, `cli/`, `examples/`
- [x] `make typecheck` passes — `mypy libs/core/genblaze_core/` clean, 92 source files
- [x] `libs/core/tests/unit/test_pattern_safety.py` — 60/60 passed (up from 36 on `origin/main`), including all new regression tests
- [x] Docs updated — `CHANGELOG.md` `[Unreleased]` / `### genblaze-core`, plus the module docstring's "Known residual gaps" section
- [x] `google-re2` was actually installed in this dev environment (unlike the expected setup), so the `_HAS_RE2`-dependent tests ran for real rather than via `monkeypatch` fallback only — no skipped/pre-existing-failure tests to report in `test_pattern_safety.py`

## Related

Closes #157