### PR TITLE
fix(core): close ReDoS wrapper bypass (#196) and disjoint-charset over-rejection (#200)

### DIFF
--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -250,6 +250,21 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
     *mandatory* (non-nullable) separator between the groups — a literal
     character the group's own quantifier can't also match away — remains a
     real anchor and isn't flagged (see ``_is_nullable_separator``).
+
+    Two adjacent unbounded groups only ambiguously partition a shared run of
+    input if their matched-character sets can actually overlap — a run is
+    only continued past a group when :func:`_charsets_overlap` says so
+    against the *previous* group in the run (via :func:`_branch_charset`
+    with ``allow_unbounded=True``, which reduces a group's body to a
+    charset regardless of its quantifier's bound). ``([a-z]+)-?([0-9]+)``
+    has an unambiguous split point (a letter run can never contain a digit
+    or vice versa) and is linear-time safe, unlike ``(a+)-?(a+)`` where both
+    groups match the same character — this gate, added for issue #200,
+    stops the former from being over-rejected as a regression of the
+    nullable-separator broadening (issue #157) without weakening the
+    latter. A group whose body can't be reduced to a concrete charset
+    (nested groups, an unresolvable escape class) keeps the prior
+    conservative "assume overlap" behavior.
     """
     spans = _iter_group_spans(src)
     # Only top-level groups matter for this shape — a group nested inside
@@ -260,8 +275,14 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
 
     run = 0
     prev_end: int | None = None
+    prev_reducible = False
+    prev_charset: frozenset[str] | None = None
     for start, end in top_level:
-        unbounded = bool(re.search(_UNBOUNDED_QUANT, src[start + 1 : end]))
+        body = src[start + 1 : end]
+        unbounded = bool(re.search(_UNBOUNDED_QUANT, body))
+        reducible, charset = (
+            _branch_charset(body, allow_unbounded=True) if unbounded else (False, None)
+        )
         # Two groups are "adjacent" only if the text between them can vanish
         # (a nullable separator — see _is_nullable_separator). A top-level `|`
         # in that gap is the exception: it puts the groups in DIFFERENT
@@ -272,10 +293,21 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
         if prev_end is not None:
             sep = src[prev_end + 1 : start]
             adjacent = len(_split_top_level_alternatives(sep)) == 1 and _is_nullable_separator(sep)
-        run = run + 1 if (adjacent and unbounded and run) else int(unbounded)
+        if adjacent and unbounded and run:
+            # Continuing a run: only if this group's charset can overlap the
+            # PRECEDING group's in the run (issue #200). Either side failing
+            # to reduce to a concrete charset falls back to the prior
+            # conservative "assume overlap" behavior.
+            overlaps = not (reducible and prev_reducible) or _charsets_overlap(
+                prev_charset, charset
+            )
+            run = run + 1 if overlaps else 1
+        else:
+            run = int(unbounded)
         if run >= 2:
             return True
         prev_end = end
+        prev_reducible, prev_charset = reducible, charset
     return False
 
 
@@ -419,25 +451,36 @@ def _bracket_charset(body: str) -> frozenset[str] | None:
     return frozenset(chars)
 
 
-def _branch_charset(branch: str) -> tuple[bool, frozenset[str] | None]:
+def _branch_charset(
+    branch: str, *, allow_unbounded: bool = False
+) -> tuple[bool, frozenset[str] | None]:
     """Return ``(reducible, charset)`` for ``branch``.
 
-    ``reducible`` is ``False`` if ``branch`` contains a nested group or an
-    atom with a genuinely unbounded quantifier — i.e. it isn't a flat
-    sequence of simple atoms (literal chars, escapes, bracket classes,
-    each with at most a *bounded* quantifier: ``?``, ``{n}``, ``{n,m}``)
-    this function can characterize. :func:`_has_ambiguous_quantified_alternation`
-    skips the semantic overlap check for such branches and relies on its
-    plain textual prefix check instead — catching byte-identical/prefix
-    overlaps for that shape, but not semantic ones. Recursing into nested
-    groups to close that gap fully would mean re-implementing regex-language
-    equivalence, disproportionate for this lightweight heuristic (see the
-    module's "Known residual gaps").
+    ``reducible`` is ``False`` if ``branch`` contains a nested group — i.e.
+    it isn't a flat sequence of simple atoms (literal chars, escapes,
+    bracket classes) this function can characterize.
+    :func:`_has_ambiguous_quantified_alternation` skips the semantic overlap
+    check for such branches and relies on its plain textual prefix check
+    instead — catching byte-identical/prefix overlaps for that shape, but
+    not semantic ones. Recursing into nested groups to close that gap fully
+    would mean re-implementing regex-language equivalence, disproportionate
+    for this lightweight heuristic (see the module's "Known residual gaps").
 
     When ``reducible`` is ``True``, ``charset`` is the set of characters
     the branch can match anywhere in its length, or ``None`` (unknown/full
     — treated as overlapping with anything) when some atom couldn't be
     resolved to a concrete set (e.g. a negated class like ``\\D``).
+
+    By default (``allow_unbounded=False``) an atom with a genuinely
+    unbounded quantifier (``+``, ``*``, ``{n,}``) also makes the branch
+    unreducible — this is the mode :func:`_has_ambiguous_quantified_alternation`
+    uses, where an unbounded-repeated branch complicates length reasoning
+    this function doesn't attempt. Callers that only care about *which
+    characters* a group's body can ever match, regardless of how many times
+    (e.g. :func:`_has_adjacent_unbounded_groups` comparing two flanking
+    unbounded groups for charset overlap, issue #200), pass
+    ``allow_unbounded=True`` so the quantifier is consumed instead of
+    bailing.
     """
     charset: set[str] = set()
     unknown = False
@@ -463,27 +506,45 @@ def _branch_charset(branch: str) -> tuple[bool, frozenset[str] | None]:
         else:
             charset.update(atom_charset)
 
-        # A bare +/* (including lazy/possessive `+?`, `*+`) makes the atom
-        # unbounded, so the branch isn't the flat bounded shape this function
-        # characterizes — bail, matching the docstring. Without this, `+`/`*`
-        # fall through and get consumed as literal `+`/`*` characters, wrongly
-        # reporting the branch reducible; today that's masked only because the
+        # A bare +/* makes the atom unbounded. In the default mode this
+        # isn't the flat bounded shape the function characterizes — bail,
+        # matching the docstring. Without this, `+`/`*` fall through and get
+        # consumed as literal `+`/`*` characters, wrongly reporting the
+        # branch reducible; today that's masked only because the
         # nested-quantifier check runs first, which is fragile to rely on.
         if i < n and branch[i] in "+*":
-            return False, None
+            if not allow_unbounded:
+                return False, None
+            i += 1
+            # Consume a trailing lazy (`+?`) or possessive (`*+`) modifier so
+            # it isn't mistaken for a new literal atom on the next iteration.
+            if i < n and branch[i] in "?+":
+                i += 1
+            continue
 
-        # Skip a bounded quantifier on the atom just consumed — its exact
-        # repeat count doesn't matter for a character-overlap check, only
-        # that it IS bounded (an unbounded one still bails out below, since
-        # that shape is already handled by the other heuristic checks and
-        # complicates length reasoning this function doesn't attempt).
+        # Skip a quantifier on the atom just consumed — its exact repeat
+        # count doesn't matter for a character-overlap check, only whether
+        # it's bounded. In the default mode an unbounded brace (`{n,}`)
+        # still bails, since that shape is handled by the other heuristic
+        # checks and complicates length reasoning this function doesn't
+        # attempt; with `allow_unbounded=True` it's consumed like `+`/`*`.
         quant = re.match(r"\?|\{(\d*),?(\d*)\}", branch[i:])
         if quant:
-            if quant.group() != "?" and (
+            unbounded_brace = quant.group() != "?" and (
                 not quant.group(1) or ("," in quant.group() and not quant.group(2))
-            ):
+            )
+            if unbounded_brace and not allow_unbounded:
                 return False, None  # `{,m}` / `{n,}` — unbounded
             i += quant.end()
+            # A trailing lazy/possessive modifier after a BOUNDED quantifier
+            # (e.g. `a??`, `a{2,3}+`) isn't itself a new atom — consume it too.
+            # Before this fix, `_branch_charset('a??')` returned
+            # `(True, frozenset({'a', '?'}))`: the second `?` fell through to
+            # the plain-atom branch above and was added to the charset as a
+            # literal, a spurious character leaking into an otherwise-correct
+            # result (issue #196).
+            if i < n and branch[i] in "?+":
+                i += 1
 
     return True, (None if unknown else frozenset(charset))
 
@@ -501,6 +562,38 @@ def _charsets_overlap(a: frozenset[str] | None, b: frozenset[str] | None) -> boo
     it.
     """
     return a is None or b is None or bool(a & b)
+
+
+def _unwrap_redundant_group(body: str) -> str:
+    """Strip a group wrapper whose entire body is, itself, just one more
+    (optionally marked) group — repeating until no more wrappers remain,
+    e.g. ``(?:(?:a|aa))`` -> ``(?:a|aa)`` -> ``a|aa``.
+
+    ``_has_ambiguous_quantified_alternation`` only ever sees the *immediate*
+    body of the quantified group it's inspecting. A redundant wrapper around
+    an alternation — ``(?:(?:a|aa))+$`` or ``((a|aa))+$`` — puts the ``|``
+    one level deeper than that immediate body, so
+    ``_split_top_level_alternatives`` sees a single "branch" (the whole
+    wrapped group) and the ambiguity check never fires, even though the
+    unwrapped ``(a|aa)+$`` is correctly rejected (issue #196). Unwrapping
+    here before the caller checks for a top-level ``|`` closes that gap
+    without having to special-case it in the split/overlap logic itself.
+
+    Only unwraps when the body is *entirely* one nested group (no text
+    outside its span) — a body like ``x(?:a|b)`` is left alone, since the
+    group there isn't a redundant wrapper around the whole thing.
+    """
+    while body.startswith("(") and body.endswith(")"):
+        spans = _iter_group_spans(body)
+        top_level = [s for s in spans if not any(o[0] < s[0] and s[1] < o[1] for o in spans)]
+        if len(top_level) != 1 or top_level[0] != (0, len(body) - 1):
+            break
+        inner = body[1:-1]
+        marker = _GROUP_MARKER.match(inner)
+        if inner.startswith("?") and not marker:
+            break  # lookaround or other unrecognized `?` construct; opaque
+        body = inner[marker.end() :] if marker else inner
+    return body
 
 
 def _has_ambiguous_quantified_alternation(src: str) -> bool:
@@ -538,6 +631,11 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
     An empty branch (``(a|)+``) is also skipped — Python's ``re`` special-
     cases zero-width alternatives in a loop to avoid infinite looping, so it
     isn't the same exponential-backtracking shape as a genuine overlap.
+
+    A redundant group wrapper around the alternation (``(?:(?:a|aa))+$``,
+    ``((a|aa))+$``) is unwrapped via :func:`_unwrap_redundant_group` before
+    the top-level ``|`` split below, so it can't hide the alternation from
+    this check (issue #196).
     """
     for start, end in _iter_group_spans(src):
         if not re.match(_UNBOUNDED_QUANT, src[end + 1 :]):
@@ -548,6 +646,7 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
             continue
         if marker:
             body = body[marker.end() :]
+        body = _unwrap_redundant_group(body)
         if "|" not in body:
             continue
         branches = _split_top_level_alternatives(body)

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -310,12 +310,18 @@ def _has_adjacent_unbounded_groups(src: str, flags: int = 0) -> bool:
     ``(a+)(a+)$`` shape — even though ``a`` and ``b`` are themselves
     disjoint; comparing only against the immediately-preceding group missed
     this (a confirmed regression caught in review of the #200 fix).
-    ``([a-z]+)([0-9]*)([a-z]+)`` (a genuinely optional, disjoint middle
-    group) correctly stays allowed: unioning carries `[a-z]` and `[0-9]`
-    forward, and the trailing `[a-z]+` overlaps the *first* group's charset
-    through that union — so the true test is "do any two groups reachable
-    across a chain of nullable groups share a character", not merely
-    adjacent pairs.
+    ``([a-z]+)([0-9]*)([a-z]+)`` correctly stays REJECTED for the same
+    reason: unioning carries `[a-z]` and `[0-9]` forward, and the trailing
+    `[a-z]+` overlaps the *first* group's charset through that union — on
+    the path where the middle `[0-9]*` matches nothing, this genuinely
+    collapses to the ambiguous `([a-z]+)([a-z]+)$` shape, so rejecting it is
+    correct, not collateral damage. The true test is "do any two groups
+    reachable across a chain of nullable groups share a character", not
+    merely adjacent pairs. A hard boundary — either a *mandatory* separator
+    immediately before a group, or a group whose own content is mandatory —
+    severs the chain and resets what's carried (e.g. `(a+)-(b*)(a+)$` stays
+    ALLOWED: the mandatory `-` proves the first group can't bleed into the
+    `b*`/third-group pair that follows it).
 
     ``flags`` is the compiled pattern's ``re`` flags, threaded through to
     :func:`_branch_charset` so ``re.IGNORECASE`` case-folds the computed
@@ -365,18 +371,28 @@ def _has_adjacent_unbounded_groups(src: str, flags: int = 0) -> bool:
         if run >= 2:
             return True
         prev_end = end
-        if unbounded:
-            if _is_nullable_separator(body):
-                # This group's own body can match empty -- it might vanish,
-                # so carry BOTH possibilities (its own charset, and
-                # whatever was already reachable) forward.
-                carried = _charset_union(carried, resolved)
-            else:
-                # Mandatory content -- a hard boundary that supersedes
-                # whatever was carried before it.
-                carried = resolved
-        else:
+        if not unbounded:
             carried = None
+        elif not adjacent:
+            # A mandatory (non-nullable) separator sits immediately before
+            # this group -- or this is the first group in the pattern --
+            # either way it's a hard boundary: whatever was carried before
+            # it can't bleed through, so start fresh from this group's own
+            # charset alone. Without this check, a stale `carried` from
+            # before the boundary would still be unioned in below whenever
+            # THIS group happens to be nullable, wrongly treating e.g.
+            # `(a+)-(b*)(a+)$` as if the mandatory `-` weren't there (a
+            # confirmed over-rejection caught in re-review of this fix).
+            carried = resolved
+        elif _is_nullable_separator(body):
+            # This group's own body can match empty -- it might vanish, so
+            # carry BOTH possibilities (its own charset, and whatever was
+            # already reachable through the adjacent chain) forward.
+            carried = _charset_union(carried, resolved)
+        else:
+            # Mandatory content, reached via a nullable separator -- a hard
+            # boundary that supersedes whatever was carried before it.
+            carried = resolved
     return False
 
 
@@ -530,10 +546,27 @@ def _case_fold_charset(charset: frozenset[str] | None, flags: int) -> frozenset[
     the same characters once the flag is applied — a confirmed live bypass
     of the #200 charset-overlap gate caught in security review of that fix.
     ``None`` (unknown/full charset) passes through unchanged.
+
+    ``str.lower()``/``str.upper()`` aren't always 1:1: some codepoints case-map
+    to a *multi-character* string (Turkish ``İ``.lower() is the two-character
+    ``i̇`` — base ``i`` plus a combining dot above; German ``ß``.upper() is the
+    two-character ``SS``). ``.update(ch.lower())``/``.update(ch.upper())``
+    below relies on ``set.update`` iterating a string *by character*, so a
+    multi-character result is decomposed into its individual characters
+    rather than kept as one opaque multi-char element — otherwise the plain
+    ``i`` that ``İ`` case-folds to under real ``re.IGNORECASE`` matching would
+    never land in the charset, silently reopening the exact bypass class this
+    function exists to close (confirmed exploitable: security review of this
+    fix found ``(İ+)(i+)(İ+)...`` sailed past `assert_safe` and backtracks
+    catastrophically at runtime).
     """
     if charset is None or not (flags & re.IGNORECASE):
         return charset
-    return frozenset(c for ch in charset for c in (ch.lower(), ch.upper()))
+    folded: set[str] = set(charset)
+    for ch in charset:
+        folded.update(ch.lower())
+        folded.update(ch.upper())
+    return frozenset(folded)
 
 
 def _branch_charset(

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -65,13 +65,27 @@ Known residual gaps (not detected):
   gate than this heuristic — see above); without the ``re2``/``dev``
   extra, a backreference-shaped pattern has no heuristic coverage. Not
   introduced by this change; pre-existing and out of scope for #157.
-* A nullable *group* between two unbounded groups (``(a+)(?:x)?(a+)`` or
-  ``(a+)(x?)(a+)``) evades the adjacency check: ``_has_adjacent_unbounded_groups``
-  treats a nullable *separator* (``-?``) as adjacency-preserving, but the
-  optional element here is itself a top-level group, so it resets the
-  run counter rather than being read as a separator. Same nullable-adjacency
-  shape ``_is_nullable_separator`` was added to catch, just wrapped in
-  parens.
+* A nullable *group* between two unbounded groups whose own body has no
+  unbounded quantifier and is instead quantified from the *outside* with a
+  bounded quantifier (``(a+)(?:x)?(a+)`` or ``(a+)(x?)(a+)``) evades the
+  adjacency check: the group's own body contains no ``+``/``*``/``{n,}``, so
+  ``_has_adjacent_unbounded_groups`` never counts it as part of the run at
+  all — same nullable-adjacency shape ``_is_nullable_separator`` was added
+  to catch, just wrapped in parens instead of a bare separator. (A middle
+  group whose *own body* is both unbounded and nullable, e.g. ``(a+)(b*)(a+)``,
+  *is* handled — see ``_has_adjacent_unbounded_groups``'s "carried charset"
+  union, added for issue #200's review.)
+* A redundant group wrapper around an alternation that itself carries a
+  no-op or optional quantifier (``((a|aa){1})+$``, ``((a|aa)?)+$``) isn't
+  unwrapped by ``_unwrap_redundant_group`` — it only strips a wrapper whose
+  entire body is *exactly* one more nested group, with nothing else, so any
+  trailing quantifier on the wrapper (even a semantically inert ``{1}``)
+  stops the unwrap. Closing this fully means reasoning about which
+  quantifiers on a wrapper are no-ops for repetition-count purposes, a step
+  beyond the "redundant wrapper" case issue #196 reported and fixed; left
+  as a documented gap per this module's stated scope rather than chased
+  (confirmed in review of the #196 fix — not a regression, since the
+  pre-#196 heuristic missed these shapes too).
 
 These are all true ReDoS shapes — the same exponential class this module
 detects elsewhere, differing only in that *detecting* them requires
@@ -232,7 +246,28 @@ def _is_nullable_separator(fragment: str) -> bool:
         return True
 
 
-def _has_adjacent_unbounded_groups(src: str) -> bool:
+def _resolved_charset(reducible: bool, charset: frozenset[str] | None) -> frozenset[str] | None:
+    """Collapse a ``(reducible, charset)`` pair from :func:`_branch_charset`
+    into a single optional charset: ``None`` means "can't be resolved to a
+    concrete set" — either because the body wasn't reducible at all (a
+    nested group) or because it resolved to the unknown/full charset —
+    so :func:`_charsets_overlap`'s "assume overlap" bias applies uniformly
+    to both cases downstream.
+    """
+    return charset if reducible else None
+
+
+def _charset_union(a: frozenset[str] | None, b: frozenset[str] | None) -> frozenset[str] | None:
+    """Union two resolved charsets (see :func:`_resolved_charset`). ``None``
+    (unknown/full) absorbs — the union of "unknown" with anything is itself
+    unknown, matching this module's conservative bias.
+    """
+    if a is None or b is None:
+        return None
+    return a | b
+
+
+def _has_adjacent_unbounded_groups(src: str, flags: int = 0) -> bool:
     """True if 2+ top-level ``(...)`` groups, each containing an unbounded
     quantifier, appear back-to-back — separated by nothing, or only by text
     that can match the empty string — the ``(a+)(a+)(a+)`` /
@@ -254,17 +289,40 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
     Two adjacent unbounded groups only ambiguously partition a shared run of
     input if their matched-character sets can actually overlap — a run is
     only continued past a group when :func:`_charsets_overlap` says so
-    against the *previous* group in the run (via :func:`_branch_charset`
-    with ``allow_unbounded=True``, which reduces a group's body to a
-    charset regardless of its quantifier's bound). ``([a-z]+)-?([0-9]+)``
-    has an unambiguous split point (a letter run can never contain a digit
-    or vice versa) and is linear-time safe, unlike ``(a+)-?(a+)`` where both
-    groups match the same character — this gate, added for issue #200,
-    stops the former from being over-rejected as a regression of the
-    nullable-separator broadening (issue #157) without weakening the
-    latter. A group whose body can't be reduced to a concrete charset
-    (nested groups, an unresolvable escape class) keeps the prior
+    against the charset "carried" from the run so far (via
+    :func:`_branch_charset` with ``allow_unbounded=True``, which reduces a
+    group's body to a charset regardless of its quantifier's bound).
+    ``([a-z]+)-?([0-9]+)`` has an unambiguous split point (a letter run can
+    never contain a digit or vice versa) and is linear-time safe, unlike
+    ``(a+)-?(a+)`` where both groups match the same character — this gate,
+    added for issue #200, stops the former from being over-rejected as a
+    regression of the nullable-separator broadening (issue #157) without
+    weakening the latter. A group whose body can't be reduced to a concrete
+    charset (nested groups, an unresolvable escape class) keeps the prior
     conservative "assume overlap" behavior.
+
+    The "carried" charset is a *union*, not just the immediately-preceding
+    group's charset: a group whose own body can match the empty string
+    (e.g. ``b*``) might contribute zero characters at match time, in which
+    case whatever preceded it is still effectively adjacent to whatever
+    follows. ``(a+)(b*)(a+)$`` must stay rejected — on the backtracking path
+    where ``b*`` matches nothing, it collapses to the canonical
+    ``(a+)(a+)$`` shape — even though ``a`` and ``b`` are themselves
+    disjoint; comparing only against the immediately-preceding group missed
+    this (a confirmed regression caught in review of the #200 fix).
+    ``([a-z]+)([0-9]*)([a-z]+)`` (a genuinely optional, disjoint middle
+    group) correctly stays allowed: unioning carries `[a-z]` and `[0-9]`
+    forward, and the trailing `[a-z]+` overlaps the *first* group's charset
+    through that union — so the true test is "do any two groups reachable
+    across a chain of nullable groups share a character", not merely
+    adjacent pairs.
+
+    ``flags`` is the compiled pattern's ``re`` flags, threaded through to
+    :func:`_branch_charset` so ``re.IGNORECASE`` case-folds the computed
+    charsets before comparison (see :func:`_case_fold_charset`) — otherwise
+    the charset-overlap gate itself would be a bypass for a
+    case-insensitive pattern whose alternating-case adjacent groups are
+    disjoint only by literal source text, not at match time.
     """
     spans = _iter_group_spans(src)
     # Only top-level groups matter for this shape — a group nested inside
@@ -275,13 +333,18 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
 
     run = 0
     prev_end: int | None = None
-    prev_reducible = False
-    prev_charset: frozenset[str] | None = None
+    # The charset "reachable" immediately before the next group's start
+    # position, given everything nullable earlier in the run might vanish
+    # (see the docstring above). `None` means unknown/unresolved -- treated
+    # as overlapping with anything, per this module's conservative bias.
+    carried: frozenset[str] | None = None
     for start, end in top_level:
         body = src[start + 1 : end]
         unbounded = bool(re.search(_UNBOUNDED_QUANT, body))
-        reducible, charset = (
-            _branch_charset(body, allow_unbounded=True) if unbounded else (False, None)
+        resolved = (
+            _resolved_charset(*_branch_charset(body, allow_unbounded=True, flags=flags))
+            if unbounded
+            else None
         )
         # Two groups are "adjacent" only if the text between them can vanish
         # (a nullable separator — see _is_nullable_separator). A top-level `|`
@@ -295,19 +358,25 @@ def _has_adjacent_unbounded_groups(src: str) -> bool:
             adjacent = len(_split_top_level_alternatives(sep)) == 1 and _is_nullable_separator(sep)
         if adjacent and unbounded and run:
             # Continuing a run: only if this group's charset can overlap the
-            # PRECEDING group's in the run (issue #200). Either side failing
-            # to reduce to a concrete charset falls back to the prior
-            # conservative "assume overlap" behavior.
-            overlaps = not (reducible and prev_reducible) or _charsets_overlap(
-                prev_charset, charset
-            )
-            run = run + 1 if overlaps else 1
+            # charset carried from the run so far (issue #200).
+            run = run + 1 if _charsets_overlap(carried, resolved) else 1
         else:
             run = int(unbounded)
         if run >= 2:
             return True
         prev_end = end
-        prev_reducible, prev_charset = reducible, charset
+        if unbounded:
+            if _is_nullable_separator(body):
+                # This group's own body can match empty -- it might vanish,
+                # so carry BOTH possibilities (its own charset, and
+                # whatever was already reachable) forward.
+                carried = _charset_union(carried, resolved)
+            else:
+                # Mandatory content -- a hard boundary that supersedes
+                # whatever was carried before it.
+                carried = resolved
+        else:
+            carried = None
     return False
 
 
@@ -451,8 +520,24 @@ def _bracket_charset(body: str) -> frozenset[str] | None:
     return frozenset(chars)
 
 
+def _case_fold_charset(charset: frozenset[str] | None, flags: int) -> frozenset[str] | None:
+    """Expand ``charset`` to include both cases of every letter when
+    ``flags`` has ``re.IGNORECASE`` set, so a later charset-overlap
+    comparison (:func:`_charsets_overlap`) reflects what the compiled
+    pattern actually matches at runtime rather than just its literal source
+    text. Without this, ``([a-z]+)([A-Z]+)`` compiled with ``re.IGNORECASE``
+    looks disjoint by source alone (`a-z` vs. `A-Z`) while matching exactly
+    the same characters once the flag is applied — a confirmed live bypass
+    of the #200 charset-overlap gate caught in security review of that fix.
+    ``None`` (unknown/full charset) passes through unchanged.
+    """
+    if charset is None or not (flags & re.IGNORECASE):
+        return charset
+    return frozenset(c for ch in charset for c in (ch.lower(), ch.upper()))
+
+
 def _branch_charset(
-    branch: str, *, allow_unbounded: bool = False
+    branch: str, *, allow_unbounded: bool = False, flags: int = 0
 ) -> tuple[bool, frozenset[str] | None]:
     """Return ``(reducible, charset)`` for ``branch``.
 
@@ -481,6 +566,15 @@ def _branch_charset(
     unbounded groups for charset overlap, issue #200), pass
     ``allow_unbounded=True`` so the quantifier is consumed instead of
     bailing.
+
+    ``flags`` is the compiled pattern's ``re`` flags (``pattern.flags`` in
+    :func:`assert_safe`). When ``re.IGNORECASE`` is set, the returned
+    charset is case-folded (both cases of every letter included) before
+    two charsets are compared for overlap — otherwise a pattern like
+    ``([a-z]+)([A-Z]+)`` compiled with ``re.IGNORECASE`` would look
+    disjoint by raw source text alone while actually matching the same
+    characters at runtime, silently defeating the charset-overlap gate a
+    security review of this fix confirmed is a live bypass otherwise.
     """
     charset: set[str] = set()
     unknown = False
@@ -546,7 +640,7 @@ def _branch_charset(
             if i < n and branch[i] in "?+":
                 i += 1
 
-    return True, (None if unknown else frozenset(charset))
+    return True, _case_fold_charset(None if unknown else frozenset(charset), flags)
 
 
 def _charsets_overlap(a: frozenset[str] | None, b: frozenset[str] | None) -> bool:
@@ -596,7 +690,7 @@ def _unwrap_redundant_group(body: str) -> str:
     return body
 
 
-def _has_ambiguous_quantified_alternation(src: str) -> bool:
+def _has_ambiguous_quantified_alternation(src: str, flags: int = 0) -> bool:
     """True if some ``(...)`` group is a 2+-branch alternation where two
     branches can match overlapping text, and the group itself is
     immediately followed by an unbounded quantifier — the ``(a|aa)+`` shape.
@@ -636,6 +730,13 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
     ``((a|aa))+$``) is unwrapped via :func:`_unwrap_redundant_group` before
     the top-level ``|`` split below, so it can't hide the alternation from
     this check (issue #196).
+
+    ``flags`` is the compiled pattern's ``re`` flags, threaded to
+    :func:`_branch_charset` so the semantic overlap check is
+    ``re.IGNORECASE``-aware (see :func:`_case_fold_charset`) — otherwise
+    ``(?:[a-z]|[A-Z])+`` compiled case-insensitively would look like two
+    disjoint branches by source text alone while matching the same
+    characters at runtime.
     """
     for start, end in _iter_group_spans(src):
         if not re.match(_UNBOUNDED_QUANT, src[end + 1 :]):
@@ -660,14 +761,14 @@ def _has_ambiguous_quantified_alternation(src: str) -> bool:
                     or branch_b.startswith(branch_a)
                 ):
                     return True
-                reducible_a, charset_a = _branch_charset(branch_a)
-                reducible_b, charset_b = _branch_charset(branch_b)
+                reducible_a, charset_a = _branch_charset(branch_a, flags=flags)
+                reducible_b, charset_b = _branch_charset(branch_b, flags=flags)
                 if reducible_a and reducible_b and _charsets_overlap(charset_a, charset_b):
                     return True
     return False
 
 
-def _unsafe_reason(src: str) -> str | None:
+def _unsafe_reason(src: str, flags: int = 0) -> str | None:
     """Return a short, shape-specific description of the first
     catastrophic-backtracking construct found in ``src``, or ``None`` if the
     heuristic considers it safe.
@@ -676,6 +777,11 @@ def _unsafe_reason(src: str) -> str | None:
     message in :func:`assert_safe`, so the message can name *which* shape fired
     and give remediation that actually clears the check — rather than a generic
     list of every possible reason plus fixes that may not apply (issue #157).
+
+    ``flags`` are the compiled pattern's ``re`` flags (``0`` when called
+    directly with a bare source string, e.g. from tests) — threaded through
+    to the charset-overlap checks so ``re.IGNORECASE`` is accounted for
+    (see :func:`_case_fold_charset`).
     """
     if _NESTED_QUANTIFIER.search(src) or _has_nested_unbounded_quantifier(src):
         return (
@@ -683,7 +789,7 @@ def _unsafe_reason(src: str) -> str | None:
             "quantifier repeated by another) — rewrite so no unbounded "
             "quantifier is itself repeated, e.g. `(a+)+` -> `a+`"
         )
-    if _has_ambiguous_quantified_alternation(src):
+    if _has_ambiguous_quantified_alternation(src, flags):
         return (
             "a quantified alternation whose branches can match overlapping "
             "text, such as `(a|aa)+` — remove the overlap so each run of input "
@@ -695,7 +801,7 @@ def _unsafe_reason(src: str) -> str | None:
             "the same atom quantified back-to-back, such as `a+a+a+` — collapse "
             "the repeats into a single quantifier, e.g. `a+a+` -> `a+`"
         )
-    if _has_adjacent_unbounded_groups(src):
+    if _has_adjacent_unbounded_groups(src, flags):
         return (
             "two or more adjacent unbounded-quantified groups, optionally "
             "separated by a nullable delimiter, such as `(a+)(a+)` or "
@@ -705,7 +811,7 @@ def _unsafe_reason(src: str) -> str | None:
     return None
 
 
-def _heuristic_unsafe(src: str) -> bool:
+def _heuristic_unsafe(src: str, flags: int = 0) -> bool:
     """Static ReDoS heuristic that always runs, whether or not ``re2`` is
     installed.
 
@@ -717,7 +823,7 @@ def _heuristic_unsafe(src: str) -> bool:
     importable in the current environment. Thin boolean wrapper over
     :func:`_unsafe_reason`.
     """
-    return _unsafe_reason(src) is not None
+    return _unsafe_reason(src, flags) is not None
 
 
 def assert_safe(pattern: re.Pattern[str]) -> None:
@@ -743,7 +849,7 @@ def assert_safe(pattern: re.Pattern[str]) -> None:
                 f"(linear-time guarantee unavailable): {exc}"
             ) from exc
 
-    reason = _unsafe_reason(src)
+    reason = _unsafe_reason(src, pattern.flags)
     if reason is not None:
         raise ValueError(
             f"Pattern {src!r} is rejected to prevent catastrophic backtracking "

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -86,6 +86,29 @@ class TestAssertSafe:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(f"{'(a+)-?' * 3}(a+)$"))
 
+    @pytest.mark.parametrize(
+        "src",
+        [
+            r"(?:(?:a|aa))+$",  # #196: non-capturing redundant wrapper
+            r"((a|aa))+$",  # #196: capturing redundant wrapper
+        ],
+    )
+    def test_redundant_group_wrapper_around_alternation_rejected(self, src: str) -> None:
+        # #196: a group wrapped redundantly around an already-ambiguous
+        # alternation must not defeat the check the un-wrapped `(a|aa)+$`
+        # already fails.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(src))
+
+    def test_disjoint_charset_nullable_separator_groups_allowed(self) -> None:
+        # #200: flanking groups with disjoint charsets have an unambiguous
+        # split point and are linear-time safe -- must not be over-rejected
+        # as a regression of the #157 nullable-separator broadening.
+        assert_safe(re.compile(r"([a-z]+)-?([0-9]+)"))
+
+    def test_disjoint_charset_mandatory_separator_groups_allowed(self) -> None:
+        assert_safe(re.compile(r"([a-z]+)-([0-9]+)"))
+
     def test_realistic_evil_pattern_rejected(self) -> None:
         # The classic "(x+x+)+y" shape. Heuristic flags the nested quantifier;
         # that's enough to fail closed. Assembled at runtime (this fixture is only
@@ -129,6 +152,8 @@ class TestRedosGuardAlwaysRunsHeuristic:
             r"(v\d+)+.*",
             r"(a|aa)+$",  # #157: overlapping (non-identical) alternation
             r"(a+)-?(a+)-?(a+)-?(a+)$",  # #157: nullable-delimiter adjacent groups
+            r"(?:(?:a|aa))+$",  # #196: non-capturing redundant wrapper
+            r"((a|aa))+$",  # #196: capturing redundant wrapper
         ],
         ids=[
             "nested-plus-anchored",
@@ -136,6 +161,8 @@ class TestRedosGuardAlwaysRunsHeuristic:
             "version-prefix-catastrophic",
             "overlapping-alternation",
             "delimiter-separated-adjacent-groups",
+            "redundant-noncapturing-wrapper",
+            "redundant-capturing-wrapper",
         ],
     )
     @pytest.mark.parametrize("has_re2_value", [True, False], ids=["re2-present", "re2-absent"])
@@ -153,6 +180,33 @@ class TestRedosGuardAlwaysRunsHeuristic:
             monkeypatch.setattr(pattern_safety, "_re2", _FakeRe2)
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(src))
+
+
+class TestSafePatternsAllowedRegardlessOfHasRe2:
+    """Regression test for #200: a disjoint-charset, linear-time-safe
+    pattern must be ALLOWED whether or not ``google-re2`` is installed,
+    proving the #200 charset-overlap gate and the #196 stricter alternation
+    check coexist without either shape regressing the other."""
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            r"([a-z]+)-?([0-9]+)",  # #200: disjoint charsets, nullable separator
+            r"([a-z]+)-([0-9]+)",  # #200: disjoint charsets, mandatory separator
+        ],
+        ids=["disjoint-nullable-separator", "disjoint-mandatory-separator"],
+    )
+    @pytest.mark.parametrize("has_re2_value", [True, False], ids=["re2-present", "re2-absent"])
+    def test_allowed_regardless_of_has_re2(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        src: str,
+        has_re2_value: bool,
+    ) -> None:
+        monkeypatch.setattr(pattern_safety, "_HAS_RE2", has_re2_value)
+        if has_re2_value:
+            monkeypatch.setattr(pattern_safety, "_re2", _FakeRe2)
+        assert_safe(re.compile(src))  # must not raise
 
 
 class TestHeuristicUnsafe:
@@ -195,6 +249,9 @@ class TestHeuristicUnsafe:
             # matches `]` or a-y) was mis-parsed as an empty class, silently
             # dropping the whole a-y range (including `q`) from the computed
             # charset — a confirmed false-negative bypass caught in re-review
+            r"(?:(?:a|aa))+$",  # #196: redundant non-capturing wrapper around
+            # an already-ambiguous alternation must not hide it
+            r"((a|aa))+$",  # #196: redundant capturing wrapper, same shape
         ],
         ids=[
             "nested-plus",
@@ -218,6 +275,8 @@ class TestHeuristicUnsafe:
             "overlapping-alternation-hex-escape",
             "overlapping-alternation-class-range-different-lengths",
             "overlapping-alternation-leading-bracket-literal",
+            "redundant-noncapturing-wrapper",
+            "redundant-capturing-wrapper",
         ],
     )
     def test_flags_known_bad_shapes(self, src: str) -> None:
@@ -266,6 +325,12 @@ class TestHeuristicUnsafe:
             # isn't caught. Asserted here so a future attempt to close this
             # gap updates this test rather than silently changing behavior.
             r"(a(?:b)?|aa)+$",
+            # #200: flanking unbounded groups with disjoint charsets have an
+            # unambiguous split point and are linear-time safe -- must not
+            # be over-rejected as a regression of the #157 nullable-
+            # separator broadening.
+            r"([a-z]+)-?([0-9]+)",
+            r"([a-z]+)-([0-9]+)",
         ],
     )
     def test_passes_known_good_shapes(self, src: str) -> None:
@@ -374,6 +439,38 @@ class TestParserHelpers:
         self, branch: str, reducible: bool, charset: frozenset[str] | None
     ) -> None:
         assert _branch_charset(branch) == (reducible, charset)
+
+    @pytest.mark.parametrize(
+        ("branch", "expected"),
+        [
+            ("a??", frozenset("a")),  # lazy `?` after bounded `?` isn't a stray atom
+            ("a{2,3}+", frozenset("a")),  # possessive modifier after `{n,m}`
+        ],
+    )
+    def test_branch_charset_consumes_lazy_possessive_modifier(
+        self, branch: str, expected: frozenset[str]
+    ) -> None:
+        # #196: a trailing lazy (`?`) or possessive (`+`) modifier right
+        # after a bounded quantifier must be consumed, not treated as a new
+        # literal atom -- before this fix, `_branch_charset('a??')` returned
+        # `(True, frozenset({'a', '?'}))`, leaking a spurious `?`.
+        assert _branch_charset(branch) == (True, expected)
+
+    @pytest.mark.parametrize(
+        ("branch", "expected"),
+        [
+            ("a+", frozenset("a")),
+            ("[a-z]+", frozenset("abcdefghijklmnopqrstuvwxyz")),
+            ("a{2,}", frozenset("a")),
+        ],
+    )
+    def test_branch_charset_allow_unbounded(self, branch: str, expected: frozenset[str]) -> None:
+        # #200: _has_adjacent_unbounded_groups needs the charset of an
+        # unbounded group's body (to compare flanking groups for overlap),
+        # not a reducibility verdict about being safely alternation-checkable
+        # -- allow_unbounded=True consumes the unbounded quantifier instead
+        # of bailing.
+        assert _branch_charset(branch, allow_unbounded=True) == (True, expected)
 
     @pytest.mark.parametrize("frag", ["", "-?", r"\s*", "(?:foo)?", "x*"])
     def test_nullable_separator_true(self, frag: str) -> None:

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -90,8 +90,11 @@ class TestAssertSafe:
     @pytest.mark.parametrize(
         "src",
         [
-            r"(?:(?:a|aa))+$",  # #196: non-capturing redundant wrapper
-            r"((a|aa))+$",  # #196: capturing redundant wrapper
+            # Assembled at runtime (only analyzed by assert_safe, never matched)
+            # so the catastrophic literal isn't itself flagged by CodeQL's ReDoS
+            # scan -- same convention as the fixtures above.
+            f"(?:(?:a|{'a' * 2}))+$",  # #196: non-capturing redundant wrapper
+            f"((a|{'a' * 2}))+$",  # #196: capturing redundant wrapper
         ],
     )
     def test_redundant_group_wrapper_around_alternation_rejected(self, src: str) -> None:
@@ -104,8 +107,10 @@ class TestAssertSafe:
     def test_triple_nested_redundant_wrapper_rejected(self) -> None:
         # #196: _unwrap_redundant_group's docstring claims it repeats "until
         # no more wrappers remain" -- pin that beyond the single-level case.
+        # Assembled at runtime so the fixture isn't flagged as a static ReDoS
+        # literal by code scanning (see test_realistic_evil_pattern).
         with pytest.raises(ValueError, match="catastrophic backtracking"):
-            assert_safe(re.compile(r"(?:(?:(?:a|aa)))+$"))
+            assert_safe(re.compile(f"(?:(?:(?:a|{'a' * 2})))+$"))
 
     def test_disjoint_charset_nullable_separator_groups_allowed(self) -> None:
         # #200: flanking groups with disjoint charsets have an unambiguous

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -9,6 +9,7 @@ from genblaze_core.providers import pattern_safety
 from genblaze_core.providers.pattern_safety import (
     _bracket_charset,
     _branch_charset,
+    _case_fold_charset,
     _escape_charset,
     _heuristic_unsafe,
     _is_nullable_separator,
@@ -231,6 +232,25 @@ class TestAdjacentGroupsNullableMiddleGroup:
     def test_nullable_middle_group_all_disjoint_allowed(self) -> None:
         assert_safe(re.compile(r"(a+)(b*)(c+)$"))
 
+    def test_two_nullable_groups_transitive_overlap_rejected(self) -> None:
+        # Two nullable unbounded groups in a row before the charset repeats:
+        # the union must keep accumulating across BOTH, not just the last one.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(a+)(b*)(c*)(a+)$"))
+
+    def test_mandatory_separator_before_nullable_group_severs_carry_allowed(self) -> None:
+        # #200 re-review: a MANDATORY (non-nullable) separator right before a
+        # later nullable group is a hard boundary -- it must reset what's
+        # carried forward, not let an earlier group's charset silently union
+        # through it. Before this fix, the stale carried charset from group 1
+        # wrongly made this look ambiguous with group 3.
+        assert_safe(re.compile(r"(a+)-(b*)(a+)$"))
+
+    def test_mandatory_content_before_nullable_group_severs_carry_allowed(self) -> None:
+        # Same "hard boundary" rule, but the boundary is the PRECEDING
+        # group's own mandatory content rather than a literal separator.
+        assert_safe(re.compile(r"(a+)(c+)(b*)(a+)$"))
+
 
 class TestIgnoreCaseAwareCharsetOverlap:
     """Regression tests for a security-review finding on the #200 fix: the
@@ -256,6 +276,17 @@ class TestIgnoreCaseAwareCharsetOverlap:
 
     def test_alternation_disjoint_case_without_ignorecase_allowed(self) -> None:
         assert_safe(re.compile(r"(?:[a-z]|[A-Z])+"))
+
+    def test_non_ascii_case_fold_with_multi_char_mapping_rejected(self) -> None:
+        # Turkish dotted capital I (U+0130) lower-cases to a TWO-character
+        # string ("i" + a combining dot above), unlike the ASCII a/A pairs
+        # above. A naive fold that adds `ch.lower()` as one opaque element
+        # (instead of decomposing it into its individual characters) never
+        # produces the plain "i" needed to detect overlap with a literal
+        # "i" elsewhere -- silently reopening this exact bypass class for
+        # non-ASCII letters even after the ASCII case is fixed.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile("(İ+)(i+)(İ+)(i+)(İ+)(i+)$", re.IGNORECASE))
 
 
 class TestHeuristicUnsafe:
@@ -557,6 +588,25 @@ class TestParserHelpers:
         # `[a-z]` and `[A-Z]` disjoint by source text alone despite matching
         # the same characters at runtime.
         assert _branch_charset(branch, flags=flags) == (True, expected)
+
+    def test_case_fold_charset_decomposes_multi_char_case_mapping(self) -> None:
+        # Security re-review finding: Turkish "İ" (U+0130) lower-cases to the
+        # TWO-character string "i̇" (base "i" + combining dot above), unlike
+        # ASCII a/A. `_case_fold_charset` must decompose that into its
+        # individual characters (via `set.update` iterating the string) so
+        # the plain "i" lands in the folded set -- an earlier version added
+        # the whole multi-char string as one opaque element instead, which
+        # never overlapped a literal "i" elsewhere, reopening the exact
+        # bypass class this function exists to close.
+        folded = _case_fold_charset(frozenset("İ"), re.IGNORECASE)
+        assert folded is not None
+        assert "i" in folded
+
+    def test_case_fold_charset_noop_without_ignorecase(self) -> None:
+        assert _case_fold_charset(frozenset("aA"), 0) == frozenset("aA")
+
+    def test_case_fold_charset_passes_through_unknown(self) -> None:
+        assert _case_fold_charset(None, re.IGNORECASE) is None
 
     @pytest.mark.parametrize("frag", ["", "-?", r"\s*", "(?:foo)?", "x*"])
     def test_nullable_separator_true(self, frag: str) -> None:

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -100,6 +100,12 @@ class TestAssertSafe:
         with pytest.raises(ValueError, match="catastrophic backtracking"):
             assert_safe(re.compile(src))
 
+    def test_triple_nested_redundant_wrapper_rejected(self) -> None:
+        # #196: _unwrap_redundant_group's docstring claims it repeats "until
+        # no more wrappers remain" -- pin that beyond the single-level case.
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(?:(?:(?:a|aa)))+$"))
+
     def test_disjoint_charset_nullable_separator_groups_allowed(self) -> None:
         # #200: flanking groups with disjoint charsets have an unambiguous
         # split point and are linear-time safe -- must not be over-rejected
@@ -207,6 +213,49 @@ class TestSafePatternsAllowedRegardlessOfHasRe2:
         if has_re2_value:
             monkeypatch.setattr(pattern_safety, "_re2", _FakeRe2)
         assert_safe(re.compile(src))  # must not raise
+
+
+class TestAdjacentGroupsNullableMiddleGroup:
+    """Regression tests for a #200-review finding: comparing only the
+    immediately-preceding group's charset missed the case where a NULLABLE
+    unbounded group sits between two others. `(a+)(b*)(a+)$` must stay
+    rejected -- on the path where `b*` matches zero characters, it collapses
+    to the canonical `(a+)(a+)$` ambiguous-partition shape, even though `a`
+    and `b` are themselves disjoint charsets. `(a+)(b*)(c+)$`, where the
+    outer groups are ALSO disjoint from each other, must stay allowed."""
+
+    def test_nullable_middle_group_reopens_ambiguity_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(a+)(b*)(a+)$"))
+
+    def test_nullable_middle_group_all_disjoint_allowed(self) -> None:
+        assert_safe(re.compile(r"(a+)(b*)(c+)$"))
+
+
+class TestIgnoreCaseAwareCharsetOverlap:
+    """Regression tests for a security-review finding on the #200 fix: the
+    charset-overlap gates (adjacent groups AND quantified alternation) must
+    fold case when the compiled pattern has ``re.IGNORECASE`` set, or a
+    pattern whose groups are disjoint only in literal source text (e.g.
+    `[a-z]` vs. `[A-Z]`) slips past as a false "safe" verdict despite
+    matching identical characters at runtime."""
+
+    def test_adjacent_groups_ignorecase_folds_to_overlap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(
+                re.compile(r"([a-z]+)([A-Z]+)([a-z]+)([A-Z]+)([a-z]+)([A-Z]+)$", re.IGNORECASE)
+            )
+
+    def test_adjacent_groups_disjoint_case_without_ignorecase_allowed(self) -> None:
+        # Same shape, no flag -- genuinely disjoint at match time, must stay safe.
+        assert_safe(re.compile(r"([a-z]+)([A-Z]+)([a-z]+)([A-Z]+)([a-z]+)([A-Z]+)$"))
+
+    def test_alternation_ignorecase_folds_to_overlap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(?:[a-z]|[A-Z])+", re.IGNORECASE))
+
+    def test_alternation_disjoint_case_without_ignorecase_allowed(self) -> None:
+        assert_safe(re.compile(r"(?:[a-z]|[A-Z])+"))
 
 
 class TestHeuristicUnsafe:
@@ -331,6 +380,16 @@ class TestHeuristicUnsafe:
             # separator broadening.
             r"([a-z]+)-?([0-9]+)",
             r"([a-z]+)-([0-9]+)",
+            # #196 review: documented residual gap, not a regression (the
+            # pre-#196 heuristic missed these too) -- a redundant wrapper
+            # that itself carries a no-op/optional quantifier isn't
+            # unwrapped by _unwrap_redundant_group, which only strips a
+            # wrapper whose entire body is exactly one more nested group
+            # with nothing else. Asserted here so a future attempt to widen
+            # the unwrap updates this test rather than silently changing
+            # behavior (see the module's "Known residual gaps").
+            r"((a|aa){1})+$",
+            r"((a|aa)?)+$",
         ],
     )
     def test_passes_known_good_shapes(self, src: str) -> None:
@@ -471,6 +530,33 @@ class TestParserHelpers:
         # -- allow_unbounded=True consumes the unbounded quantifier instead
         # of bailing.
         assert _branch_charset(branch, allow_unbounded=True) == (True, expected)
+
+    def test_branch_charset_allow_unbounded_still_bails_on_nested_group(self) -> None:
+        # allow_unbounded only changes how a bare unbounded QUANTIFIER is
+        # handled -- a nested group in the body is unconditionally
+        # unreducible either way (the `ch in "(|)"` bailout runs first).
+        assert _branch_charset("(?:x)+", allow_unbounded=True) == (False, None)
+
+    @pytest.mark.parametrize(
+        ("branch", "flags", "expected"),
+        [
+            ("a", 0, frozenset("a")),
+            ("a", re.IGNORECASE, frozenset("aA")),
+            (
+                "[a-z]",
+                re.IGNORECASE,
+                frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+            ),
+        ],
+    )
+    def test_branch_charset_ignorecase_folds(
+        self, branch: str, flags: int, expected: frozenset[str]
+    ) -> None:
+        # Security-review finding on the #200 fix: without case-folding, a
+        # charset-overlap comparison under `re.IGNORECASE` would judge
+        # `[a-z]` and `[A-Z]` disjoint by source text alone despite matching
+        # the same characters at runtime.
+        assert _branch_charset(branch, flags=flags) == (True, expected)
 
     @pytest.mark.parametrize("frag", ["", "-?", r"\s*", "(?:foo)?", "x*"])
     def test_nullable_separator_true(self, frag: str) -> None:


### PR DESCRIPTION
Closes #196, closes #200.

Two opposed corrections to the `pattern_safety.py` ReDoS heuristic, landed together with combined tests since they pull the same `_branch_charset`/`_charsets_overlap` helpers in opposite directions.

**#196 (false-negative / bypass):** a redundant group-wrapper hid an ambiguous alternation from `_has_ambiguous_quantified_alternation` — `(?:(?:a|aa))+` and `((a|aa))+` passed `assert_safe` (even with re2) yet backtrack exponentially under stdlib `re` (runtime uses stdlib re). Now rejected. Also fixes the `_branch_charset` lazy-`?` leak (`a??` no longer yields `?` in the charset).

**#200 (false-positive / regression):** `_has_adjacent_unbounded_groups` rejected disjoint-charset, linear-time-safe patterns like `([a-z]+)-?([0-9]+)` (allowed at v0.5.0). Now gated on `_charsets_overlap` of the flanking groups.

**Acceptance (verified):** `assert_safe` REJECTS `(?:(?:a|aa))+$`, `((a|aa))+$`, `(a|aa)+$`, `(a+)-?(a+)`; ALLOWS `([a-z]+)-?([0-9]+)`, `([a-z]+)-([0-9]+)`. `test_pattern_safety.py`: 139 passed.

Larger diff (security-heuristic code) — worth a careful human read. Note: `lint` is red repo-wide from unpinned-ruff drift (#211), fixed by #212 — unrelated to this diff.