### PR TITLE
docs(google): correct Imagen entitlement-probe references (follow-up to #220)

### DIFF
--- a/libs/connectors/google/genblaze_google/_errors.py
+++ b/libs/connectors/google/genblaze_google/_errors.py
@@ -1,4 +1,5 @@
-"""Shared Google API error mapping — used by provider.py, imagen.py."""
+"""Shared Google API error mapping — used by provider.py, imagen.py,
+chat.py, gemini_image.py."""
 
 from genblaze_core.models.enums import ProviderErrorCode
 
@@ -8,11 +9,12 @@ def map_google_error(exc: Exception) -> ProviderErrorCode:
     msg = str(exc).lower()
     # Imagen entitlement gate (issue #206): models.get says the slug is
     # cataloged, but :predict 404s for accounts without Imagen access.
-    # ImagenProvider.validate_model warns (OK_PROVISIONAL) rather than blocks at
-    # preflight, so an unentitled imagen-4.0-* slug is expected to reach call
-    # time and 404 here — this mapping is the primary enforcement point, not a
-    # rare backstop. MODEL_ERROR lets the pipeline's fallback_models retry fire
-    # on it exactly like any other dead slug.
+    # ImagenProvider.validate_model warns (OK_PROVISIONAL) rather than blocks
+    # at preflight, so an unentitled imagen-4.0-* slug is expected to reach
+    # call time and 404 on the actual API call — this branch, not preflight,
+    # is where the gate is actually handled. MODEL_ERROR matches what
+    # preflight already raises for a DEAD probe result, so the pipeline's
+    # fallback_models retry fires on it exactly like any other dead slug.
     if "no longer available to new users" in msg:
         return ProviderErrorCode.MODEL_ERROR
     if "rate" in msg or "429" in msg or "resource_exhausted" in msg:

--- a/libs/connectors/google/genblaze_google/_errors.py
+++ b/libs/connectors/google/genblaze_google/_errors.py
@@ -8,11 +8,11 @@ def map_google_error(exc: Exception) -> ProviderErrorCode:
     msg = str(exc).lower()
     # Imagen entitlement gate (issue #206): models.get says the slug is
     # cataloged, but :predict 404s for accounts without Imagen access.
-    # google_imagen_predict_probe catches this at preflight, but map it to
-    # MODEL_ERROR here too in case it ever slips through to call time — same
-    # code preflight already raises for a DEAD probe result, so the
-    # pipeline's fallback_models retry fires on it exactly like any other
-    # dead slug.
+    # ImagenProvider.validate_model warns (OK_PROVISIONAL) rather than blocks at
+    # preflight, so an unentitled imagen-4.0-* slug is expected to reach call
+    # time and 404 here — this mapping is the primary enforcement point, not a
+    # rare backstop. MODEL_ERROR lets the pipeline's fallback_models retry fire
+    # on it exactly like any other dead slug.
     if "no longer available to new users" in msg:
         return ProviderErrorCode.MODEL_ERROR
     if "rate" in msg or "429" in msg or "resource_exhausted" in msg:

--- a/libs/connectors/google/genblaze_google/_families.py
+++ b/libs/connectors/google/genblaze_google/_families.py
@@ -1,7 +1,8 @@
-"""Google model families — Veo (video) and Imagen (image).
+"""Google model families — Veo (video), Imagen (image), and
+Gemini-native image generation.
 
 Pattern-keyed; future ``veo-N`` / ``imagen-N`` slugs inherit param
-shape automatically. Both families ship the
+shape automatically. All families ship the
 ``google_models_get_probe`` so ``Pipeline.preflight()`` returns
 ``OK_AUTHORITATIVE`` when the slug exists on the user's project,
 ``NOT_FOUND`` when it doesn't, and ``OK_PROVISIONAL`` when google-genai

--- a/libs/connectors/google/genblaze_google/_probe.py
+++ b/libs/connectors/google/genblaze_google/_probe.py
@@ -14,9 +14,10 @@ Mapping:
   ``OK_PROVISIONAL`` rather than blocking the user.
 
 Used by ``DiscoverySupport.PARTIAL`` providers in
-``genblaze-google``: ``VeoProvider`` and ``ImagenProvider``. Each
-provider attaches this callable to its ``ModelFamily`` instances and
-forwards its lazy-built genai client via ``_invoke_family_probe``.
+``genblaze-google``: ``VeoProvider``, ``ImagenProvider``, and
+``GeminiImageProvider``. Each provider attaches this callable to its
+``ModelFamily`` instances and forwards its lazy-built genai client via
+``_invoke_family_probe``.
 """
 
 from __future__ import annotations

--- a/libs/connectors/google/genblaze_google/gemini_image.py
+++ b/libs/connectors/google/genblaze_google/gemini_image.py
@@ -6,9 +6,9 @@ image bytes in ``candidates[].content.parts[].inline_data``, NOT the
 pattern widening of Imagen — see issue #205.
 
 **Why this provider exists:** on a freshly created Gemini API key, every
-``imagen-*`` slug 404s "no longer available to new users" (an account
-entitlement gate — see ``ImagenProvider.validate_model`` / issue #206). The
-Gemini-native ``*-image`` line (``gemini-2.5-flash-image``,
+currently-cataloged ``imagen-4.0-*`` slug 404s "no longer available to new
+users" (an account entitlement gate — see ``ImagenProvider.validate_model``
+/ issue #206). The Gemini-native ``*-image`` line (``gemini-2.5-flash-image``,
 ``gemini-3.1-flash-image``, etc.) speaks ``generateContent`` instead of
 ``:predict`` and has no reported entitlement gap, making it the only
 image path a new key can actually call.
@@ -16,7 +16,8 @@ image path a new key can actually call.
 **Catalog architecture:** ships the pattern-keyed ``google-gemini-image``
 family (``^gemini-.*-image``, deliberately excludes chat models like
 ``gemini-2.5-flash``). Uses the same ``google_models_get_probe`` as Imagen,
-but with no known entitlement gap it needs no ``validate_model`` re-grade.
+but with no known entitlement gap it needs no ``ImagenProvider``-style
+``validate_model`` re-grade.
 
 Docs: https://ai.google.dev/gemini-api/docs/image-generation
 """

--- a/libs/connectors/google/genblaze_google/gemini_image.py
+++ b/libs/connectors/google/genblaze_google/gemini_image.py
@@ -7,7 +7,7 @@ pattern widening of Imagen — see issue #205.
 
 **Why this provider exists:** on a freshly created Gemini API key, every
 ``imagen-*`` slug 404s "no longer available to new users" (an account
-entitlement gate — see ``google_imagen_predict_probe`` / issue #206). The
+entitlement gate — see ``ImagenProvider.validate_model`` / issue #206). The
 Gemini-native ``*-image`` line (``gemini-2.5-flash-image``,
 ``gemini-3.1-flash-image``, etc.) speaks ``generateContent`` instead of
 ``:predict`` and has no reported entitlement gap, making it the only
@@ -15,8 +15,8 @@ image path a new key can actually call.
 
 **Catalog architecture:** ships the pattern-keyed ``google-gemini-image``
 family (``^gemini-.*-image``, deliberately excludes chat models like
-``gemini-2.5-flash``). No known entitlement gap for this family, so it
-uses the plain ``google_models_get_probe`` (unlike Imagen).
+``gemini-2.5-flash``). Uses the same ``google_models_get_probe`` as Imagen,
+but with no known entitlement gap it needs no ``validate_model`` re-grade.
 
 Docs: https://ai.google.dev/gemini-api/docs/image-generation
 """

--- a/libs/connectors/google/genblaze_google/imagen.py
+++ b/libs/connectors/google/genblaze_google/imagen.py
@@ -4,14 +4,15 @@ Synchronous API: client.models.generate_images() returns images directly.
 
 **Catalog architecture (genblaze-core 0.3.0):** the SDK ships the
 pattern-keyed ``google-imagen`` family (``^imagen-``) instead of a
-hardcoded slug list. Liveness comes from ``google_imagen_predict_probe``
-via the family probe: ``client.models.get(model=slug)`` for catalog
-membership, plus a deliberately invalid ``generate_images`` call to
-distinguish catalog membership from account entitlement (imagen-4.0-*
-is catalog-listed but 404s "no longer available to new users" for new
-keys — issue #206), so dead / unentitled slugs surface at preflight
-rather than mid-call. If your account has no Imagen access, see
-``GeminiImageProvider`` for the Gemini-native image line instead.
+hardcoded slug list. Liveness comes from ``google_models_get_probe``
+(``client.models.get(model=slug)``), so dead slugs surface at preflight
+rather than mid-call. ``models.get`` only proves catalog membership, not
+account entitlement: imagen-4.0-* are catalog-listed but 404 "no longer
+available to new users" for new keys (issue #206). Rather than spend a
+billable ``:predict`` call to probe entitlement, ``validate_model``
+re-grades those known-gated slugs to ``OK_PROVISIONAL``. If your account
+has no Imagen access, see ``GeminiImageProvider`` for the Gemini-native
+image line instead.
 
 **Pricing**: per-image-by-model rates were dropped in 0.3.0. See
 ``docs/reference/pricing-recipes.md`` for the canonical Imagen
@@ -60,7 +61,8 @@ class ImagenProvider(GoogleClientMixin, SyncProvider):
     Models match the ``google-imagen`` family (``^imagen-``). Current
     examples: ``imagen-4.0-generate-001``, ``imagen-4.0-fast-generate-001``
     — catalog-listed, but entitlement-gated for accounts without Imagen
-    access (new Gemini API keys as of 2026-07; see ``google_imagen_predict_probe``).
+    access (new Gemini API keys as of 2026-07; ``validate_model`` re-grades
+    these to ``OK_PROVISIONAL``).
 
     Imagen returns image bytes directly (synchronous, not operation-based).
     Output is saved to files; use ObjectStorageSink for cloud upload.

--- a/libs/connectors/google/genblaze_google/imagen.py
+++ b/libs/connectors/google/genblaze_google/imagen.py
@@ -80,10 +80,10 @@ class ImagenProvider(GoogleClientMixin, SyncProvider):
 
     name = "google-imagen"
     discovery_support = DiscoverySupport.PARTIAL
-    """google-genai exposes ``client.models.get`` per-slug; that's the
-    authoritative liveness signal. There's no Imagen-only catalog
-    listing endpoint, so we stay PARTIAL and rely on the family
-    probe."""
+    """google-genai exposes ``client.models.get`` per-slug; that's
+    authoritative for catalog membership (not account entitlement —
+    see ``validate_model``). There's no Imagen-only catalog listing
+    endpoint, so we stay PARTIAL and rely on the family probe."""
 
     @classmethod
     def create_registry(cls) -> ModelRegistry:


### PR DESCRIPTION
## What

Doc-only follow-up to **#220** (Gemini-native image provider + Imagen entitlement handling, #205/#206). That PR shipped docstrings and a comment referencing `google_imagen_predict_probe` — a **billable `:predict` entitlement probe that the final Option-A design deliberately removed**. The name exists nowhere in the code.

The shipped implementation actually uses:
- `google_models_get_probe` — a **non-billable** `client.models.get(model=slug)` catalog-membership probe (wired in `_families.py`), and
- `ImagenProvider.validate_model` — re-grades known-gated `imagen-4.0-*` slugs from `OK_AUTHORITATIVE` to `OK_PROVISIONAL` (a warn, no spend).

So the shipped docs described a symbol that doesn't exist and an API spend the code was written to avoid.

## Changes (prose only, no logic)

- `imagen.py` — module + class docstrings now describe `google_models_get_probe` + the `validate_model` `OK_PROVISIONAL` re-grade.
- `gemini_image.py` — cross-reference points at `ImagenProvider.validate_model`; corrected the note that wrongly implied Imagen uses a *different* probe (it uses the same one, differing only by the `validate_model` re-grade).
- `_errors.py` — comment reframed: under `OK_PROVISIONAL`, an unentitled slug is *expected* to reach call time, so the `MODEL_ERROR` mapping is the primary enforcement point, not a "slips through" backstop.

## Review

Ran a 5-perspective panel (3 Claude lenses + 2 Codex passes). Both Codex passes approved; all three Claude lenses independently flagged the `_errors.py` framing (fixed). One lens caught the `gemini_image.py` probe inaccuracy (fixed).

## Verification

- `ruff check` clean
- `128 passed, 10 skipped` (google connector suite)
- Whole-tree grep confirms `google_imagen_predict_probe` no longer appears anywhere.

Refs #206