### PR TITLE
docs(guides): document local_file_url() for local-output file:// URLs

### DIFF
--- a/docs/guides/new-provider.md
+++ b/docs/guides/new-provider.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-21 -->
+<!-- last_verified: 2026-07-27 -->
 # Adding a New Provider
 
 Step-by-step guide for contributing a provider adapter to genblaze. This guide is the canonical contract — every section maps to a check the compliance harness or pipeline relies on.
@@ -264,6 +264,8 @@ if step.inputs:
 ```
 
 This prevents SSRF — only `https://` and `file://` URLs are allowed.
+
+> **Local file output:** if your provider writes a local file and exposes it as a `file://` asset, build the URL with `genblaze_core._utils.local_file_url(path.resolve())` — never `f"file://{quote(str(path))}"`. `local_file_url()` uses `Path.as_uri()`, which yields the empty-netloc form (`file:///C:/...`) that parses correctly on every platform, including Windows; the hand-rolled `quote()` pattern percent-encodes the drive colon and broke every connector-produced asset on Windows (#164).
 
 > **Shortcut:** if your provider uses a `ModelSpec` with `input_mapping` declared, call `self.prepare_payload(step, base_params=...)` instead. It runs the full ModelSpec pipeline (aliases → transformer → chain inputs → coercers → defaults → schemas → required → constraints → allowlist) **and** SSRF-validates every `step.inputs` URL automatically. See [`model-registry.md`](../features/model-registry.md) for the pipeline order.
 


### PR DESCRIPTION
## Summary

`docs/guides/new-provider.md` — the canonical contract for new connector PRs — never mentioned `local_file_url()` and had no section on constructing local-output `file://` URLs, even though the #164 Windows bug shipped identically across ~10 connectors before being fixed centrally. This adds a short callout so future connector authors use the shared helper instead of reintroducing the broken pattern.

## Changes

- `docs/guides/new-provider.md`: added a "Local file output" callout in section 6 (Chain input validation), next to the existing SSRF / `file://` input discussion. States that a connector writing a local output and exposing it as a `file://` asset must build the URL via `genblaze_core._utils.local_file_url(path.resolve())`, never `f"file://{quote(str(path))}"`, with a one-line why (`as_uri()`'s empty-netloc form vs. the percent-encoded drive colon that broke Windows). Cross-references #164.
- Bumped the doc's `last_verified` stamp to today per repo convention.

Docs-only change — no code, no version bump, no CHANGELOG edit (per the coordinated v0.6.1 batch rules).

## Test plan

- [ ] `make test` passes — not run; docs-only change, no code touched
- [ ] `make lint` passes — not run; docs-only change, no code touched
- [x] Docs updated (if behavior changed) — this PR is the doc update

## Related

Closes #203