### PR TITLE
fix(tools): preserve in-flight dependency blockers in batch_cluster

### DIFF
--- a/tools/batch_cluster.py
+++ b/tools/batch_cluster.py
@@ -94,7 +94,9 @@ class Cluster:
     pr_mode: str  # "combined" (>1 issue, one PR) | "single"
     layer: int  # dependency depth; 0 == no prerequisite clusters
     executable: bool  # runnable this batch (layer 0 and within cap)
-    blocked_by: list[str] = field(default_factory=list)  # cluster ids
+    blocked_by: list[str] = field(
+        default_factory=list
+    )  # cluster ids, or "issue-N" for a skipped-in-flight prerequisite
     defer_reason: str = ""
 
 
@@ -216,12 +218,25 @@ def build_plan(scout: list[dict], config: Config | None = None) -> Plan:
     # 4. Map each issue to its component root, then build inter-component
     #    dependency edges from explicit "depends on #x" links.
     root_of = {num: root for root, members in components.items() for num in members}
+    # Issues the scout saw but excluded via skip_reason are, today, always
+    # "already has an open PR/branch" (batch-plan.js only sets skip_reason for
+    # that case) — i.e. in flight, not merged. A dep pointing at one of these
+    # must still block its dependent; only deps pointing at numbers the scout
+    # never saw at all (truly closed/merged or out of scope) are safe to drop.
+    skipped_numbers = {row["number"] for row in skipped}
     dep_edges: dict[int, set[int]] = {
         root: set() for root in components
     }  # child_root <- {prereq_root}
+    blocked_by_issue: dict[int, set[int]] = {}  # child_root <- {in-flight issue #}
     for num, row in active.items():
         for dep in row.get("deps", []):
             dep = int(dep)
+            if dep in skipped_numbers:
+                # Prerequisite is skipped-in-flight: it has no cluster/root of
+                # its own, so record it directly as an issue-level blocker
+                # instead of dropping the edge.
+                blocked_by_issue.setdefault(root_of[num], set()).add(dep)
+                continue
             if dep not in root_of:
                 continue  # prereq already merged/closed or out of scope
             child, prereq = root_of[num], root_of[dep]
@@ -263,6 +278,7 @@ def build_plan(scout: list[dict], config: Config | None = None) -> Plan:
         member_files = _normalize([f for n in members for f in files[n]])
         member_hot = _normalize([f for n in members for f in hot[n]])
         blocked_by = sorted(_slug(components[p]) for p in dep_edges[root])
+        blocked_by += [f"issue-{n}" for n in sorted(blocked_by_issue.get(root, ()))]
         oversized = len(members) > cfg.max_issues or len(member_files) > cfg.max_files
 
         if root in cyclic:

--- a/tools/tests/test_batch_cluster.py
+++ b/tools/tests/test_batch_cluster.py
@@ -193,6 +193,104 @@ def test_dep_on_out_of_scope_issue_is_ignored():
     assert not plan.clusters[0].blocked_by
 
 
+def test_dep_on_skipped_in_flight_issue_blocks_dependent():
+    # #1 depends on #2, which the scout skipped because it already has an open
+    # PR/branch (still in flight, not merged). #2 never becomes a cluster, but
+    # #1 must stay blocked rather than being cleared to run against
+    # origin/main before #2 lands.
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"], deps=[2]),
+            _issue(2, ["libs/core/b.py"], skip="has open PR"),
+        ]
+    )
+    assert len(plan.clusters) == 1
+    cluster = plan.clusters[0]
+    assert cluster.issues == [1]
+    assert not cluster.executable
+    assert cluster.defer_reason == DEFER_AWAITING_PREREQ
+    assert cluster.blocked_by == ["issue-2"]
+    assert plan.skipped == [{"number": 2, "reason": "has open PR"}]
+
+
+def test_skipped_in_flight_issue_blocks_multiple_downstream_clusters():
+    # #1 and #2 don't share files (separate clusters) but both depend on the
+    # same skipped-in-flight #3 -- neither should be cleared to run.
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"], deps=[3]),
+            _issue(2, ["libs/core/b.py"], deps=[3]),
+            _issue(3, ["libs/core/c.py"], skip="has open PR"),
+        ]
+    )
+    clusters = _by_id(plan)
+    assert clusters["issues-1"].blocked_by == ["issue-3"]
+    assert clusters["issues-2"].blocked_by == ["issue-3"]
+    assert not clusters["issues-1"].executable
+    assert not clusters["issues-2"].executable
+
+
+def test_component_members_depend_on_different_skipped_issues():
+    # #1 and #2 share a file (one cluster) but each depends on a different
+    # skipped-in-flight prerequisite -- both must accumulate as blockers.
+    shared = "libs/core/shared.py"
+    plan = build_plan(
+        [
+            _issue(1, [shared], deps=[3]),
+            _issue(2, [shared], deps=[4]),
+            _issue(3, ["libs/core/c.py"], skip="has open PR"),
+            _issue(4, ["libs/core/d.py"], skip="has open PR"),
+        ]
+    )
+    assert len(plan.clusters) == 1
+    cluster = plan.clusters[0]
+    assert cluster.issues == [1, 2]
+    assert cluster.blocked_by == ["issue-3", "issue-4"]
+    assert not cluster.executable
+
+
+def test_oversized_component_blocked_by_skipped_dep_on_tail_member():
+    # The skipped-in-flight dependency is on #3, a tail member, not the head
+    # (#1). blocked_by is computed once per component and shared by both the
+    # serialized head and deferred tail, so the head must also stay blocked --
+    # it would otherwise wrongly run now just because it isn't the member
+    # holding the dependency.
+    shared = "libs/core/shared.py"
+    plan = build_plan(
+        [
+            _issue(1, [shared, "libs/core/f1.py"]),
+            _issue(2, [shared, "libs/core/f2.py"]),
+            _issue(3, [shared, "libs/core/f3.py"], deps=[99]),
+            _issue(4, [shared, "libs/core/f4.py"]),
+            _issue(99, ["libs/core/f99.py"], skip="has open PR"),
+        ],
+        Config(max_issues=3),
+    )
+    clusters = _by_id(plan)
+    head = clusters["issues-1"]
+    tail = clusters["issues-2-3-4"]
+    assert not head.executable
+    assert head.blocked_by == ["issue-99"]
+    assert head.defer_reason == DEFER_AWAITING_PREREQ
+    assert not tail.executable
+    assert tail.defer_reason == DEFER_OVERSIZED
+
+
+def test_blocked_by_mixes_cluster_and_issue_level_blockers():
+    # #1 depends on both an active prerequisite (#2, its own cluster) and a
+    # skipped-in-flight one (#3) -- blocked_by must carry both blocker shapes.
+    plan = build_plan(
+        [
+            _issue(1, ["libs/core/a.py"], deps=[2, 3]),
+            _issue(2, ["libs/core/b.py"]),
+            _issue(3, ["libs/core/c.py"], skip="has open PR"),
+        ]
+    )
+    cluster = _by_id(plan)["issues-1"]
+    assert not cluster.executable
+    assert cluster.blocked_by == ["issues-2", "issue-3"]
+
+
 def test_plan_serializes_to_json_dict():
     plan = build_plan([_issue(1, ["libs/core/a.py"])])
     d = plan.to_dict()


### PR DESCRIPTION
## Summary

`tools/batch_cluster.py` could mark an issue executable before its prerequisite landed, when the prerequisite was skipped because it already had an open PR/branch (in flight, not merged).

## Changes

- `tools/batch_cluster.py`: in the dependency-resolution loop, deps pointing at a scout-skipped-in-flight issue are now recorded in a new `blocked_by_issue` map (root -> in-flight issue numbers) instead of being silently dropped via `if dep not in root_of: continue`. Those are folded into each cluster's existing `blocked_by` list as `"issue-N"` entries, so the pre-existing `executable = layer[root] == 0 and not blocked_by` check and `DEFER_AWAITING_PREREQ` fallback correctly withhold execution. Deps pointing at issue numbers the scout never returned at all (truly closed/merged/out of scope) are still safely dropped, unchanged. Updated the `Cluster.blocked_by` field comment to note the new `"issue-N"` shape.
- `tools/tests/test_batch_cluster.py`: added 5 cases — the core in-flight-prerequisite regression from the issue, plus edge cases surfaced in review (same in-flight issue blocking multiple downstream clusters, a component whose members depend on different in-flight issues, an in-flight dependency held by a tail member of an oversized/serialized component still blocking the head, and a cluster blocked by both a cluster-level and an issue-level blocker simultaneously).

No version bump / CHANGELOG entry — `tools/` is internal dev tooling, not a shipped package.

## Test plan

- [x] `cd tools && pytest tests/test_batch_cluster.py -v` — 18 passed
- [x] `cd tools && pytest tests/ -v` — 130 passed (full tools suite, unaffected packages included)
- [x] `ruff check tools/batch_cluster.py tools/tests/test_batch_cluster.py && ruff format --check` — clean
- [ ] `make test` (full monorepo suite) — not run this session; change is scoped to `tools/` only, already covered by the tools pytest run above, which `make test` also invokes (`pytest tools/tests/ -v`)
- [ ] `make lint` — not run; `tools/` is outside the lint gate (`ruff check libs/ cli/ examples/`, see #31) and no `libs/`/`cli/`/`examples/` files changed
- Docs updated: N/A — internal tooling behavior, no user-facing docs reference this module's dependency-edge semantics

### Triangulated pre-PR review (3 independent lenses)

- **Correctness & tests**: No P0. Confirmed the fix closes the gap in all three cluster-emission branches (normal, oversized-serialize, cyclic), confirmed the new regression test fails on pre-fix code and passes post-fix, confirmed the existing out-of-scope-dep test is unaffected. Raised 4 test-coverage gaps (multi-cluster blocking, mixed skipped deps within a component, oversized-tail dependency, mixed cluster/issue blockers) — all 4 added as new tests before push.
- **Security & invariants**: No P0. No fail-open path found; traced `blocked_by_issue` population/read for `KeyError`/silent-drop risk (none reachable). Confirmed no slug collision between `"issue-N"` and `"issues-N..."`, no injection surface in `batch_plandoc.py`'s consumption of `blocked_by`, and the module stays pure (no I/O/subprocess/secrets). Noted a P1 (pre-existing, out of scope for #204): a dep pointing at an issue number the scout omits entirely from its output still silently drops, same failure class — worth a follow-up issue.
- **Architecture, scalability & DRY**: No P0. Confirmed reusing `blocked_by: list[str]` for both cluster-slug and issue-level blockers is sound given it's a single display-only consumer (`batch_plandoc.py`, joined into a markdown cell, never parsed by shape) — updated the stale field comment (P1) accordingly. Confirmed keeping `blocked_by_issue` separate from `dep_edges` is correct since skipped issues have no root/layer for `_resolve`'s DAG-layering to consume. Confirmed no scalability concern at the ~40-issue batch cap.

## Related

Closes #204