### PR TITLE
chore(ci): stop Dependabot proposing major-version bumps on runtime deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,11 @@ updates:
       # wave (see RELEASING.md), not Dependabot — keeps it from opening PRs
       # that fight the umbrella version flow.
       - dependency-name: "genblaze-*"
+      # Bounded-major policy (#61): every runtime dep is capped one major past
+      # what the connector is verified against, so adopting a new major is a
+      # deliberate, manually-verified step — never an automated cap-raise
+      # (see #192, closed for exactly this reason). Dependabot still proposes
+      # minor/patch bumps within the verified major; major bumps are opened by
+      # a human once the connector is tested against the new major.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Follow-up to #192 (closed).

#192 raised runtime-dep caps to unverified next-majors (google-genai <2->3, runwayml <5->6, aiobotocore <3->4, pillow <12->13, pyarrow <23->26), contrary to the bounded-major policy (#61): every runtime dep is capped one major past what the connector is verified against so a future major can't silently break resolution.

This adds a single `ignore` rule so Dependabot no longer opens major-version bumps for pip deps — it still proposes minor/patch updates within the verified major. Adopting a new major stays a deliberate, human-verified step (test the connector against it, then raise the cap by hand). Auto-covers current and future runtime deps under one rule.

Refs #61, #192