### PR TITLE
fix(meta): preserve optional-dependency install hint through umbrella __getattr__

### DIFF
--- a/libs/meta/genblaze/__init__.py
+++ b/libs/meta/genblaze/__init__.py
@@ -47,7 +47,18 @@ def __getattr__(name: str):
         raise AttributeError(f"module 'genblaze' has no attribute {name!r}")
     try:
         val = getattr(_core, name)
-    except AttributeError:
+    except AttributeError as exc:
+        # Issue #197: genblaze_core.__getattr__ (#165) re-raises a missing
+        # optional dependency as AttributeError chained via __cause__ to an
+        # OptionalDependencyError carrying the actionable install hint (e.g.
+        # `pip install "genblaze[parquet]"`). Without unwrapping __cause__
+        # here, that hint was lost and replaced with the generic "unknown
+        # attribute / provider adapter" message below — which actively
+        # misdirects since the name IS known, just its extra isn't installed.
+        from genblaze_core._optional import OptionalDependencyError
+
+        if isinstance(exc.__cause__, OptionalDependencyError):
+            raise AttributeError(str(exc.__cause__)) from exc.__cause__
         raise AttributeError(
             f"module 'genblaze' has no attribute {name!r}. "
             f"For nested submodules (e.g. genblaze_core.media) import from "

--- a/libs/meta/tests/test_shim.py
+++ b/libs/meta/tests/test_shim.py
@@ -114,8 +114,8 @@ class TestLazyAttributeCapabilityProbing:
         # The misleading "provider adapter" fallback must not appear.
         assert "provider adapter" not in msg
 
-    def test_genuinely_unknown_name_still_gets_fallback_message(self, missing_pyarrow):
-        self._evict_cached_lazy_attr("ParquetSink")
+    def test_genuinely_unknown_name_still_gets_fallback_message(self):
+        # Doesn't touch ParquetSink/pyarrow — no missing_pyarrow fixture needed.
         with pytest.raises(AttributeError) as excinfo:
             _ = genblaze.SoraProvider  # type: ignore[attr-defined]
         msg = str(excinfo.value)

--- a/libs/meta/tests/test_shim.py
+++ b/libs/meta/tests/test_shim.py
@@ -60,6 +60,69 @@ def test_star_import_exposes_every_public_symbol():
     assert ns["Pipeline"] is genblaze_core.Pipeline
 
 
+@pytest.fixture
+def missing_pyarrow():
+    """Simulate the ``parquet`` extra not being installed.
+
+    pyarrow IS available in this dev env, so we evict any cached import and
+    shadow it in ``sys.modules`` with ``None`` — Python's import machinery
+    treats that as "this module cannot be imported," mirroring what a
+    fresh-install user without the parquet extra would experience. Mirrors
+    the fixture of the same name in
+    ``libs/core/tests/unit/test_optional_imports.py``.
+    """
+    for cached in list(sys.modules):
+        if cached.startswith("pyarrow") or cached == "genblaze_core.sinks.parquet":
+            sys.modules.pop(cached, None)
+    sys.modules["pyarrow"] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        sys.modules.pop("pyarrow", None)
+        sys.modules.pop("genblaze_core.sinks.parquet", None)
+
+
+class TestLazyAttributeCapabilityProbing:
+    """Issue #197: the umbrella ``genblaze.__getattr__`` must preserve the
+    actionable ``OptionalDependencyError`` install hint that
+    ``genblaze_core.__getattr__`` raises (issue #165) instead of collapsing
+    it into the generic "unknown attribute / provider adapter" message.
+    Mirrors ``TestLazyAttributeCapabilityProbing`` in
+    ``libs/core/tests/unit/test_optional_imports.py``.
+    """
+
+    @staticmethod
+    def _evict_cached_lazy_attr(name: str) -> None:
+        # Both genblaze and genblaze_core cache resolved lazy imports into
+        # module globals; pop from both so __getattr__ runs again instead of
+        # returning a class resolved by an earlier, unrelated test/import.
+        genblaze.__dict__.pop(name, None)
+        genblaze_core.__dict__.pop(name, None)
+
+    def test_hasattr_returns_false_when_optional_dep_missing(self, missing_pyarrow):
+        self._evict_cached_lazy_attr("ParquetSink")
+        assert hasattr(genblaze, "ParquetSink") is False
+
+    def test_direct_access_surfaces_install_hint(self, missing_pyarrow):
+        self._evict_cached_lazy_attr("ParquetSink")
+        with pytest.raises(AttributeError) as excinfo:
+            _ = genblaze.ParquetSink  # type: ignore[attr-defined]
+        msg = str(excinfo.value)
+        assert "pyarrow" in msg
+        assert "pip install 'genblaze[parquet]'" in msg
+        assert "ParquetSink" in msg
+        # The misleading "provider adapter" fallback must not appear.
+        assert "provider adapter" not in msg
+
+    def test_genuinely_unknown_name_still_gets_fallback_message(self, missing_pyarrow):
+        self._evict_cached_lazy_attr("ParquetSink")
+        with pytest.raises(AttributeError) as excinfo:
+            _ = genblaze.SoraProvider  # type: ignore[attr-defined]
+        msg = str(excinfo.value)
+        assert "SoraProvider" in msg
+        assert "genblaze_openai" in msg
+
+
 def test_import_genblaze_does_not_eagerly_load_core_submodules():
     """Documents the lazy-load contract: `import genblaze` must not pull
     pipeline / providers / storage / etc. into sys.modules. Regression guard


### PR DESCRIPTION
Closes #197.

The umbrella `genblaze.__getattr__` caught `AttributeError` from `getattr(_core, name)` and unconditionally rewrote it to the "unknown attribute / provider adapter" message, so with the `parquet` extra missing, `genblaze.ParquetSink` / `from genblaze import ParquetSink` lost the `pip install "genblaze[parquet]"` hint (and misdirected to a connector install).

**Fix:** when the caught error's `__cause__` is an `OptionalDependencyError` (the type core's #165 fix chains), re-raise preserving that hint; only fall through to the unknown-name message for genuinely-unknown names. Meta-source only, no core change, no floor bump.

Tests: `libs/meta/tests/test_shim.py` — hasattr→False, direct access surfaces the hint, unknown names still get the generic message.

Note: the `lint` check is red repo-wide from unpinned-ruff drift (#211), fixed by #212 — unrelated to this diff.