### PR TITLE
fix(ci): retry genblaze[all] install in install-verify on PyPI CDN lag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -486,5 +486,24 @@ jobs:
           version="$UMBRELLA_VERSION"
           python -m venv /tmp/verify
           /tmp/verify/bin/pip install --upgrade pip
-          /tmp/verify/bin/pip install "genblaze[all]==$version"
+
+          # The umbrella pre-check above only confirms `genblaze` itself is
+          # indexed; `genblaze[all]` also resolves ~18 connector packages
+          # that propagate across PyPI's CDN independently, so this exact
+          # install can still 404 on a connector's stale edge even when the
+          # umbrella wait passed (#189). Retry the install itself — it's the
+          # operation that actually fails, regardless of which package lags.
+          attempts=5
+          for i in $(seq 1 "$attempts"); do
+            if /tmp/verify/bin/pip install "genblaze[all]==$version"; then
+              break
+            fi
+            if [ "$i" -eq "$attempts" ]; then
+              echo "::error::pip install genblaze[all]==$version failed after $attempts attempts"
+              exit 1
+            fi
+            echo "[$i/$attempts] pip install genblaze[all]==$version failed, retrying in 30s…"
+            sleep 30
+          done
+
           /tmp/verify/bin/python tools/release_import_smoke.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,7 +488,7 @@ jobs:
           /tmp/verify/bin/pip install --upgrade pip
 
           # The umbrella pre-check above only confirms `genblaze` itself is
-          # indexed; `genblaze[all]` also resolves ~18 connector packages
+          # indexed; `genblaze[all]` also resolves the ~14 connector packages
           # that propagate across PyPI's CDN independently, so this exact
           # install can still 404 on a connector's stale edge even when the
           # umbrella wait passed (#189). Retry the install itself — it's the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **Fixed** `install-verify`'s "Wait for PyPI to index the umbrella" pre-check
+  only polled for the `genblaze` umbrella itself, but `genblaze[all]` also
+  resolves ~18 connector packages that propagate across PyPI's CDN
+  independently — so the pre-check could pass while a connector's simple-index
+  page was still stale, and the very next `pip install "genblaze[all]==$version"`
+  false-red the job on a genuinely-healthy release (hit twice during the
+  v0.6.0 release, #189). The fresh install step itself now retries up to 5
+  times (30s apart) so transient propagation of any package is tolerated; a
+  truly missing/unresolvable package still fails the job after retries are
+  exhausted. The umbrella pre-check and the import-smoke invocation are
+  unchanged. Release tooling only — no packaged code changed.
+
 ## [0.6.0] - 2026-07-22
 
 Bug-fix and compatibility wave with one new opt-in feature. Fixes cross-platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed** `install-verify`'s "Wait for PyPI to index the umbrella" pre-check
   only polled for the `genblaze` umbrella itself, but `genblaze[all]` also
-  resolves ~18 connector packages that propagate across PyPI's CDN
+  resolves the ~14 connector packages that propagate across PyPI's CDN
   independently — so the pre-check could pass while a connector's simple-index
   page was still stale, and the very next `pip install "genblaze[all]==$version"`
   false-red the job on a genuinely-healthy release (hit twice during the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -283,11 +283,14 @@ production releases (recommended once the project graduates from alpha).
 * **The umbrella is the long pole.** If `publish-meta` fails, users
   cannot `pip install genblaze` — but they can still install individual
   packages. Treat a meta failure as a P0.
-* **install-verify is best-effort.** PyPI's CDN sometimes lags; the job
-  retries for 2 minutes before failing. A red `install-verify` after a
-  green publish graph usually means the package is fine and the index
-  is just behind — verify manually with `pip install genblaze==X.Y.Z`
-  in a fresh venv before assuming a regression.
+* **install-verify is best-effort.** PyPI's CDN sometimes lags. The
+  umbrella pre-check retries for 2 minutes before failing, and the
+  `genblaze[all]` install itself retries up to 5 times (30s apart) since
+  any of its ~18 connector packages can propagate independently of the
+  umbrella (#189). A red `install-verify` after a green publish graph
+  usually means a package is fine and the index is just behind — verify
+  manually with `pip install "genblaze[all]==X.Y.Z"` in a fresh venv
+  before assuming a regression.
 
 ## Post-publish verification
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -286,7 +286,7 @@ production releases (recommended once the project graduates from alpha).
 * **install-verify is best-effort.** PyPI's CDN sometimes lags. The
   umbrella pre-check retries for 2 minutes before failing, and the
   `genblaze[all]` install itself retries up to 5 times (30s apart) since
-  any of its ~18 connector packages can propagate independently of the
+  any of its ~14 connector packages can propagate independently of the
   umbrella (#189). A red `install-verify` after a green publish graph
   usually means a package is fine and the index is just behind — verify
   manually with `pip install "genblaze[all]==X.Y.Z"` in a fresh venv


### PR DESCRIPTION
## Summary

`install-verify`'s "Wait for PyPI to index the umbrella" pre-check only polls for the `genblaze` umbrella package, but the subsequent `pip install "genblaze[all]==$version"` also resolves the ~14 connector packages (`genblaze-nvidia`, `genblaze-google`, etc.), which propagate across PyPI's CDN independently of the umbrella. The pre-check can pass while a connector's simple-index page is still stale on the edge the runner hits, false-redding a genuinely-healthy release. This happened twice during the v0.6.0 release (first `genblaze-nvidia>=0.3.2`, then `genblaze-google>=0.3.3`).

## Changes

- `.github/workflows/release.yml` — wraps the `pip install "genblaze[all]==$version"` line (inside the existing "Fresh install and import smoke" step) in a bounded retry loop: 5 attempts, 30s apart. Retries the exact operation that fails, regardless of which package lags, rather than trying to enumerate every connector in the pre-check. The umbrella pre-check step and the `tools/release_import_smoke.py` invocation are both unchanged.
- `RELEASING.md` — updates the "install-verify is best-effort" operational note to describe both retry mechanisms (umbrella pre-check + install retry).
- `CHANGELOG.md` — adds an `### Internal` entry under `[Unreleased]`, matching the precedent used for other release-tooling-only changes (no packaged code changed).

## Test plan

- [ ] `make test` — not run; no Python/packaged code touched (workflow-YAML-only change)
- [ ] `make lint` — not run; ruff doesn't cover `.yml`/`.md`
- [x] `actionlint .github/workflows/release.yml` — passes (one pre-existing, unrelated SC2129 style note at line 90, confirmed present on `origin/main` before this change too)
- [x] `bash -n` on the extracted `run:` script — passes, no syntax errors
- [x] Hand-traced the retry loop's exit-code semantics for all three paths: immediate success (breaks, runs import-smoke once), success after N<5 failures (same), and exhaustion after 5 failed attempts (`::error::` + `exit 1`, job goes red, import-smoke never reached) — confirmed correct via a standalone bash simulation of all three cases
- [x] Docs updated in the same PR (RELEASING.md, CHANGELOG.md)

Three independent review passes (correctness/tests, security/invariants, architecture/DRY/scalability) were run against the committed diff before pushing. All three came back with no P0/P1 blocking findings — only informational P2s, one of which (an inaccurate "~18 connector packages" figure vs. the actual 14 in `libs/meta/pyproject.toml`'s `all` extra) was fixed in a follow-up commit on this branch.

## Related

Refs #189