### PR TITLE
fix(cli): reject remote file:// authorities in verify --fetch; redact userinfo; dedupe stream-hash

### DIFF
--- a/cli/genblaze_cli/commands/verify.py
+++ b/cli/genblaze_cli/commands/verify.py
@@ -19,21 +19,20 @@ if TYPE_CHECKING:
 # 256 KB chunks; matches the transfer layer's streaming granularity.
 _FETCH_CHUNK = 256 * 1024
 
-# A presigned URL's query string is a bearer credential for that object (#75);
-# it must never be echoed in CLI output or error messages.
-_URL_QUERY_RE = re.compile(r"https?://\S+?\?\S+")
+# A presigned URL's query string, or basic-auth userinfo (user:pass@host), is
+# a bearer credential for that object (#75, #201); it must never be echoed in
+# CLI output or error messages. Matches any http(s) URL — not just ones with a
+# query string — so a userinfo-only URL embedded in a transfer-layer exception
+# message is also caught; _redact_url no-ops on a URL with neither.
+_URL_RE = re.compile(r"https?://\S+")
 
 
 def _redact_url(url: str) -> str:
     parsed = urlsplit(url)
-    # Userinfo (user:pass@host) is a bearer credential exactly like a
-    # presigned query string (#201) — blank it the same way rather than
-    # only scrubbing the query.
-    netloc = parsed.netloc
-    if parsed.username or parsed.password:
-        netloc = parsed.hostname or ""
-        if parsed.port:
-            netloc = f"{netloc}:{parsed.port}"
+    # Strip userinfo by editing the netloc string directly rather than
+    # rebuilding it from parsed.hostname/.port — hostname strips the []
+    # brackets off an IPv6 literal, which would otherwise corrupt the URL.
+    netloc = parsed.netloc.rsplit("@", 1)[-1] if "@" in parsed.netloc else parsed.netloc
     if parsed.query or netloc != parsed.netloc:
         query = "REDACTED" if parsed.query else parsed.query
         return urlunsplit(parsed._replace(netloc=netloc, query=query))
@@ -41,7 +40,7 @@ def _redact_url(url: str) -> str:
 
 
 def _redact_text(text: str) -> str:
-    return _URL_QUERY_RE.sub(lambda m: _redact_url(m.group(0)), text)
+    return _URL_RE.sub(lambda m: _redact_url(m.group(0)), text)
 
 
 def _hash_url_bytes(url: str, extra_roots: tuple[Path, ...] = ()) -> tuple[str, int]:

--- a/cli/genblaze_cli/commands/verify.py
+++ b/cli/genblaze_cli/commands/verify.py
@@ -26,8 +26,17 @@ _URL_QUERY_RE = re.compile(r"https?://\S+?\?\S+")
 
 def _redact_url(url: str) -> str:
     parsed = urlsplit(url)
-    if parsed.query:
-        return urlunsplit(parsed._replace(query="REDACTED"))
+    # Userinfo (user:pass@host) is a bearer credential exactly like a
+    # presigned query string (#201) — blank it the same way rather than
+    # only scrubbing the query.
+    netloc = parsed.netloc
+    if parsed.username or parsed.password:
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+    if parsed.query or netloc != parsed.netloc:
+        query = "REDACTED" if parsed.query else parsed.query
+        return urlunsplit(parsed._replace(netloc=netloc, query=query))
     return url
 
 
@@ -48,36 +57,42 @@ def _hash_url_bytes(url: str, extra_roots: tuple[Path, ...] = ()) -> tuple[str, 
     temp-dir allowlist). Bytes are hashed as they arrive; a whole asset is
     never held in memory.
     """
-    scheme = urlsplit(url).scheme
+    parsed = urlsplit(url)
+    scheme = parsed.scheme
     if scheme == "https":
-        from genblaze_core.exceptions import StorageError
+        # TODO(#202): these are genblaze_core underscore-private symbols;
+        # the private-import cleanup (promoting a public streaming helper)
+        # is a deferred follow-up, not part of this fix.
         from genblaze_core.storage.transfer import (
             _DEFAULT_DOWNLOAD_TIMEOUT,
             _DEFAULT_MAX_DOWNLOAD_BYTES,
+            _HashingStreamReader,
             _http_get_stream,
         )
 
-        digest = hashlib.sha256()
-        size = 0
         resp = _http_get_stream(url, timeout=_DEFAULT_DOWNLOAD_TIMEOUT)
+        # Reuse the transfer layer's own chunk-read/incremental-sha256/cap
+        # loop instead of duplicating it (#202) — same exception type and
+        # message shape by construction, so callers see one error taxonomy.
+        reader = _HashingStreamReader(resp, max_bytes=_DEFAULT_MAX_DOWNLOAD_BYTES)
         try:
-            while chunk := resp.read(_FETCH_CHUNK):
-                digest.update(chunk)
-                size += len(chunk)
-                if size > _DEFAULT_MAX_DOWNLOAD_BYTES:
-                    # Same exception type and message shape as the transfer
-                    # layer's own cap, so callers see one error taxonomy.
-                    raise StorageError(
-                        f"Download exceeds {_DEFAULT_MAX_DOWNLOAD_BYTES} byte limit"
-                    )
+            while reader.read(_FETCH_CHUNK):
+                pass
         finally:
             resp.release_conn()
-        return digest.hexdigest(), size
+        return reader.sha256_hex, reader.size
     if scheme == "file":
         from genblaze_core._utils import ALLOWED_FILE_ROOTS
 
+        # RFC 8089: empty or 'localhost' netloc only; anything else is a
+        # remote-authority reference and must not be silently resolved as a
+        # local path (#201) — matches core's validate_chain_input_url.
+        if parsed.netloc and parsed.netloc != "localhost":
+            raise ValueError(
+                f"file:// URL must have empty or 'localhost' netloc; got {parsed.netloc!r}"
+            )
         allowed = (*ALLOWED_FILE_ROOTS, *(r.resolve() for r in extra_roots))
-        resolved = Path(url2pathname(urlsplit(url).path)).resolve()
+        resolved = Path(url2pathname(parsed.path)).resolve()
         if not any(resolved.is_relative_to(root) for root in allowed):
             raise ValueError(f"file:// path outside allowed roots: {resolved}")
         digest = hashlib.sha256()
@@ -130,12 +145,18 @@ def _fetch_and_compare(
 @click.option(
     "--hash-only",
     is_flag=True,
-    help="Only verify canonical_hash; skip output sha256 and asset-metadata checks.",
+    help=(
+        "Only verify canonical_hash; skip output sha256 and asset-metadata checks. "
+        "Mutually exclusive with --fetch."
+    ),
 )
 @click.option(
     "--fetch",
     is_flag=True,
-    help="Also download each output asset and compare its bytes to the declared sha256.",
+    help=(
+        "Also download each output asset and compare its bytes to the declared "
+        "sha256. Mutually exclusive with --hash-only."
+    ),
 )
 @click.option(
     "--allowed-root",

--- a/cli/tests/test_verify_fetch.py
+++ b/cli/tests/test_verify_fetch.py
@@ -293,6 +293,88 @@ def test_verify_fetch_no_output_assets_reports_nothing_to_fetch(tmp_path: Path) 
     assert "no output assets to fetch" in result.output
 
 
+def test_verify_fetch_rejects_file_url_with_remote_netloc(tmp_path: Path) -> None:
+    """file://remote-host/... must fail, not silently resolve to a local path
+    (#201) — mirrors core's validate_chain_input_url netloc contract."""
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="file://remote-host/tmp/a", media_type="image/png")
+    asset.sha256 = "f" * 64
+    step.assets = [asset]
+    run = RunBuilder("fetch-remote-netloc").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "netloc" in combined
+    assert "outside allowed roots" not in combined
+
+
+def test_verify_fetch_allows_file_url_with_localhost_netloc(tmp_path: Path) -> None:
+    """RFC 8089 permits an explicit 'localhost' authority; only non-empty,
+    non-localhost netlocs are rejected."""
+    manifest_path, asset_path = _create_fetch_manifest(tmp_path)
+    manifest_json = manifest_path.read_text(encoding="utf-8")
+    localhost_url = f"file://localhost{asset_path.resolve()}"
+    manifest_path.write_text(manifest_json.replace(asset_path.as_uri(), localhost_url))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "fetched and matched" in result.output
+
+
+def test_redact_url_blanks_userinfo() -> None:
+    """A presigned/basic-auth userinfo (user:pass@) is a credential; it must
+    not survive redaction any more than the query string does (#201)."""
+    from genblaze_cli.commands.verify import _redact_url
+
+    redacted = _redact_url("https://user:pass@cdn.example.com/output.png")
+
+    assert "user" not in redacted
+    assert "pass" not in redacted
+    assert "cdn.example.com/output.png" in redacted
+
+
+def test_verify_fetch_redacts_userinfo_in_label(tmp_path: Path) -> None:
+    """A userinfo-bearing asset URL must not leak credentials into the
+    per-asset label used in both OK and failure output."""
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="https://user:s3cr3t@cdn.example.com/output.png", media_type="image/png")
+    asset.sha256 = "f" * 64  # deliberately wrong; forces a failure line with the label
+    step.assets = [asset]
+    run = RunBuilder("fetch-userinfo").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "s3cr3t" not in combined
+
+
+def test_verify_help_mentions_mutual_exclusion() -> None:
+    """--fetch and --hash-only mutual exclusion must be discoverable from
+    --help, not just from triggering the UsageError (#201)."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--help"])
+
+    assert result.exit_code == 0
+    # Click wraps long help strings across lines, so assert against the
+    # normalized full block rather than a single line.
+    normalized = " ".join(result.output.split())
+    assert "mutually exclusive with --hash-only" in normalized.lower()
+    assert "mutually exclusive with --fetch" in normalized.lower()
+
+
 def test_verify_fetch_rejects_http_scheme(tmp_path: Path) -> None:
     """Plain http:// is rejected; https-only, same policy as the transfer layer."""
     step = StepBuilder("test", "test-model").prompt("hello").build()

--- a/cli/tests/test_verify_fetch.py
+++ b/cli/tests/test_verify_fetch.py
@@ -361,6 +361,91 @@ def test_verify_fetch_redacts_userinfo_in_label(tmp_path: Path) -> None:
     assert "s3cr3t" not in combined
 
 
+def test_redact_url_preserves_ipv6_brackets() -> None:
+    """Stripping userinfo must not corrupt an IPv6 host literal's brackets —
+    rebuilding netloc from parsed.hostname (which unwraps them) would."""
+    from genblaze_cli.commands.verify import _redact_url
+
+    redacted = _redact_url("https://user:pass@[::1]:8443/output.png")
+
+    assert "user" not in redacted
+    assert "pass" not in redacted
+    assert "[::1]:8443" in redacted
+
+
+def test_verify_fetch_redacts_userinfo_without_query_in_failure_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A userinfo-bearing URL with no query string must still be redacted out
+    of freeform exception text (e.g. a transfer-layer error echoing the URL),
+    not just out of the per-asset label — _redact_text's matcher must not
+    require a literal '?' to catch a credential (#201)."""
+    from genblaze_core.exceptions import StorageError
+
+    url = "https://user:s3cr3t@cdn.example.com/output.png"
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url=url, media_type="image/png")
+    asset.set_hash(b"whatever")
+    step.assets = [asset]
+    run = RunBuilder("fetch-userinfo-noquery").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    def _raise(url: str, *, timeout: float) -> None:
+        # Mirrors the transfer layer echoing the raw URL into its own
+        # exception message on a download failure.
+        raise StorageError(f"Download failed for {url}: connection refused")
+
+    monkeypatch.setattr("genblaze_core.storage.transfer._http_get_stream", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "s3cr3t" not in combined
+
+
+def test_verify_fetch_enforces_max_download_bytes_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The max-bytes cap must still be enforced through the
+    _HashingStreamReader wiring used to fetch https:// assets (#202)."""
+    step = StepBuilder("test", "test-model").prompt("hello").build()
+    step.status = StepStatus.SUCCEEDED
+    asset = Asset(url="https://cdn.example.com/output.png", media_type="image/png")
+    asset.sha256 = "f" * 64
+    step.assets = [asset]
+    run = RunBuilder("fetch-cap").add_step(step).build()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(Manifest.from_run(run).to_canonical_json(), encoding="utf-8")
+
+    class _FakeResp:
+        def __init__(self) -> None:
+            self._buf = b"x" * 20
+            self.released = False
+
+        def read(self, size: int) -> bytes:
+            chunk, self._buf = self._buf[:size], self._buf[size:]
+            return chunk
+
+        def release_conn(self) -> None:
+            self.released = True
+
+    monkeypatch.setattr(
+        "genblaze_core.storage.transfer._http_get_stream", lambda url, *, timeout: _FakeResp()
+    )
+    monkeypatch.setattr("genblaze_core.storage.transfer._DEFAULT_MAX_DOWNLOAD_BYTES", 10)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify", "--fetch", str(manifest_path)])
+    combined = result.output + getattr(result, "stderr", "")
+
+    assert result.exit_code != 0
+    assert "byte limit" in combined
+
+
 def test_verify_help_mentions_mutual_exclusion() -> None:
     """--fetch and --hash-only mutual exclusion must be discoverable from
     --help, not just from triggering the UsageError (#201)."""


### PR DESCRIPTION
Closes #201. Partial #202 (minimal variant).

#201: `_hash_url_bytes` resolved only `urlsplit(url).path` for `file://`, so `file://remote-host/tmp/a` read local `/tmp/a`. Now rejects any `file://` URL whose netloc is not empty or `localhost` (matches core's chain-input contract). Also: `_redact_url` now strips `user:pass@` userinfo (not just the query string), and the `--fetch`/`--hash-only` help text states the mutual exclusion.

#202 (minimal): removed the duplicated chunk/hash/cap loop by reusing `genblaze_core.storage.transfer._HashingStreamReader`. Kept cli-only; the private-import cleanup is a deferred follow-up (TODO noted).

Tests: `cli/tests/test_verify_fetch.py` — remote-netloc file:// is a failure, userinfo redaction, existing SSRF/mismatch/mutex coverage intact.

Note: `lint` is red repo-wide from unpinned-ruff drift (#211), fixed by #212 — unrelated to this diff.