### PR TITLE
fix(google): translate ImageURLContent to Gemini inline_data/file_data

### DIFF
--- a/libs/connectors/google/genblaze_google/chat.py
+++ b/libs/connectors/google/genblaze_google/chat.py
@@ -6,10 +6,18 @@ same signature, same ``ChatResponse`` shape. Auth: ``GEMINI_API_KEY`` or
 from __future__ import annotations
 
 import asyncio
+import mimetypes
 from typing import Any
 
 from genblaze_core.exceptions import ProviderError
-from genblaze_core.models.chat import ChatMessage, ChatResponse, TextContent, ToolCall
+from genblaze_core.models.chat import (
+    ChatMessage,
+    ChatResponse,
+    ImageURLContent,
+    ImageURLRef,
+    TextContent,
+    ToolCall,
+)
 from genblaze_core.models.enums import ProviderErrorCode
 from genblaze_core.providers.retry import retry_after_from_response
 
@@ -40,26 +48,86 @@ def _normalize_to_gemini(
 
     for m in iter_msgs:
         msg = m if isinstance(m, ChatMessage) else ChatMessage(**m)
-        text = _gemini_text_only(msg.content)
         # Gemini takes a separate system_instruction; pull the first system msg out.
+        # system_instruction is plain text only, so reject media blocks there too.
         if msg.role == "system":
             if system_instruction is None:
-                system_instruction = text
+                system_instruction = _gemini_text_only(msg.content)
             continue
         role = _ROLE_MAP.get(msg.role, "user")
-        contents.append({"role": role, "parts": [{"text": text}]})
+        contents.append({"role": role, "parts": _content_to_gemini_parts(msg.content)})
 
     return contents, system_instruction
+
+
+def _content_to_gemini_parts(content: Any) -> list[dict]:
+    """Translate ChatMessage.content into Gemini `parts` (text + inline/file image data).
+
+    Mirrors the block-to-wire translation `genblaze_openai.chat._normalize_messages`
+    already does for the OpenAI-vision shape, so a `ChatMessage` built from the
+    canonical content blocks is portable across providers instead of being
+    pre-flight-rejected here (#194). Block types Gemini has no `parts` mapping
+    for (video, audio) still raise a precise `INVALID_INPUT` rather than
+    failing mid-request.
+    """
+    if isinstance(content, str):
+        return [{"text": content}]
+    parts: list[dict] = []
+    for block in content:
+        if isinstance(block, TextContent):
+            parts.append({"text": block.text})
+        elif isinstance(block, ImageURLContent):
+            parts.append(_image_ref_to_gemini_part(block.image_url))
+        else:
+            raise ProviderError(
+                f"Gemini does not accept {type(block).__name__}. Only TextContent and "
+                "ImageURLContent translate to Gemini `parts` today. Pass native Gemini "
+                "parts via raw dict messages, or wait for genblaze-google's typed "
+                "multimodal support (tracked in framework-dx-recommendations.md).",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+    return parts
+
+
+def _image_ref_to_gemini_part(ref: ImageURLRef) -> dict:
+    """Translate an `ImageURLRef` to Gemini's `inline_data` or `file_data` part.
+
+    - `data:` URIs decode to `inline_data` — the base64 payload split from the
+      URI header, mime type read from the header (falling back to
+      `media_type` if the header omits one).
+    - Any other URL (e.g. a Gemini Files API URI) passes through as
+      `file_data`; mime type comes from `media_type` if set, else a
+      best-effort guess from the URL's extension. Gemini validates the URI
+      upstream — we don't preflight-reject unresolvable URLs here.
+    """
+    url = ref.url
+    if url.startswith("data:"):
+        header, _, payload = url.partition(",")
+        if not payload:
+            raise ProviderError(
+                f"Malformed data URI in image_url — missing comma-delimited payload: "
+                f"{url[:32]}...",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        meta = header[len("data:") :]
+        if ";base64" not in meta:
+            raise ProviderError(
+                "Gemini inline_data requires a base64-encoded data URI "
+                "(e.g. 'data:image/jpeg;base64,...'); got a non-base64 data URI.",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
+        mime_type = meta.split(";")[0] or ref.media_type or "application/octet-stream"
+        return {"inline_data": {"mime_type": mime_type, "data": payload}}
+
+    mime_type = ref.media_type or mimetypes.guess_type(url)[0] or "application/octet-stream"
+    return {"file_data": {"mime_type": mime_type, "file_uri": url}}
 
 
 def _gemini_text_only(content: Any) -> str:
     """Reduce ChatMessage.content to plain text; raise on non-text blocks.
 
-    Gemini's chat API does not accept the OpenAI-vision wire shape — media
-    requires `inline_data` (base64) or `file_data` (File API URI). Until the
-    Google connector grows native multimodal block translation, refuse
-    Image/Video blocks at construction with a precise message rather than
-    erroring mid-runtime.
+    Only used for `system` messages — Gemini's `system_instruction` is a
+    plain string field, unlike `contents[].parts` which accepts media.
     """
     if isinstance(content, str):
         return content
@@ -69,10 +137,8 @@ def _gemini_text_only(content: Any) -> str:
             text_parts.append(block.text)
             continue
         raise ProviderError(
-            f"Gemini does not accept {type(block).__name__}. Pass media as "
-            "inline_data (base64) or file_data (File API URI) via raw dict messages, "
-            "or wait for genblaze-google's typed multimodal support (tracked in "
-            "framework-dx-recommendations.md).",
+            f"Gemini's system_instruction does not accept {type(block).__name__} — "
+            "only TextContent blocks are supported for system messages.",
             error_code=ProviderErrorCode.INVALID_INPUT,
         )
     return "".join(text_parts)

--- a/libs/connectors/google/genblaze_google/chat.py
+++ b/libs/connectors/google/genblaze_google/chat.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import mimetypes
+import re
 from typing import Any
 
 from genblaze_core.exceptions import ProviderError
@@ -110,17 +111,29 @@ def _image_ref_to_gemini_part(ref: ImageURLRef) -> dict:
                 error_code=ProviderErrorCode.INVALID_INPUT,
             )
         meta = header[len("data:") :]
-        if ";base64" not in meta:
+        if "base64" not in meta.lower():
             raise ProviderError(
                 "Gemini inline_data requires a base64-encoded data URI "
                 "(e.g. 'data:image/jpeg;base64,...'); got a non-base64 data URI.",
                 error_code=ProviderErrorCode.INVALID_INPUT,
             )
-        mime_type = meta.split(";")[0] or ref.media_type or "application/octet-stream"
+        header_mime = _valid_mime_type(meta.split(";")[0])
+        mime_type = header_mime or ref.media_type or "application/octet-stream"
         return {"inline_data": {"mime_type": mime_type, "data": payload}}
 
     mime_type = ref.media_type or mimetypes.guess_type(url)[0] or "application/octet-stream"
     return {"file_data": {"mime_type": mime_type, "file_uri": url}}
+
+
+# RFC 2045 token chars, loosely: reject anything that isn't a plain "type/subtype"
+# so a malformed data-URI header (e.g. stray whitespace/control chars from a
+# hand-built URI) can't be forwarded verbatim into the request payload as mime_type.
+_MIME_TYPE_RE = re.compile(r"^[\w.+-]+/[\w.+-]+$")
+
+
+def _valid_mime_type(candidate: str) -> str | None:
+    """Return `candidate` if it looks like a `type/subtype` MIME string, else None."""
+    return candidate if _MIME_TYPE_RE.match(candidate) else None
 
 
 def _gemini_text_only(content: Any) -> str:

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -50,24 +50,96 @@ def mock_client():
     return client
 
 
-def test_image_block_refused_with_clear_message(mock_client):
-    """Gemini does not accept OpenAI-vision shape — raise INVALID_INPUT, not mid-runtime."""
+def test_data_uri_image_translated_to_inline_data(mock_client):
+    """A `data:` URI ImageURLContent block becomes a Gemini `inline_data` part.
+
+    Regression test for #194: genblaze-google's chat() used to reject any
+    ImageURLContent block pre-flight, breaking provider-swappable multimodal
+    with the OpenAI-wire connectors (which accept it directly).
+    """
+    from genblaze_core.models.chat import ImageURLContent, ImageURLRef
+
+    data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+    msgs = [
+        ChatMessage(role="user", content=[ImageURLContent(image_url=ImageURLRef(url=data_uri))])
+    ]
+    chat("gemini-2.5-flash", messages=msgs, client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [{"inline_data": {"mime_type": "image/jpeg", "data": "/9j/4AAQSkZJRg=="}}]
+
+
+def test_text_and_image_multimodal_message_round_trips(mock_client):
+    """Exact repro from #194: TextContent + ImageURLContent(data URI) in one message."""
     from genblaze_core.models.chat import ImageURLContent, ImageURLRef, TextContent
 
+    data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
     msgs = [
         ChatMessage(
             role="user",
             content=[
-                TextContent(text="describe"),
-                ImageURLContent(image_url=ImageURLRef(url="https://x/y.png")),
+                TextContent(text="Describe this frame."),
+                ImageURLContent(image_url=ImageURLRef(url=data_uri)),
             ],
+        )
+    ]
+    resp = chat("gemini-2.5-flash", messages=msgs, client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [
+        {"text": "Describe this frame."},
+        {"inline_data": {"mime_type": "image/jpeg", "data": "/9j/4AAQSkZJRg=="}},
+    ]
+    assert resp.text == "Hello!"
+
+
+def test_raw_dict_message_with_image_url_also_works(mock_client):
+    """The raw-dict workaround the old error message recommended must actually work too —
+    `_normalize_to_gemini` coerces dicts back through `ChatMessage(**m)`, so the fix for
+    typed `ImageURLContent` has to cover this path as well (#194)."""
+    data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+    raw = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this frame."},
+            {"type": "image_url", "image_url": {"url": data_uri}},
+        ],
+    }
+    chat("gemini-2.5-flash", messages=[raw], client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [
+        {"text": "Describe this frame."},
+        {"inline_data": {"mime_type": "image/jpeg", "data": "/9j/4AAQSkZJRg=="}},
+    ]
+
+
+def test_https_image_url_translated_to_file_data(mock_client):
+    """A non-`data:` URL maps to Gemini's `file_data` part; mime type guessed from
+    extension when `media_type` isn't given."""
+    from genblaze_core.models.chat import ImageURLContent, ImageURLRef
+
+    msgs = [
+        ChatMessage(
+            role="user",
+            content=[ImageURLContent(image_url=ImageURLRef(url="https://x/y.png"))],
+        )
+    ]
+    chat("gemini-2.5-flash", messages=msgs, client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [{"file_data": {"mime_type": "image/png", "file_uri": "https://x/y.png"}}]
+
+
+def test_malformed_data_uri_raises_invalid_input(mock_client):
+    """A `data:` URI missing the comma-delimited payload is a client error, not a Gemini one."""
+    from genblaze_core.models.chat import ImageURLContent, ImageURLRef
+
+    msgs = [
+        ChatMessage(
+            role="user",
+            content=[ImageURLContent(image_url=ImageURLRef(url="data:image/jpeg;base64"))],
         )
     ]
     with pytest.raises(ProviderError) as info:
         chat("gemini-2.5-flash", messages=msgs, client=mock_client)
     assert info.value.error_code == ProviderErrorCode.INVALID_INPUT
-    assert "ImageURLContent" in str(info.value)
-    assert "inline_data" in str(info.value) or "file_data" in str(info.value)
 
 
 def test_video_block_refused_with_clear_message(mock_client):
@@ -85,7 +157,9 @@ def test_video_block_refused_with_clear_message(mock_client):
 
 
 def test_text_only_list_content_translated(mock_client):
-    """All-text list content translates cleanly to Gemini's parts shape."""
+    """All-text list content translates cleanly to Gemini's parts shape — one
+    `parts` entry per content block, matching the OpenAI connector's block-per-part
+    translation (needed so image blocks can be interleaved, see #194)."""
     from genblaze_core.models.chat import TextContent
 
     msgs = [
@@ -93,9 +167,8 @@ def test_text_only_list_content_translated(mock_client):
     ]
     chat("gemini-2.5-flash", messages=msgs, client=mock_client)
     call = mock_client.models.generate_content.call_args.kwargs
-    # first user content's parts text should join the blocks.
     parts = call["contents"][0]["parts"]
-    assert parts == [{"text": "hello world"}]
+    assert parts == [{"text": "hello"}, {"text": " world"}]
 
 
 def test_prompt_shorthand(mock_client):

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -127,6 +127,48 @@ def test_https_image_url_translated_to_file_data(mock_client):
     assert parts == [{"file_data": {"mime_type": "image/png", "file_uri": "https://x/y.png"}}]
 
 
+def test_data_uri_base64_marker_is_case_insensitive(mock_client):
+    """RFC 2397 doesn't mandate lowercase `;base64,`; accept `;BASE64,` too."""
+    from genblaze_core.models.chat import ImageURLContent, ImageURLRef
+
+    msgs = [
+        ChatMessage(
+            role="user",
+            content=[
+                ImageURLContent(
+                    image_url=ImageURLRef(url="data:image/jpeg;BASE64,/9j/4AAQSkZJRg==")
+                )
+            ],
+        )
+    ]
+    chat("gemini-2.5-flash", messages=msgs, client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [{"inline_data": {"mime_type": "image/jpeg", "data": "/9j/4AAQSkZJRg=="}}]
+
+
+def test_data_uri_with_malformed_mime_header_falls_back_to_octet_stream(mock_client):
+    """A data-URI header that doesn't look like `type/subtype` (e.g. injected control
+    chars or stray whitespace) must never be forwarded verbatim as `mime_type` — fall
+    back to a safe default instead."""
+    from genblaze_core.models.chat import ImageURLContent, ImageURLRef
+
+    msgs = [
+        ChatMessage(
+            role="user",
+            content=[
+                ImageURLContent(
+                    image_url=ImageURLRef(url="data:not a mime type;base64,/9j/4AAQSkZJRg==")
+                )
+            ],
+        )
+    ]
+    chat("gemini-2.5-flash", messages=msgs, client=mock_client)
+    parts = mock_client.models.generate_content.call_args.kwargs["contents"][0]["parts"]
+    assert parts == [
+        {"inline_data": {"mime_type": "application/octet-stream", "data": "/9j/4AAQSkZJRg=="}}
+    ]
+
+
 def test_malformed_data_uri_raises_invalid_input(mock_client):
     """A `data:` URI missing the comma-delimited payload is a client error, not a Gemini one."""
     from genblaze_core.models.chat import ImageURLContent, ImageURLRef


### PR DESCRIPTION
## Summary

`genblaze_google.chat()` pre-flight-rejected any `ChatMessage` whose `content` list carried the canonical `ImageURLContent` block, even though the OpenAI-wire connectors (OpenAI, GMICloud) accept it directly — breaking the unified `chat()` surface's promise of provider-swappable multimodal. The raw-dict workaround the error message itself recommended failed identically, since dicts are coerced back through `ChatMessage(**m)` before translation.

This PR makes Gemini translate the same canonical blocks the OpenAI connector already consumes, instead of raising.

## Changes

- `libs/connectors/google/genblaze_google/chat.py`:
  - `_normalize_to_gemini` now builds each message's Gemini `parts` from its content blocks (via new `_content_to_gemini_parts`) instead of collapsing to a single concatenated text string.
  - New `_image_ref_to_gemini_part` translates `ImageURLRef`: a `data:` URI becomes an `inline_data` part (base64 payload split from the header, mime type read from the header with a format check + `application/octet-stream` fallback so a malformed header is never forwarded verbatim); any other URL becomes a `file_data` part (mime type from `media_type` or a best-effort guess from the URL extension via stdlib `mimetypes`).
  - `VideoURLContent`/`AudioURLContent` still raise `INVALID_INPUT` (no Gemini `parts` mapping exists yet); the error message no longer points at the raw-dict workaround, since that path is now identical to the typed path.
  - `_gemini_text_only` is retained, scoped to `system` messages only (Gemini's `system_instruction` is a plain string field).
- `libs/connectors/google/tests/test_chat.py`: replaced the now-stale "image block refused" test with coverage for the fixed behavior — data-URI → `inline_data`, text+image round trip, the raw-dict workaround, `https://` → `file_data`, case-insensitive `;base64` marker, malformed mime-type header falling back safely, and malformed data URI still raising `INVALID_INPUT`. Updated `test_text_only_list_content_translated` for the new one-part-per-block shape.

**Pre-PR triangulated review** (3 independent sub-agents against the committed diff, no P0s found):
- **Correctness & tests** — confirmed the #194 repro is fixed and the full suite passes; noted the `;base64` marker was case-sensitive (fixed in the follow-up commit) and a couple of minor untested edge cases (non-blocking).
- **Security & invariants** — flagged (P1) that the data-URI mime-type substring was forwarded into the request payload unvalidated; fixed in the follow-up commit with a `type/subtype` format check and safe fallback. Confirmed no new SSRF exposure (`file_data.file_uri` pass-through matches the OpenAI connector's existing `image_url` pass-through pattern), no payload/secret leakage in error messages, and no contact with `EmbedPolicy`/manifest/`canonical_hash` invariants (this module sits outside the Pipeline/manifest system).
- **Architecture, scalability & DRY** — confirmed this is the first data-URI parser in the repo (not duplicating an existing `genblaze_core.media` utility) and is appropriately scoped to this connector at single-consumer scale; confirmed no leakage into `_families.py`/`_probe.py`/`__init__.py`/image-gen providers; flagged (non-blocking, informational) that arbitrary `https://` URLs passed as `file_data` will fail upstream at Gemini rather than pre-flight (deferred "download and inline" is out of scope for this issue).

## Test plan

- [x] `cd libs/connectors/google && pytest tests -v` — 101 passed, 7 skipped
- [ ] `make test` — not run (full-suite gate; run in CI)
- [x] `ruff check` / `ruff format --check` on changed files — pass
- [x] `mypy libs/connectors/google/genblaze_google/chat.py --ignore-missing-imports` — no issues
- [ ] Docs updated — not needed; no public docs describe Gemini's vision support today, and no CHANGELOG/version bump per wave-batch rules (release-assembly owns those)

## Related

Closes #194