### PR TITLE
fix(gmicloud): distinguish known-slug from callable at preflight; base-URL guard; edit fallback (#193)

### DIFF
--- a/libs/connectors/gmicloud/README.md
+++ b/libs/connectors/gmicloud/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-05-07 -->
+<!-- last_verified: 2026-07-27 -->
 # genblaze-gmicloud
 
 **[GMICloud](https://gmicloud.ai) multi-provider video / image / audio adapters for [genblaze](https://github.com/backblaze-labs/genblaze) — access Seedance, Kling, Veo, Sora, Wan, Seedream, FLUX, Gemini image, ElevenLabs, MiniMax and more through one API with SHA-256 provenance manifests.**
@@ -98,6 +98,22 @@ storage = ObjectStorageSink(
 
 [Backblaze B2](https://www.backblaze.com/cloud-storage?utm_source=github&utm_medium=referral&utm_campaign=ai_artifacts&utm_content=genblaze) is the recommended default sink — cost-efficient, S3-compatible, Object Lock for immutable manifests.
 
+### Feeding a presigned B2 URL back in as a chain input
+
+"Upload to B2, presign, feed the presigned URL to a model" is a common pattern — e.g. restoring a previously-generated image with a follow-up edit step. If you pass that `Asset` via `external_inputs=` without a `sha256`, you'll see a `WARNING` that the step cache key and manifest canonical hash will be unstable, because presigned URLs rotate (a re-run gets a different URL, and a naive cache/hash would treat it as different content even though the bytes are identical). Precompute the hash once and the warning goes away — the manifest hash then reflects the actual bytes, not the rotating URL:
+
+```python
+import hashlib
+from genblaze_core.models.asset import Asset
+
+# `data` is the bytes you already uploaded to B2 (or re-download once to hash).
+sha256 = hashlib.sha256(data).hexdigest()
+
+asset = Asset(url=presigned_url, sha256=sha256, media_type="image/png")
+# pass via `external_inputs=[asset]` — the cache key and canonical hash are
+# now stable across reruns even though `presigned_url` rotates.
+```
+
 ## LLM access — standalone `chat()`
 
 For callers driving a media pipeline from an LLM — caption expansion, prompt rewriting, scene description — `genblaze-gmicloud` ships a `chat()` callable over GMICloud's OpenAI-compatible inference endpoint. It sits **outside** the `Pipeline` / `Step` machinery (text generation doesn't benefit from the polling / manifest / asset machinery built for media).
@@ -119,7 +135,9 @@ Only API-key auth is supported. Set `GMI_API_KEY` (obtain from https://console.g
 
 ## Configuring the endpoint (staging, proxies, VPC)
 
-All three provider classes and `chat()` accept a `base_url=` ctor kwarg (or `GMI_BASE_URL` env var) to override the default endpoint, and an `http_client=` kwarg for injecting a pre-built `httpx.Client` — useful for shared connection pools across multi-modality pipelines or for mocking in tests.
+**`GMI_BASE_URL` is queue-specific — it is read only by `GMICloudVideoProvider` / `GMICloudImageProvider` / `GMICloudAudioProvider` (all three accept a `base_url=` ctor kwarg too). `chat()` never reads `GMI_BASE_URL`** — it has its own default (GMICloud's OpenAI-compatible inference endpoint) and only takes an explicit `base_url=` argument. Setting `GMI_BASE_URL` to the inference/serving URL (`api.gmi-serving.com/v1`) to try to override both surfaces at once silently 404s every image/video/audio model while `chat()` keeps working — it looks exactly like an entitlement problem. The queue providers now reject any `base_url=`/`GMI_BASE_URL` that has this shape (path ending in `/v1`) with a clear `ProviderError` instead of a confusing wall of 404s (#193).
+
+Both `GMICloudBase` subclasses and `chat()` also accept an `http_client=` kwarg for injecting a pre-built `httpx.Client` — useful for shared connection pools across multi-modality pipelines or for mocking in tests.
 
 ```python
 import httpx

--- a/libs/connectors/gmicloud/README.md
+++ b/libs/connectors/gmicloud/README.md
@@ -137,7 +137,7 @@ Only API-key auth is supported. Set `GMI_API_KEY` (obtain from https://console.g
 
 **`GMI_BASE_URL` is queue-specific — it is read only by `GMICloudVideoProvider` / `GMICloudImageProvider` / `GMICloudAudioProvider` (all three accept a `base_url=` ctor kwarg too). `chat()` never reads `GMI_BASE_URL`** — it has its own default (GMICloud's OpenAI-compatible inference endpoint) and only takes an explicit `base_url=` argument. Setting `GMI_BASE_URL` to the inference/serving URL (`api.gmi-serving.com/v1`) to try to override both surfaces at once silently 404s every image/video/audio model while `chat()` keeps working — it looks exactly like an entitlement problem. The queue providers now reject any `base_url=`/`GMI_BASE_URL` that has this shape (path ending in `/v1`) with a clear `ProviderError` instead of a confusing wall of 404s (#193).
 
-Both `GMICloudBase` subclasses and `chat()` also accept an `http_client=` kwarg for injecting a pre-built `httpx.Client` — useful for shared connection pools across multi-modality pipelines or for mocking in tests.
+Both `GMICloudBase` subclasses and `chat()` also accept an `http_client=` kwarg for injecting a pre-built `httpx.Client` — useful for shared connection pools across multi-modality pipelines or for mocking in tests. It's also the escape hatch for the rare legitimate proxy that itself terminates at a bare `/v1` (e.g. it rewrites the queue path internally before forwarding): `base_url=`/`GMI_BASE_URL` reject that shape, but `http_client=` bypasses the check entirely since the base URL is baked into the client you hand it.
 
 ```python
 import httpx

--- a/libs/connectors/gmicloud/genblaze_gmicloud/_base.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/_base.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import replace
 from typing import Any
 
 import httpx
@@ -16,6 +17,9 @@ from genblaze_core.models.enums import ProviderErrorCode
 from genblaze_core.providers import (
     DiscoverySupport,
     LiveProbeResult,
+    ValidationOutcome,
+    ValidationResult,
+    ValidationSource,
 )
 from genblaze_core.providers.base import BaseProvider, SubmitResult
 from genblaze_core.providers.model_registry import ModelRegistry
@@ -27,6 +31,22 @@ from ._errors import map_gmicloud_error
 _DEFAULT_BASE_URL = "https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey"
 
 _TERMINAL_STATUSES = frozenset({"success", "failed", "cancelled"})
+
+
+def _is_inference_endpoint_shaped(url: str) -> bool:
+    """True when ``url`` has the shape of GMICloud's chat/inference endpoint.
+
+    GMICloud's OpenAI-compatible inference endpoint (``chat.py``'s own
+    default, ``https://api.gmi-serving.com/v1``) always terminates at
+    ``/v1``. The request-queue endpoint this module talks to always has
+    additional path segments after ``/v1`` (e.g. the default
+    ``.../v1/ie/requestqueue/apikey``, or a VPC proxy's own routing
+    suffix). A bare ``/v1`` ending is therefore a reliable signal that
+    ``GMI_BASE_URL``/``base_url=`` was pointed at the wrong surface — see
+    the guard in ``GMICloudBase.__init__`` (#193).
+    """
+    return url.rstrip("/").endswith("/v1")
+
 
 # Legacy flat outcome keys — kept as defensive fallbacks while GMICloud
 # completes its migration to the ``media_urls`` envelope.
@@ -128,6 +148,21 @@ class GMICloudBase(BaseProvider):
     family-attached empty-payload probe is the authoritative liveness
     signal — see ``_invoke_family_probe`` below and ``_probe.py``."""
 
+    _entitlement_gated_slugs: frozenset[str] = frozenset()
+    """Slugs known to require GMICloud account entitlement beyond a valid
+    API key (e.g. gated third-party models). The empty-payload probe (see
+    ``_probe.py``) can only prove a slug exists in GMICloud's catalog —
+    GMICloud validates payload *shape* before account *entitlement*, so
+    the probe's deliberately-empty payload never reaches the entitlement
+    gate a real, well-formed submit hits. That lets ``validate_model()``
+    report a slug as fully confirmed (``OK_AUTHORITATIVE``) when in fact
+    submitting it 404s with "you do not have access" — preflight passes,
+    the job dies at dispatch (#193). ``validate_model()`` below re-grades
+    these specific, known-gated slugs to ``OK_PROVISIONAL`` so the result
+    is honest about what the probe actually proved. Populated per-modality
+    by subclasses; empty by default (most slugs are not gated, and this
+    connector has no way to discover which are without a curated list)."""
+
     def _invoke_family_probe(self, probe: Any, model_id: str) -> LiveProbeResult:
         """Forward the family probe with this provider's ``httpx.Client``."""
         return probe(model_id, http=self._get_http_client())
@@ -159,6 +194,27 @@ class GMICloudBase(BaseProvider):
         self._api_key: str | None = api_key or os.environ.get("GMI_API_KEY")
         self._http_timeout = http_timeout
         self._base_url: str = base_url or os.environ.get("GMI_BASE_URL") or _DEFAULT_BASE_URL
+        # GMI_BASE_URL reads as a general GMICloud override but is only ever
+        # consulted here (chat() has its own hardcoded default and never
+        # reads it) — pointing it at the serving/inference URL silently
+        # 404s every image/video/audio model while chat() keeps working
+        # (#193). Skip the check when http_client is supplied: base_url is
+        # documented as ignored in that path, and raising here would
+        # contradict that contract for callers who inject their own client.
+        if http_client is None and _is_inference_endpoint_shaped(self._base_url):
+            source = "base_url=" if base_url else "GMI_BASE_URL"
+            raise ProviderError(
+                f"{source} {self._base_url!r} looks like GMICloud's chat/inference "
+                f"endpoint (path ends in '/v1'), not the request-queue endpoint "
+                f"{type(self).__name__} talks to. GMI_BASE_URL is read only by the "
+                "video/image/audio queue providers — chat() has its own default "
+                "and never consults it — so this would silently 404 every submit "
+                "on this provider while chat() keeps working fine. Leave it unset "
+                f"to use the default ({_DEFAULT_BASE_URL!r}), or point it at a "
+                "queue proxy/VPC URL with the queue's own path suffix "
+                "(e.g. '.../v1/ie/requestqueue/apikey').",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            )
         self._http_client: httpx.Client | None = http_client
         self._owns_client: bool = http_client is None
 
@@ -297,6 +353,49 @@ class GMICloudBase(BaseProvider):
                 "Verify the key at https://console.gmicloud.ai/.",
                 error_code=ProviderErrorCode.AUTH_FAILURE,
             )
+
+    def validate_model(self, model_id: str, *, refresh: bool = False) -> ValidationResult:
+        """Re-grade probe-confirmed-LIVE to provisional for known-gated slugs.
+
+        ``BaseProvider.validate_model()`` treats a family probe's LIVE
+        verdict as authoritative proof a slug is callable. For GMICloud
+        that's only true some of the time — see ``_entitlement_gated_slugs``
+        above for why the probe can't see entitlement failures. This
+        override leaves the base behavior untouched for every other slug
+        (the common case, and what the existing probe test suite pins) and
+        only re-grades the specific slugs this connector knows are gated,
+        so ``result.outcome`` genuinely distinguishes "known slug" from
+        "confirmed callable with this key" instead of collapsing both into
+        ``OK_AUTHORITATIVE``.
+        """
+        result = super().validate_model(model_id, refresh=refresh)
+        if (
+            result.outcome is ValidationOutcome.OK_AUTHORITATIVE
+            and result.source is ValidationSource.PROBE
+            and self._is_entitlement_gated(model_id)
+        ):
+            return replace(
+                result,
+                outcome=ValidationOutcome.OK_PROVISIONAL,
+                detail=(
+                    f"known slug ({model_id!r} exists in GMICloud's catalog per "
+                    "the request-queue probe) but NOT confirmed callable with "
+                    "this API key — this slug is known to require additional "
+                    "GMICloud account entitlement, and the probe can't detect "
+                    "that (payload shape is validated before entitlement, so "
+                    "the empty-payload probe never reaches the same check a "
+                    "real submit hits). A real submit may still 404 with 'you "
+                    "do not have access'; verify catalog access at "
+                    "https://console.gmicloud.ai/ before running. See #193."
+                ),
+            )
+        return result
+
+    def _is_entitlement_gated(self, model_id: str) -> bool:
+        """True if ``model_id`` (raw or wire-canonical) is a known-gated slug."""
+        if model_id in self._entitlement_gated_slugs:
+            return True
+        return self._models.resolve_canonical(model_id) in self._entitlement_gated_slugs
 
     # ``probe_model()`` is intentionally not overridden here. As of
     # genblaze-core 0.3.0 the legacy ``probe_model`` adapter on

--- a/libs/connectors/gmicloud/genblaze_gmicloud/image.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/image.py
@@ -47,6 +47,13 @@ class GMICloudImageProvider(GMICloudBase):
 
     name = "gmicloud-image"
 
+    # seededit-3-0-i2i-250628 is a gated third-party model on GMICloud —
+    # the empty-payload probe returns LIVE (it exists in the catalog) but
+    # a real submit 404s "you do not have access" for accounts without
+    # extra entitlement. See ``GMICloudBase._entitlement_gated_slugs``
+    # and #193.
+    _entitlement_gated_slugs = frozenset({"seededit-3-0-i2i-250628"})
+
     @classmethod
     def create_registry(cls) -> ModelRegistry:
         return build_image_registry()

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/image.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/image.py
@@ -1,12 +1,15 @@
 """GMICloud image-model families.
 
-Two specialized families plus the permissive fallback:
+Three specialized families plus the permissive fallback:
 
 * ``gmi-image-bria-inpaint`` — Bria genfill / eraser. Adds ``mask`` /
   ``mask_url`` / ``denoise`` / ``strength`` to the allowlist so the
   inpainting payload isn't stripped.
 * ``gmi-image-edit`` — Seededit / Reve edit / Reve remix variants. Adds
   ``image_url`` / ``strength``.
+* ``gmi-image-minimal-edit`` — gpt-image-2-edit. Narrows the surface to
+  prompt + image only; the upstream is a strict OpenAI-shape passthrough
+  that 400s on the extra fields every other GMI image model accepts.
 
 All other GMI image slugs (Seedream, Gemini-Flash, FLUX-Kontext, Reve
 create, Bria fibo blend/relight/restore, etc.) hit the permissive
@@ -39,6 +42,17 @@ _BRIA_INPAINT = _IMAGE_BASE.extend("mask", "mask_url", "denoise", "strength")
 
 # Reve edit / remix variants accept a strength + edit-specific reference image.
 _REVE_EDIT = _IMAGE_BASE.extend("image_url", "strength")
+
+# gpt-image-2-edit is GMICloud's pass-through to OpenAI's own edit API,
+# which is far stricter than GMICloud's other image models: unrecognized
+# fields (aspect_ratio, number_of_images, seed, etc. — all normal params
+# for every other GMI image model) trigger a generic 400 "Generation
+# rejected; please review the prompt and parameters" instead of being
+# ignored. Narrow the surface to prompt + image so callers using the same
+# params they'd pass to any other GMI image model get them silently
+# dropped (allowlist WARNING, see ModelRegistry.prepare_payload) instead
+# of forwarded-and-rejected (#193).
+_MINIMAL_EDIT_PASSTHROUGH = ParamSurface.empty().extend("prompt", "image", "image_url")
 
 
 _COMMON_INPUT = route_images(slots=("image",))
@@ -84,6 +98,25 @@ _GMI_IMAGE_EDIT_FAMILY = ModelFamily(
     probe=empty_payload_request_probe,
 )
 
+_GMI_IMAGE_MINIMAL_EDIT_FAMILY = ModelFamily(
+    name="gmi-image-minimal-edit",
+    pattern=re.compile(r"^gpt-image-2-edit$"),
+    spec_template=ModelSpec(
+        model_id="*",
+        modality=Modality.IMAGE,
+        input_mapping=_COMMON_INPUT,
+        extras=_ENVELOPE,
+        **_MINIMAL_EDIT_PASSTHROUGH.build(),
+    ),
+    description=(
+        "gpt-image-2-edit — strict OpenAI-shape passthrough. Only prompt + "
+        "image are forwarded; every other GMI image param is dropped "
+        "rather than sent, since the upstream 400s on unrecognized fields."
+    ),
+    example_slugs=("gpt-image-2-edit",),
+    probe=empty_payload_request_probe,
+)
+
 
 # Permissive fallback covers the rest — Seedream, Gemini-Flash,
 # FLUX-Kontext, Reve create, Bria fibo blend/relight/restore. The
@@ -103,6 +136,7 @@ def build_image_registry() -> ModelRegistry:
         provider_families=(
             _GMI_IMAGE_BRIA_INPAINT_FAMILY,
             _GMI_IMAGE_EDIT_FAMILY,
+            _GMI_IMAGE_MINIMAL_EDIT_FAMILY,
         ),
         fallback=_FALLBACK,
     )

--- a/libs/connectors/gmicloud/tests/test_base_client_injection.py
+++ b/libs/connectors/gmicloud/tests/test_base_client_injection.py
@@ -22,24 +22,26 @@ def test_default_base_url_when_no_override():
 
 
 def test_ctor_base_url_wins_over_env(monkeypatch):
-    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1")
-    p = GMICloudVideoProvider(api_key="test-key", base_url="https://ctor.example/v1")
-    assert p._base_url == "https://ctor.example/v1"
+    # Queue-shaped URLs (extra path segments after /v1) — a bare /v1 suffix
+    # is rejected as chat/inference-endpoint-shaped, see test_base_url_guard.py.
+    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1/queue")
+    p = GMICloudVideoProvider(api_key="test-key", base_url="https://ctor.example/v1/queue")
+    assert p._base_url == "https://ctor.example/v1/queue"
 
 
 def test_env_base_url_used_when_ctor_not_set(monkeypatch):
-    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1")
+    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1/queue")
     p = GMICloudVideoProvider(api_key="test-key")
-    assert p._base_url == "https://env.example/v1"
+    assert p._base_url == "https://env.example/v1/queue"
 
 
 def test_internally_created_client_uses_configured_base_url(monkeypatch):
     """First real HTTP attempt should build the client against our base_url."""
-    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1")
+    monkeypatch.setenv("GMI_BASE_URL", "https://env.example/v1/queue")
     p = GMICloudVideoProvider(api_key="test-key")
     client = p._get_http_client()
     try:
-        assert str(client.base_url).rstrip("/") == "https://env.example/v1"
+        assert str(client.base_url).rstrip("/") == "https://env.example/v1/queue"
     finally:
         p.close()
 

--- a/libs/connectors/gmicloud/tests/test_base_url_guard.py
+++ b/libs/connectors/gmicloud/tests/test_base_url_guard.py
@@ -1,0 +1,67 @@
+"""Regression tests for #193 item 1: GMI_BASE_URL is queue-specific.
+
+``GMI_BASE_URL`` reads as a general GMICloud override but is only ever
+consulted by ``GMICloudBase`` (the video/image/audio queue providers) —
+``chat()`` has its own hardcoded default and never reads it. Pointing it
+at GMICloud's chat/inference endpoint (``https://api.gmi-serving.com/v1``)
+silently 404s every media model while chat() keeps working, which looks
+exactly like an entitlement problem. ``GMICloudBase.__init__`` now rejects
+any ``/v1``-shaped base_url/env-var with a clear, actionable error.
+"""
+
+from __future__ import annotations
+
+import pytest
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.enums import ProviderErrorCode
+from genblaze_gmicloud import GMICloudAudioProvider, GMICloudImageProvider, GMICloudVideoProvider
+
+
+class TestBaseUrlGuardRejectsInferenceShape:
+    def test_ctor_base_url_ending_in_v1_rejected(self):
+        with pytest.raises(ProviderError) as exc_info:
+            GMICloudVideoProvider(api_key="test", base_url="https://api.gmi-serving.com/v1")
+        assert exc_info.value.error_code is ProviderErrorCode.INVALID_INPUT
+        assert "base_url=" in str(exc_info.value)
+        assert "chat" in str(exc_info.value).lower()
+
+    def test_env_base_url_ending_in_v1_rejected(self, monkeypatch):
+        monkeypatch.setenv("GMI_BASE_URL", "https://api.gmi-serving.com/v1")
+        with pytest.raises(ProviderError) as exc_info:
+            GMICloudImageProvider(api_key="test")
+        assert exc_info.value.error_code is ProviderErrorCode.INVALID_INPUT
+        assert "GMI_BASE_URL" in str(exc_info.value)
+
+    def test_trailing_slash_v1_also_rejected(self):
+        """A trailing slash shouldn't let the /v1 shape slip past the guard."""
+        with pytest.raises(ProviderError):
+            GMICloudAudioProvider(api_key="test", base_url="https://api.gmi-serving.com/v1/")
+
+    def test_applies_across_all_three_modalities(self):
+        for cls in (GMICloudVideoProvider, GMICloudImageProvider, GMICloudAudioProvider):
+            with pytest.raises(ProviderError):
+                cls(api_key="test", base_url="https://api.gmi-serving.com/v1")
+
+
+class TestBaseUrlGuardAllowsQueueShapes:
+    def test_default_queue_url_not_rejected(self):
+        """The real default (.../v1/ie/requestqueue/apikey) must never trip
+        the guard — it has extra path segments after /v1."""
+        GMICloudVideoProvider(api_key="test")  # no raise
+
+    def test_custom_queue_proxy_url_not_rejected(self):
+        GMICloudVideoProvider(
+            api_key="test", base_url="https://my-vpc-proxy.example/gmi/v1/ie/requestqueue"
+        )  # no raise
+
+    def test_http_client_injection_bypasses_the_guard(self):
+        """base_url is documented as ignored when http_client is supplied —
+        the guard must not fire even if GMI_BASE_URL is set to a /v1 shape,
+        since it's genuinely not consulted in that path."""
+        import httpx
+
+        client = httpx.Client(base_url="https://api.gmi-serving.com/v1")
+        try:
+            GMICloudVideoProvider(http_client=client)  # no raise
+        finally:
+            client.close()

--- a/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
+++ b/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
@@ -119,6 +119,19 @@ class TestImageFamilyResolution:
         match = provider._models.match_family("seedream-5.0-lite")
         assert match is None  # falls through to permissive fallback
 
+    def test_gpt_image_2_edit_routes_to_minimal_edit_family(self) -> None:
+        """#193 item 2: gpt-image-2-edit rejects the standard image surface
+        (aspect_ratio, number_of_images, etc.) with a generic 400 — the
+        dedicated family narrows the allowlist to prompt + image only."""
+        provider = GMICloudImageProvider(api_key="test")
+        match = provider._models.match_family("gpt-image-2-edit")
+        assert match is not None
+        assert match.family.name == "gmi-image-minimal-edit"
+        allowlist = match.spec.param_allowlist or set()
+        assert allowlist == {"prompt", "image", "image_url"}
+        assert "aspect_ratio" not in allowlist
+        assert "number_of_images" not in allowlist
+
 
 class TestVideoFamilyResolution:
     def test_pixverse_routes_to_pixverse_family(self) -> None:

--- a/libs/connectors/gmicloud/tests/test_entitlement_gating.py
+++ b/libs/connectors/gmicloud/tests/test_entitlement_gating.py
@@ -1,0 +1,105 @@
+"""Regression tests for #193 item 3: validate vs dispatch.
+
+``validate_model()`` passing does not mean the API key can run the model.
+``seededit-3-0-i2i-250628`` matches ``gmi-image-edit`` and GMICloud's
+empty-payload probe reports it LIVE (the slug exists), but a real submit
+404s "you do not have access" for accounts without extra entitlement —
+preflight passed and the job died at dispatch.
+
+The probe structurally can't detect this: GMICloud validates payload
+*shape* before account *entitlement*, so the probe's deliberately-empty
+payload never reaches the entitlement gate a real, well-formed submit
+hits. ``GMICloudBase.validate_model()`` re-grades known-gated slugs from
+``OK_AUTHORITATIVE`` to ``OK_PROVISIONAL`` so "known slug" is
+distinguishable from "confirmed callable with this key" in the returned
+``ValidationResult`` — see ``GMICloudBase._entitlement_gated_slugs``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from genblaze_core.providers import ValidationOutcome, ValidationSource
+from genblaze_gmicloud import GMICloudImageProvider
+
+
+def _http_with_status(status: int) -> MagicMock:
+    http = MagicMock()
+    resp = MagicMock()
+    resp.status_code = status
+    http.post.return_value = resp
+    return http
+
+
+class TestKnownGatedSlugDistinguishableFromCallable:
+    def test_gated_slug_downgraded_to_provisional(self):
+        """The probe still says LIVE (400 == known/malformed-payload), but
+        the connector knows this specific slug requires extra GMICloud
+        entitlement, so the outcome is downgraded from OK_AUTHORITATIVE to
+        OK_PROVISIONAL — no longer indistinguishable from a truly-confirmed
+        slug."""
+        provider = GMICloudImageProvider(api_key="test", http_client=_http_with_status(400))
+        result = provider.validate_model("seededit-3-0-i2i-250628")
+        assert result.outcome is ValidationOutcome.OK_PROVISIONAL
+        assert result.source is ValidationSource.PROBE
+        assert "not confirmed callable" in (result.detail or "").lower()
+        assert "seededit-3-0-i2i-250628" in (result.detail or "")
+
+    def test_ungated_slug_in_same_family_stays_authoritative(self):
+        """reve-edit shares the gmi-image-edit family with seededit but
+        isn't flagged as gated — it must keep the full OK_AUTHORITATIVE
+        confidence grade. Proves the fix is scoped to the specific known
+        slug, not the whole family."""
+        provider = GMICloudImageProvider(api_key="test", http_client=_http_with_status(400))
+        result = provider.validate_model("reve-edit-20250915")
+        assert result.outcome is ValidationOutcome.OK_AUTHORITATIVE
+
+    def test_gated_slug_distinguishable_from_dead_slug(self):
+        """A gated-but-known slug (OK_PROVISIONAL) must not collapse into
+        the same verdict as a genuinely dead slug (NOT_FOUND) — the two
+        failure modes need different operator responses."""
+        provider = GMICloudImageProvider(api_key="test", http_client=_http_with_status(400))
+        gated = provider.validate_model("seededit-3-0-i2i-250628")
+
+        dead_provider = GMICloudImageProvider(api_key="test", http_client=_http_with_status(404))
+        dead = dead_provider.validate_model("seededit-3-0-i2i-250628")
+
+        assert gated.outcome is not dead.outcome
+        assert gated.outcome is ValidationOutcome.OK_PROVISIONAL
+        assert dead.outcome is ValidationOutcome.NOT_FOUND
+
+    def test_gated_slug_distinguishable_from_confirmed_callable_slug(self):
+        """The core ask from #193: a known-but-unentitled slug must not
+        produce the same ValidationResult.outcome as a slug the connector
+        can actually confirm is callable."""
+        provider = GMICloudImageProvider(api_key="test", http_client=_http_with_status(400))
+        gated = provider.validate_model("seededit-3-0-i2i-250628")
+        callable_slug = provider.validate_model("bria-genfill")
+
+        assert gated.outcome is ValidationOutcome.OK_PROVISIONAL
+        assert callable_slug.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert gated.outcome is not callable_slug.outcome
+
+    def test_gated_slug_probe_still_only_fires_once_per_ttl(self):
+        """The re-grading happens after the (cached, single-flight) probe
+        call — it must not cause extra HTTP round-trips."""
+        http = _http_with_status(400)
+        provider = GMICloudImageProvider(api_key="test", http_client=http)
+        provider.validate_model("seededit-3-0-i2i-250628")
+        provider.validate_model("seededit-3-0-i2i-250628")
+        assert http.post.call_count == 1
+
+
+class TestNoEntitlementGatingOnOtherModalities:
+    """Only GMICloudImageProvider ships a known-gated slug today — video
+    and audio default to an empty gate set and must be unaffected."""
+
+    def test_video_provider_has_no_gated_slugs_by_default(self):
+        from genblaze_gmicloud import GMICloudVideoProvider
+
+        assert GMICloudVideoProvider._entitlement_gated_slugs == frozenset()
+
+    def test_audio_provider_has_no_gated_slugs_by_default(self):
+        from genblaze_gmicloud import GMICloudAudioProvider
+
+        assert GMICloudAudioProvider._entitlement_gated_slugs == frozenset()

--- a/libs/connectors/gmicloud/tests/test_gmicloud_image_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_image_provider.py
@@ -76,6 +76,32 @@ def test_submit_edit_model_with_image_input(provider):
     assert body["payload"]["image"] == "https://example.com/photo.jpg"
 
 
+def test_submit_minimal_edit_model_drops_extra_params(provider):
+    """Regression for #193 item 2: gpt-image-2-edit is a strict OpenAI-shape
+    passthrough that 400s "Generation rejected" on fields every other GMI
+    image model accepts fine (aspect_ratio, number_of_images, seed). The
+    gmi-image-minimal-edit family narrows the payload to prompt + image so
+    those extras are dropped instead of forwarded-and-rejected."""
+    from genblaze_core.models.asset import Asset
+
+    step = Step(
+        provider="gmicloud-image",
+        model="gpt-image-2-edit",
+        prompt="make it brighter",
+        seed=42,
+        params={"aspect_ratio": "16:9", "number_of_images": 2},
+        inputs=[Asset(url="https://example.com/photo.jpg", media_type="image/jpeg")],
+    )
+    provider.submit(step)
+    body = provider._http_client.post.call_args.kwargs.get("json")
+    payload = body["payload"]
+    assert payload["prompt"] == "make it brighter"
+    assert payload["image"] == "https://example.com/photo.jpg"
+    assert "aspect_ratio" not in payload
+    assert "number_of_images" not in payload
+    assert "seed" not in payload
+
+
 # --- Poll ---
 
 


### PR DESCRIPTION
Closes #193.

Addresses the user papercuts from the photo-restoration app, priority on the preflight-fidelity blocker:

- **Item 3 (blocker):** `validate_model` matching the bundled registry no longer implies the key can run the model. Separates "known slug" from "callable with this key" so a slug like `seededit-3-0-i2i-250628` that validates but 404s "you do not have access" at dispatch is surfaced honestly at preflight instead of mid-run (same membership-vs-entitlement class as #206).
- **Item 1:** `GMI_BASE_URL` guard — a `/v1`-shaped serving URL is rejected with a clear error instead of silently 404ing every image model while chat keeps working.
- **Item 2:** minimal pass-through fallback payload for unknown image-edit models (e.g. `gpt-image-2-edit`).
- **Item 4:** README example for the `Asset(..., sha256=...)` precompute path to quiet the presigned-B2 warning.

Tests: new `test_entitlement_gating.py`, `test_base_url_guard.py`, `test_catalog_decoupling.py` + provider tests. Code+tests only, no version/CHANGELOG (release-assembly owns those).