### PR TITLE
docs(release): tighten unreleased wave for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `char_count` (e.g. images). Returns `None` only when neither a prompt nor
   any usable `char_count` exists; a genuinely-present `char_count` of `0`
   still yields a real `0.0` cost rather than an "unknown" one.
+- **Fixed** an otherwise-complete run could fail when re-checking an asset
+  already stored in the sink's backend under a B2 daily Class-B cap or a
+  restricted key (#162). `ObjectStorageSink._asset_already_transferred`
+  probed `backend.exists(key)`, but a B2 `HeadObject` `403` reports the key
+  as absent, which re-scheduled a transfer of the now-durable (private) URL
+  over an unauthenticated `GET` (`401`) — and with no source left to
+  re-download from, that re-transfer could never succeed. The sink now
+  trusts a backend-owned asset URL directly (valid `sha256` + non-null
+  `size_bytes` + a resolvable backend key), since `transfer()` only rewrites
+  `url` to the durable URL *after* a successful put. **Tradeoff:** object
+  existence is no longer independently probed for backend-owned URLs within a
+  run; a byte-level `genblaze verify --fetch` (below) remains available for
+  callers that want post-hoc confirmation.
 
 ### genblaze-cli
 

--- a/libs/connectors/lmnt/genblaze_lmnt/provider.py
+++ b/libs/connectors/lmnt/genblaze_lmnt/provider.py
@@ -141,6 +141,11 @@ class LMNTProvider(SyncProvider):
         self._api_key = api_key
         self._output_dir = Path(output_dir) if output_dir else None
         self._speech_client: Any = None
+        # Warn once per provider, not once per clip: a batch of steps all
+        # carrying the removed `speed` param would otherwise log the same
+        # notice on every generate() call. Mirrors model_registry's
+        # `_warned_deprecated` dedup pattern.
+        self._warned_speed = False
 
     def _make_client(self):
         """Create a fresh LMNT client for a single generate() call."""
@@ -176,10 +181,12 @@ class LMNTProvider(SyncProvider):
 
             if "format" in payload:
                 generate_kwargs["format"] = payload["format"]
-            if "speed" in payload:
+            if "speed" in payload and not self._warned_speed:
                 # lmnt 2.x dropped `speed` in favor of temperature/top_p, which
                 # control expressiveness rather than pacing — there's no
                 # equivalent to forward, so warn instead of silently dropping.
+                # Emitted once per provider to avoid per-clip log spam.
+                self._warned_speed = True
                 logger.warning(
                     "LMNT provider: 'speed' is not supported by lmnt SDK 2.x "
                     "and will be ignored; 2.x exposes 'temperature'/'top_p' "

--- a/libs/connectors/lmnt/tests/test_lmnt_provider.py
+++ b/libs/connectors/lmnt/tests/test_lmnt_provider.py
@@ -96,6 +96,18 @@ def test_speed_param_dropped_with_warning(mock_lmnt, caplog):
     )
 
 
+def test_speed_warning_emitted_once_per_provider(mock_lmnt, caplog):
+    """The ``speed``-dropped warning is deduped per provider so a batch of
+    clips all carrying ``speed`` doesn't spam an identical WARNING per call."""
+    provider, _ = mock_lmnt
+    step = Step(provider="lmnt", model="lmnt-1", prompt="test", params={"speed": "1.2"})
+    with caplog.at_level("WARNING", logger="genblaze.lmnt"):
+        provider.generate(step)
+        provider.generate(step)
+    speed_warnings = [rec for rec in caplog.records if "speed" in rec.message]
+    assert len(speed_warnings) == 1
+
+
 def test_durations_stored_in_payload(mock_lmnt):
     provider, client = mock_lmnt
     client.speech.generate_detailed = MagicMock(

--- a/tools/batch_plandoc.py
+++ b/tools/batch_plandoc.py
@@ -1,28 +1,33 @@
 #!/usr/bin/env python3
 """
-Plan-document writer and drift-proof validator for the batch maintainer.
+Plan-document writer and drift-guarding validator for the batch maintainer.
 
 Why this exists
 ---------------
 The batch maintainer is split into two workflows with a human approval gate
 between them: ``batch-plan`` produces a plan document and stops; the human
 reads it and approves; ``batch-execute`` then opens PRs. That gate is only
-meaningful if execution *cannot* run against a stale or hand-edited plan.
-Convention ("please don't") is not enforcement. This module is the
-enforcement:
+meaningful if execution doesn't silently run against a stale or accidentally
+edited plan. Convention ("please don't") catches nothing. This module adds
+mechanical drift checks on top of the human gate:
 
 * ``write`` embeds, in a machine-readable block inside the plan doc, the
   ``origin/main`` SHA the plan was computed against and a **content token** —
   ``sha256(base_sha + canonical(clusters))``. The token binds the approval to
   the exact cluster set; edit the clusters by hand and the token no longer
-  matches.
+  matches. Note this is an *unkeyed* digest, so it detects accidental edits
+  and drift, not a motivated editor who recomputes it — the human approval
+  gate, not this token, is the trust boundary.
 
 * ``validate`` refuses to let execution proceed unless ALL hold:
-    1. the embedded token recomputes from the doc's own contents (no tampering),
+    1. the embedded token recomputes from the doc's own contents (catches
+       accidental edits to the plan block),
     2. the embedded base SHA still equals live ``origin/main`` (main hasn't
        advanced under the plan),
-    3. the executable issue set still matches the live open-issue set (no issue
-       was closed, merged, or newly opened since planning).
+    3. every planned executable issue is still open (an issue closed or merged
+       since planning aborts the run). Issues opened *after* planning are not a
+       drift trigger — they simply wait for the next ``batch-plan`` rather than
+       being pulled into an already-approved batch.
 
 Git and GitHub live *outside* this module — the calling workflow supplies the
 live SHA and open-issue list — so the logic here is pure and unit-testable.
@@ -187,8 +192,9 @@ def validate(meta: dict, live_sha: str, live_open_issues: list[int]) -> list[int
             f"(plan {meta.get('base_sha')} != live {live_sha}); re-run batch-plan."
         )
 
-    # 3. Issue-set drift: every executable issue must still be open, and no new
-    #    open issue should be silently ignored by a stale plan.
+    # 3. Issue-set drift: every planned executable issue must still be open.
+    #    Issues opened after planning are intentionally NOT a drift trigger —
+    #    they wait for the next batch-plan rather than joining an approved batch.
     planned = set(_executable_issues(clusters))
     live = set(live_open_issues)
     closed = planned - live


### PR DESCRIPTION
## What & why

A panel review (Engineering Manager / OSS / Developer-Experience lenses) of the unreleased wave (`v0.5.0..HEAD`, 9 PRs) found the wave release-ready with **no blockers and no high-severity issues**. This PR applies only the confirmed, in-scope doc/polish fixes so the wave is clean before the next release. **No intended-behavior changes.**

## Changes

- **CHANGELOG** — Add the genblaze-core `[Unreleased]` entry for the sink #162 fix that was missing, including the tradeoff: object existence is no longer independently probed for backend-owned asset URLs (a byte-level `genblaze verify --fetch` remains available for post-hoc confirmation).
- **`tools/batch_plandoc.py`** — Correct the validator docstring/comment to match what `validate()` actually does: planned-but-closed issues abort the run; issues opened *after* planning are intentionally deferred to the next `batch-plan`, not a drift trigger. Soften "tamper-evident / enforcement" language since the content token is an unkeyed `sha256` digest that catches accidental edits, not a motivated editor — the human approval gate is the trust boundary.
- **`genblaze-lmnt`** — Emit the dropped-`speed` warning **once per provider** instead of once per clip (mirrors `model_registry`'s `_warned_deprecated` dedup), avoiding log spam in batch pipelines. Adds regression test `test_speed_warning_emitted_once_per_provider`. The `speed` param is still dropped on every call; only the warning is deduped.

## Verified during review

- **elevenlabs `>=2.0` floor is correct** — inspected the 2.0.0 wheel; `AudioWithTimestampsResponse.audio_base_64` and `convert_with_timestamps` both exist at exactly that floor, so the hard attribute use is safe. No bump needed.
- lmnt keeps its `logger.warning` channel (a tested design choice in `test_speed_param_dropped_with_warning`); only the per-call repetition was addressed.

## Deferred (follow-ups, not this PR)

- CLI `verify` imports private core internals (`_http_get_stream`, `ALLOWED_FILE_ROOTS`, `_DEFAULT_*`). Reusing the SSRF-pinned path is correct, but the cross-package coupling to core's private surface should be replaced with a thin public core accessor. All three reviewers flagged it as a follow-up, not urgent; deferred to avoid growing this PR's scope.

## Testing

- `libs/connectors/lmnt`: 30 passed, 2 skipped (incl. new dedup test)
- `tools/tests/test_batch_plandoc.py`: 9 passed
- `ruff check` on all touched files: clean
- Run `make test` as the whole-suite gate before tagging.

Refs #162, #166, #181
