### PR TITLE
fix(ci): pin ruff to 0.14.0 in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
           python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
-      - run: pip install ruff
+      # Pin ruff: unpinned drift false-reds lint on every PR + main when a new
+      # ruff reformats pre-existing files no PR touched (#211). Bump deliberately
+      # alongside a matching `make format`.
+      - run: pip install ruff==0.14.0
       - run: ruff check libs/ cli/ examples/
       - run: ruff format --check libs/ cli/ examples/
 


### PR DESCRIPTION
Closes #211.

CI's `lint` job did `pip install ruff` unpinned (ci.yml L33), so a newer ruff than the `0.14.0` contributors format against reformats 17 pre-existing doc files (READMEs with Python blocks) that no PR touches. Result: `ruff format --check` fails on **every open PR and on main** (red since 293bead / 2026-07-23).

**Fix:** pin `ruff==0.14.0` in the lint job so check/format are deterministic. No file reformat needed; local `ruff 0.14.0` already reports all 394 files clean. Unblocks the whole PR queue.

Follow-up (noted in #211): add an upper bound to the `ruff>=0.4` dev-dep floor in libs/core so local installs match CI.