### PR TITLE
feat(chat): opt-in rate-limit backoff for chat()/vision helpers (#221)

### DIFF
--- a/docs/features/llm-calls.md
+++ b/docs/features/llm-calls.md
@@ -79,10 +79,24 @@ resp = chat("gpt-4o-mini", messages=frame_messages, retry_on_rate_limit=True)
 ```
 
 Pass a `genblaze_core.providers.retry.RetryPolicy` via `retry_policy=` to tune
-the attempt cap or backoff timing (passing `retry_policy=` alone, without
-`retry_on_rate_limit=True`, also opts in). `achat()` accepts the same kwargs —
-the retry wait happens inside the worker thread `achat` already runs in, so it
-never blocks the event loop.
+the attempt cap, retryable-code set, or backoff timing (passing `retry_policy=`
+alone, without `retry_on_rate_limit=True`, also opts in). `achat()` accepts the
+same kwargs — the retry wait happens inside the worker thread `achat` already
+runs in, so it never blocks the event loop.
+
+**Known limits of this opt-in loop:**
+
+- **Bounded but not tiny.** Worst case is `(max_attempts - 1) *
+  MAX_RETRY_AFTER_SEC` — with the default policy (6 attempts, 120s cap), that's
+  up to ~10 minutes if a misbehaving upstream returns the maximum `Retry-After`
+  hint on every attempt. Pass a tighter `retry_policy=RetryPolicy(max_attempts=2)`
+  if that's unacceptable for your call site.
+- **Not a rate limiter.** This is a per-call retry wrapper, not a shared
+  token-bucket / queue-level limiter. Many concurrent callers hitting the same
+  TPM ceiling all see the same server `Retry-After` hint and wake in lockstep,
+  which can immediately re-trip the limit. For sustained, high-concurrency
+  archive runs, pace calls externally (e.g. a semaphore or a queue) in addition
+  to (not instead of) `retry_on_rate_limit=True`.
 
 ## Limits (v1)
 

--- a/docs/features/llm-calls.md
+++ b/docs/features/llm-calls.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-24 -->
+<!-- last_verified: 2026-07-28 -->
 # Feature: LLM Calls
 
 Thin standalone wrappers around OpenAI, Google Gemini, and GMICloud chat /
@@ -33,6 +33,8 @@ chat(
     max_tokens: int | None = None,
     api_key: str | None = None,
     client: Any = None,        # escape hatch
+    retry_on_rate_limit: bool = False,   # openai / google only — see "Rate limits" below
+    retry_policy: RetryPolicy | None = None,
     **kwargs,
 ) -> ChatResponse
 ```
@@ -55,6 +57,32 @@ Compose with a media step manually:
 description = chat("gpt-4o", prompt="A cinematic sunset").text
 pipe = Pipeline("hero").step(SoraProvider(), model="sora-2", prompt=description)
 ```
+
+## Rate limits
+
+**These helpers do not retry by default.** A 429 raises immediately — the
+`ProviderError` carries a parsed `retry_after` hint (seconds), but callers
+must act on it themselves. At archive scale (e.g. many vision calls over
+video frames) this is the common case, not an edge case.
+
+For `genblaze_openai.chat`/`achat` and `genblaze_google.chat`/`achat`, pass
+`retry_on_rate_limit=True` to opt in to a bounded wait-and-retry loop that
+honors the server's `Retry-After` hint (falling back to exponential backoff
+with jitter when no hint is present):
+
+```python
+from genblaze_openai import chat
+
+# Retries up to RetryPolicy()'s default 6 attempts, honoring each 429's
+# `Retry-After` hint before raising.
+resp = chat("gpt-4o-mini", messages=frame_messages, retry_on_rate_limit=True)
+```
+
+Pass a `genblaze_core.providers.retry.RetryPolicy` via `retry_policy=` to tune
+the attempt cap or backoff timing (passing `retry_policy=` alone, without
+`retry_on_rate_limit=True`, also opts in). `achat()` accepts the same kwargs —
+the retry wait happens inside the worker thread `achat` already runs in, so it
+never blocks the event loop.
 
 ## Limits (v1)
 

--- a/docs/features/llm-calls.md
+++ b/docs/features/llm-calls.md
@@ -79,18 +79,26 @@ resp = chat("gpt-4o-mini", messages=frame_messages, retry_on_rate_limit=True)
 ```
 
 Pass a `genblaze_core.providers.retry.RetryPolicy` via `retry_policy=` to tune
-the attempt cap, retryable-code set, or backoff timing (passing `retry_policy=`
-alone, without `retry_on_rate_limit=True`, also opts in). `achat()` accepts the
-same kwargs — the retry wait happens inside the worker thread `achat` already
-runs in, so it never blocks the event loop.
+the attempt cap or backoff timing (passing `retry_policy=` alone, without
+`retry_on_rate_limit=True`, also opts in). `retry_policy.retryable_codes` can
+only *narrow* retry here — e.g. `RetryPolicy.disabled()` turns retry off
+entirely — it cannot broaden retry to other error codes; this loop only ever
+acts on `RATE_LIMIT`, by design, regardless of what `retryable_codes` contains.
+`achat()` accepts the same kwargs — the retry wait happens inside the worker
+thread `achat` already runs in, so it never blocks the event loop.
 
 **Known limits of this opt-in loop:**
 
-- **Bounded but not tiny.** Worst case is `(max_attempts - 1) *
-  MAX_RETRY_AFTER_SEC` — with the default policy (6 attempts, 120s cap), that's
-  up to ~10 minutes if a misbehaving upstream returns the maximum `Retry-After`
-  hint on every attempt. Pass a tighter `retry_policy=RetryPolicy(max_attempts=2)`
-  if that's unacceptable for your call site.
+- **Bounded but not tiny — and only at this layer.** Worst case here is
+  `(max_attempts - 1) * MAX_RETRY_AFTER_SEC` — with the default policy (6
+  attempts, 120s cap), that's up to ~10 minutes if a misbehaving upstream
+  returns the maximum `Retry-After` hint on every attempt. For
+  `genblaze_openai`, the OpenAI SDK client also retries transient errors on
+  its own (`max_retries=2` by default) *underneath* this loop, so the actual
+  worst case is higher than the bound above; pass `client=openai.OpenAI(max_retries=0)`
+  if you want this loop's bound to be exact. Pass a tighter
+  `retry_policy=RetryPolicy(max_attempts=2)` if the documented bound is
+  already unacceptable for your call site.
 - **Not a rate limiter.** This is a per-call retry wrapper, not a shared
   token-bucket / queue-level limiter. Many concurrent callers hitting the same
   TPM ceiling all see the same server `Retry-After` hint and wake in lockstep,

--- a/libs/connectors/google/genblaze_google/_errors.py
+++ b/libs/connectors/google/genblaze_google/_errors.py
@@ -15,7 +15,11 @@ def map_google_error(exc: Exception) -> ProviderErrorCode:
     # dead slug.
     if "no longer available to new users" in msg:
         return ProviderErrorCode.MODEL_ERROR
-    if "rate" in msg or "429" in msg or "resource_exhausted" in msg:
+    # Bare "rate" collides with "generate"/"generateContent" (this call's own
+    # method name shows up in most SDK error strings) — match on "rate limit" /
+    # "rate_limit" instead, same predicate genblaze_core's own classify_api_error
+    # uses (providers/base.py).
+    if "rate limit" in msg or "rate_limit" in msg or "429" in msg or "resource_exhausted" in msg:
         return ProviderErrorCode.RATE_LIMIT
     # Gemini / Imagen safety block — deterministic refusal, never retryable.
     # Surfaces as "safety", "blocked", "responsibleai", or "content_filter"

--- a/libs/connectors/google/genblaze_google/chat.py
+++ b/libs/connectors/google/genblaze_google/chat.py
@@ -20,7 +20,11 @@ from genblaze_core.models.chat import (
     ToolCall,
 )
 from genblaze_core.models.enums import ProviderErrorCode
-from genblaze_core.providers.retry import retry_after_from_response
+from genblaze_core.providers.retry import (
+    RetryPolicy,
+    call_with_rate_limit_retry,
+    retry_after_from_response,
+)
 
 from genblaze_google._errors import map_google_error
 
@@ -215,6 +219,8 @@ def chat(
     project: str | None = None,
     location: str = "us-central1",
     client: Any = None,
+    retry_on_rate_limit: bool = False,
+    retry_policy: RetryPolicy | None = None,
     **kwargs: Any,
 ) -> ChatResponse:
     """Call a Google Gemini model and return a uniform `ChatResponse`.
@@ -230,10 +236,18 @@ def chat(
         project: GCP project for Vertex AI auth (mutually exclusive with api_key).
         location: GCP region for Vertex AI.
         client: Pre-built `google.genai.Client` — escape hatch for tests.
+        retry_on_rate_limit: When ``True``, a 429 wait-and-retry using the
+            server's ``Retry-After`` hint (falling back to exponential backoff)
+            instead of raising immediately. Off by default — existing callers
+            see no behavior change. See ``docs/features/llm-calls.md``.
+        retry_policy: Optional ``RetryPolicy`` controlling attempt cap / backoff
+            when ``retry_on_rate_limit=True`` (or passed on its own to opt in
+            implicitly). Defaults to ``RetryPolicy()`` (6 attempts).
         **kwargs: Extra keys merged into the `generation_config`.
 
     Raises:
         ProviderError: With a classified `error_code` for any SDK exception.
+            Re-raised once retries (if enabled) are exhausted.
     """
     own_client = client is None
     if own_client:
@@ -268,20 +282,28 @@ def chat(
     if gen_config:
         call_kwargs["config"] = gen_config
 
+    def _invoke() -> Any:
+        try:
+            return client.models.generate_content(**call_kwargs)
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"Gemini chat failed: {exc}",
+                error_code=map_google_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc
+
     try:
-        raw = client.models.generate_content(**call_kwargs)
-    except ProviderError:
-        raise
-    except Exception as exc:
-        raise ProviderError(
-            f"Gemini chat failed: {exc}",
-            error_code=map_google_error(exc),
-            retry_after=retry_after_from_response(exc),
-        ) from exc
+        if retry_on_rate_limit or retry_policy is not None:
+            raw = call_with_rate_limit_retry(_invoke, policy=retry_policy)
+        else:
+            raw = _invoke()
     finally:
         if own_client:
             # Best-effort close — not all google-genai versions expose close(),
-            # so probe via hasattr to stay compatible.
+            # so probe via hasattr to stay compatible. Closed once here (not
+            # per attempt) so the client stays open across retries.
             close_fn = getattr(client, "close", None)
             if callable(close_fn):
                 close_fn()
@@ -294,5 +316,10 @@ async def achat(
     messages: list[ChatMessage] | list[dict] | None = None,
     **kwargs: Any,
 ) -> ChatResponse:
-    """Async wrapper around `chat()`. Runs in a worker thread (matches `BaseProvider.ainvoke`)."""
+    """Async wrapper around `chat()`. Runs in a worker thread (matches `BaseProvider.ainvoke`).
+
+    Accepts the same `retry_on_rate_limit` / `retry_policy` kwargs as `chat()`.
+    Any backoff sleep happens inside the worker thread, so it never blocks the
+    event loop — no separate async retry path is needed.
+    """
     return await asyncio.to_thread(chat, model, messages, **kwargs)

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -314,3 +314,124 @@ def test_cost_usd_always_none(mock_client):
 def test_achat_runs_in_thread(mock_client):
     resp = asyncio.run(achat("gemini-2.5-flash", prompt="hi", client=mock_client))
     assert resp.text == "Hello!"
+
+
+# --- Opt-in rate-limit backoff (#221) ---
+#
+# `chat()`/`achat()` already parse a 429's `Retry-After` hint onto
+# `ProviderError.retry_after`; these tests cover the opt-in wait-and-retry
+# loop built on top of that (`genblaze_core.providers.retry.call_with_rate_limit_retry`).
+# `time.sleep` is patched at its source in `genblaze_core.providers.retry` so
+# tests never actually block, and so we can assert the delay used.
+
+
+def test_default_does_not_retry_on_rate_limit(mock_client, monkeypatch):
+    """Opt-out is the default — an unadorned `chat()` call must still raise on the
+    first 429, with no sleep and no second attempt."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.models.generate_content.side_effect = ProviderError(
+        "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.5
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat("gemini-2.5-flash", prompt="hi", client=mock_client)
+
+    assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
+    assert mock_client.models.generate_content.call_count == 1
+    assert sleeps == []
+
+
+def test_retry_on_rate_limit_waits_then_succeeds(mock_client, monkeypatch):
+    """`retry_on_rate_limit=True` waits the server's `Retry-After` hint, then retries."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.models.generate_content.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.5),
+        _mock_response(),
+    ]
+
+    resp = chat("gemini-2.5-flash", prompt="hi", client=mock_client, retry_on_rate_limit=True)
+
+    assert resp.text == "Hello!"
+    assert mock_client.models.generate_content.call_count == 2
+    assert sleeps == [0.5]  # server hint honored verbatim, not a computed backoff
+
+
+def test_retry_on_rate_limit_raises_after_attempt_cap(mock_client, monkeypatch):
+    """After `max_attempts`, the last rate-limit error still propagates."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", lambda _s: None)
+    mock_client.models.generate_content.side_effect = ProviderError(
+        "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat(
+            "gemini-2.5-flash",
+            prompt="hi",
+            client=mock_client,
+            retry_on_rate_limit=True,
+            retry_policy=RetryPolicy(max_attempts=3),
+        )
+
+    assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
+    assert mock_client.models.generate_content.call_count == 3
+
+
+def test_retry_policy_alone_opts_in_without_the_flag(mock_client, monkeypatch):
+    """Passing `retry_policy=` implies opt-in even without `retry_on_rate_limit=True`."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.models.generate_content.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.2),
+        _mock_response(),
+    ]
+
+    resp = chat(
+        "gemini-2.5-flash",
+        prompt="hi",
+        client=mock_client,
+        retry_policy=RetryPolicy(max_attempts=4),
+    )
+
+    assert resp.text == "Hello!"
+    assert sleeps == [0.2]
+
+
+def test_retry_on_rate_limit_does_not_retry_other_error_codes(mock_client, monkeypatch):
+    """Only RATE_LIMIT is eligible — a content-policy error still fails fast even
+    with retries enabled."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.models.generate_content.side_effect = ProviderError(
+        "blocked", error_code=ProviderErrorCode.CONTENT_POLICY
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat("gemini-2.5-flash", prompt="hi", client=mock_client, retry_on_rate_limit=True)
+
+    assert exc.value.error_code == ProviderErrorCode.CONTENT_POLICY
+    assert mock_client.models.generate_content.call_count == 1
+    assert sleeps == []
+
+
+def test_achat_retry_on_rate_limit(mock_client, monkeypatch):
+    """`achat()` forwards retry kwargs through to `chat()` via `asyncio.to_thread`."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.models.generate_content.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.3),
+        _mock_response(),
+    ]
+
+    resp = asyncio.run(
+        achat("gemini-2.5-flash", prompt="hi", client=mock_client, retry_on_rate_limit=True)
+    )
+
+    assert resp.text == "Hello!"
+    assert mock_client.models.generate_content.call_count == 2
+    assert sleeps == [0.3]

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -316,6 +316,35 @@ def test_achat_runs_in_thread(mock_client):
     assert resp.text == "Hello!"
 
 
+def test_internally_created_client_closed_once_across_retries(monkeypatch):
+    """The client must be created once, reused across every retry attempt, and
+    closed exactly once after the loop finishes — not per-attempt (#221)."""
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", lambda _s: None)
+    fake_google = MagicMock()
+    created_clients: list[MagicMock] = []
+
+    def _client_factory(**_kwargs):
+        c = MagicMock()
+        c.models.generate_content.side_effect = [
+            ProviderError(
+                "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+            ),
+            _mock_response(),
+        ]
+        created_clients.append(c)
+        return c
+
+    fake_google.genai.Client.side_effect = _client_factory
+    monkeypatch.setitem(__import__("sys").modules, "google", fake_google)
+
+    resp = chat("gemini-2.5-flash", prompt="hi", api_key="test-key", retry_on_rate_limit=True)
+
+    assert resp.text == "Hello!"
+    assert fake_google.genai.Client.call_count == 1  # one client for the whole retry loop
+    assert created_clients[0].models.generate_content.call_count == 2
+    created_clients[0].close.assert_called_once()
+
+
 # --- Opt-in rate-limit backoff (#221) ---
 #
 # `chat()`/`achat()` already parse a 429's `Retry-After` hint onto

--- a/libs/connectors/google/tests/test_error_mapping.py
+++ b/libs/connectors/google/tests/test_error_mapping.py
@@ -30,6 +30,20 @@ def test_rate_limit_still_classifies():
     assert map_google_error(Exception("RESOURCE_EXHAUSTED 429")) == ProviderErrorCode.RATE_LIMIT
 
 
+def test_generate_content_kwarg_error_not_misclassified_as_rate_limit():
+    """ "rate" is a substring of "generate"/"generateContent" — a bare `"rate" in msg`
+    check would wrongly retry this deterministic TypeError as a 429 (#221 follow-up)."""
+    exc = TypeError("generate_content() got an unexpected keyword argument 'foo'")
+    assert map_google_error(exc) != ProviderErrorCode.RATE_LIMIT
+
+
+def test_model_not_found_for_generate_content_not_misclassified_as_rate_limit():
+    exc = Exception(
+        "404 NOT_FOUND. models/gemini-x is not found or is not supported for generateContent."
+    )
+    assert map_google_error(exc) != ProviderErrorCode.RATE_LIMIT
+
+
 def test_auth_failure():
     assert map_google_error(Exception("403 permission denied")) == ProviderErrorCode.AUTH_FAILURE
 

--- a/libs/connectors/openai/genblaze_openai/chat.py
+++ b/libs/connectors/openai/genblaze_openai/chat.py
@@ -11,7 +11,11 @@ from typing import Any
 from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.chat import ChatMessage, ChatResponse, ToolCall, coerce_response_format
 from genblaze_core.models.enums import ProviderErrorCode
-from genblaze_core.providers.retry import retry_after_from_response
+from genblaze_core.providers.retry import (
+    RetryPolicy,
+    call_with_rate_limit_retry,
+    retry_after_from_response,
+)
 
 from genblaze_openai._errors import map_openai_error
 
@@ -118,6 +122,8 @@ def chat(
     base_url: str | None = None,
     timeout: float = 60.0,
     client: Any = None,
+    retry_on_rate_limit: bool = False,
+    retry_policy: RetryPolicy | None = None,
     **kwargs: Any,
 ) -> ChatResponse:
     """Call an OpenAI chat / completion model and return a uniform `ChatResponse`.
@@ -139,10 +145,18 @@ def chat(
         client: Pre-built `openai.OpenAI` instance — escape hatch for tests
             and custom clients. When supplied, its lifecycle is the caller's
             (we won't close it).
+        retry_on_rate_limit: When ``True``, a 429 wait-and-retry using the
+            server's ``Retry-After`` hint (falling back to exponential backoff)
+            instead of raising immediately. Off by default — existing callers
+            see no behavior change. See ``docs/features/llm-calls.md``.
+        retry_policy: Optional ``RetryPolicy`` controlling attempt cap / backoff
+            when ``retry_on_rate_limit=True`` (or passed on its own to opt in
+            implicitly). Defaults to ``RetryPolicy()`` (6 attempts).
         **kwargs: Forwarded to `client.chat.completions.create`.
 
     Raises:
         ProviderError: With a classified `error_code` for any SDK exception.
+            Re-raised once retries (if enabled) are exhausted.
 
     Performance note:
         For high-throughput callers (many chat calls in a tight loop), pass a
@@ -177,20 +191,28 @@ def chat(
         payload["response_format"] = coerce_response_format(response_format)
     payload.update(kwargs)
 
+    def _invoke() -> Any:
+        try:
+            return client.chat.completions.create(**payload)
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"OpenAI chat failed: {exc}",
+                error_code=map_openai_error(exc),
+                retry_after=retry_after_from_response(exc),
+            ) from exc
+
     try:
-        raw = client.chat.completions.create(**payload)
-    except ProviderError:
-        raise
-    except Exception as exc:
-        raise ProviderError(
-            f"OpenAI chat failed: {exc}",
-            error_code=map_openai_error(exc),
-            retry_after=retry_after_from_response(exc),
-        ) from exc
+        if retry_on_rate_limit or retry_policy is not None:
+            raw = call_with_rate_limit_retry(_invoke, policy=retry_policy)
+        else:
+            raw = _invoke()
     finally:
         if own_client:
             # Best-effort close — matches the GMI chat pattern and prevents
-            # httpx transport leaks on high-throughput callers.
+            # httpx transport leaks on high-throughput callers. Closed once
+            # here (not per attempt) so the client stays open across retries.
             close_fn = getattr(client, "close", None)
             if callable(close_fn):
                 close_fn()
@@ -208,5 +230,9 @@ async def achat(
     Matches the in-tree `BaseProvider.ainvoke` pattern (uses `asyncio.to_thread`
     rather than the SDK's native async client) for consistency. Switch to
     `openai.AsyncOpenAI` here if true async I/O ever shows up in profiling.
+
+    Accepts the same `retry_on_rate_limit` / `retry_policy` kwargs as `chat()`.
+    Any backoff sleep happens inside the worker thread, so it never blocks the
+    event loop — no separate async retry path is needed.
     """
     return await asyncio.to_thread(chat, model, messages, **kwargs)

--- a/libs/connectors/openai/tests/test_chat.py
+++ b/libs/connectors/openai/tests/test_chat.py
@@ -236,6 +236,35 @@ def test_internally_created_client_is_closed(monkeypatch):
     created_clients[0].close.assert_called_once()
 
 
+def test_internally_created_client_closed_once_across_retries(monkeypatch):
+    """The client must be created once, reused across every retry attempt, and
+    closed exactly once after the loop finishes — not per-attempt (#221)."""
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", lambda _s: None)
+    fake_openai = MagicMock()
+    created_clients: list[MagicMock] = []
+
+    def _client_factory(**_kwargs):
+        c = MagicMock()
+        c.chat.completions.create.side_effect = [
+            ProviderError(
+                "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+            ),
+            _mock_completion(),
+        ]
+        created_clients.append(c)
+        return c
+
+    fake_openai.OpenAI.side_effect = _client_factory
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+
+    resp = chat("gpt-4o", prompt="hi", api_key="sk-test", retry_on_rate_limit=True)
+
+    assert resp.text == "Hello!"
+    assert fake_openai.OpenAI.call_count == 1  # one client for the whole retry loop
+    assert created_clients[0].chat.completions.create.call_count == 2
+    created_clients[0].close.assert_called_once()
+
+
 def test_base_url_forwarded_to_sdk(monkeypatch):
     fake_openai = MagicMock()
     fake_openai.OpenAI.return_value.chat.completions.create.return_value = _mock_completion()

--- a/libs/connectors/openai/tests/test_chat.py
+++ b/libs/connectors/openai/tests/test_chat.py
@@ -265,3 +265,121 @@ def test_achat_runs_in_thread(mock_client):
 
     resp = asyncio.run(achat("gpt-4o", prompt="hi", client=mock_client))
     assert resp.text == "Hello!"
+
+
+# --- Opt-in rate-limit backoff (#221) ---
+#
+# `chat()`/`achat()` already parse a 429's `Retry-After` hint onto
+# `ProviderError.retry_after`; these tests cover the opt-in wait-and-retry
+# loop built on top of that (`genblaze_core.providers.retry.call_with_rate_limit_retry`).
+# `time.sleep` is patched at its source in `genblaze_core.providers.retry` so
+# tests never actually block, and so we can assert the delay used.
+
+
+def test_default_does_not_retry_on_rate_limit(mock_client, monkeypatch):
+    """Opt-out is the default — an unadorned `chat()` call must still raise on the
+    first 429, with no sleep and no second attempt."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.chat.completions.create.side_effect = ProviderError(
+        "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.5
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat("gpt-4o", prompt="hi", client=mock_client)
+
+    assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
+    assert mock_client.chat.completions.create.call_count == 1
+    assert sleeps == []
+
+
+def test_retry_on_rate_limit_waits_then_succeeds(mock_client, monkeypatch):
+    """`retry_on_rate_limit=True` waits the server's `Retry-After` hint, then retries."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.chat.completions.create.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.5),
+        _mock_completion(),
+    ]
+
+    resp = chat("gpt-4o", prompt="hi", client=mock_client, retry_on_rate_limit=True)
+
+    assert resp.text == "Hello!"
+    assert mock_client.chat.completions.create.call_count == 2
+    assert sleeps == [0.5]  # server hint honored verbatim, not a computed backoff
+
+
+def test_retry_on_rate_limit_raises_after_attempt_cap(mock_client, monkeypatch):
+    """After `max_attempts`, the last rate-limit error still propagates."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", lambda _s: None)
+    mock_client.chat.completions.create.side_effect = ProviderError(
+        "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat(
+            "gpt-4o",
+            prompt="hi",
+            client=mock_client,
+            retry_on_rate_limit=True,
+            retry_policy=RetryPolicy(max_attempts=3),
+        )
+
+    assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
+    assert mock_client.chat.completions.create.call_count == 3
+
+
+def test_retry_policy_alone_opts_in_without_the_flag(mock_client, monkeypatch):
+    """Passing `retry_policy=` implies opt-in even without `retry_on_rate_limit=True`."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.chat.completions.create.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.2),
+        _mock_completion(),
+    ]
+
+    resp = chat(
+        "gpt-4o", prompt="hi", client=mock_client, retry_policy=RetryPolicy(max_attempts=4)
+    )
+
+    assert resp.text == "Hello!"
+    assert sleeps == [0.2]
+
+
+def test_retry_on_rate_limit_does_not_retry_other_error_codes(mock_client, monkeypatch):
+    """Only RATE_LIMIT is eligible — a content-policy error still fails fast even
+    with retries enabled."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.chat.completions.create.side_effect = ProviderError(
+        "blocked", error_code=ProviderErrorCode.CONTENT_POLICY
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        chat("gpt-4o", prompt="hi", client=mock_client, retry_on_rate_limit=True)
+
+    assert exc.value.error_code == ProviderErrorCode.CONTENT_POLICY
+    assert mock_client.chat.completions.create.call_count == 1
+    assert sleeps == []
+
+
+def test_achat_retry_on_rate_limit(mock_client, monkeypatch):
+    """`achat()` forwards retry kwargs through to `chat()` via `asyncio.to_thread`."""
+    import asyncio
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("genblaze_core.providers.retry.time.sleep", sleeps.append)
+    mock_client.chat.completions.create.side_effect = [
+        ProviderError("rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.3),
+        _mock_completion(),
+    ]
+
+    resp = asyncio.run(achat("gpt-4o", prompt="hi", client=mock_client, retry_on_rate_limit=True))
+
+    assert resp.text == "Hello!"
+    assert mock_client.chat.completions.create.call_count == 2
+    assert sleeps == [0.3]

--- a/libs/core/genblaze_core/providers/__init__.py
+++ b/libs/core/genblaze_core/providers/__init__.py
@@ -72,6 +72,7 @@ from genblaze_core.providers.retry import (
     MAX_RETRY_AFTER_SEC,
     PRE_RESPONSE_EXCEPTIONS,
     RetryPolicy,
+    call_with_rate_limit_retry,
     retry_after_from_response,
 )
 from genblaze_core.providers.spec import (
@@ -134,6 +135,7 @@ __all__ = [
     "bucketed_by_duration",
     "by_model_and_param",
     "by_param",
+    "call_with_rate_limit_retry",
     "chain_routers",
     "compute_cost",
     "discover_providers",

--- a/libs/core/genblaze_core/providers/retry.py
+++ b/libs/core/genblaze_core/providers/retry.py
@@ -10,6 +10,7 @@ keep working unchanged.
 
 from __future__ import annotations
 
+import logging
 import random
 import time
 import uuid
@@ -24,6 +25,8 @@ from genblaze_core.models.enums import ProviderErrorCode
 
 if TYPE_CHECKING:
     from genblaze_core.models.step import Step
+
+logger = logging.getLogger("genblaze.provider")
 
 _T = TypeVar("_T")
 
@@ -291,7 +294,9 @@ def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | No
     Raises:
         ProviderError: Re-raised once attempts are exhausted, or immediately
             if the error isn't classified as ``RATE_LIMIT`` (or the policy
-            doesn't consider ``RATE_LIMIT`` retryable).
+            doesn't consider ``RATE_LIMIT`` retryable). ``exc.attempts`` is
+            set to the number of attempts made before re-raising, matching
+            ``BaseProvider``'s pipeline retry loop.
     """
     policy = policy or RetryPolicy()
     attempt = 1
@@ -302,8 +307,11 @@ def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | No
             if exc.error_code != ProviderErrorCode.RATE_LIMIT or not policy.should_retry(
                 exc.error_code, attempt
             ):
+                exc.attempts = attempt
                 raise
-            time.sleep(policy.compute_delay(attempt, retry_after=exc.retry_after))
+            delay = policy.compute_delay(attempt, retry_after=exc.retry_after)
+            logger.warning("rate-limit retry %d/%d in %.1fs", attempt, policy.max_attempts, delay)
+            time.sleep(delay)
             attempt += 1
 
 

--- a/libs/core/genblaze_core/providers/retry.py
+++ b/libs/core/genblaze_core/providers/retry.py
@@ -256,11 +256,24 @@ def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | No
     ``BaseProvider``'s pipeline retry loop (``RetryPolicy.compute_delay`` —
     server hint wins when present, else exponential backoff with jitter).
 
-    Only ``ProviderErrorCode.RATE_LIMIT`` is retried here, regardless of
-    ``policy.retryable_codes`` — this helper exists to fix 429 backoff
-    specifically, not to become a general retry wrapper for the convenience
-    helpers. Any other exception (including other ``ProviderError`` codes)
-    propagates on the first attempt.
+    Narrowed to ``ProviderErrorCode.RATE_LIMIT`` — this helper exists to fix
+    429 backoff specifically, not to become a general retry wrapper for the
+    convenience helpers — but still defers to ``policy.should_retry`` (which
+    checks both ``policy.retryable_codes`` membership and the ``max_attempts``
+    budget) rather than hardcoding the attempt-cap check. A caller who passes
+    a ``policy`` with ``RATE_LIMIT`` excluded from ``retryable_codes`` (e.g.
+    ``RetryPolicy.disabled()``) gets no retry, same as they would on the
+    ``BaseProvider`` pipeline path. Any other exception (including other
+    ``ProviderError`` codes) propagates on the first attempt.
+
+    Bounded worst case: total wait is at most ``(max_attempts - 1) *
+    MAX_RETRY_AFTER_SEC`` — with the default policy (6 attempts), up to ~10
+    minutes if a misbehaving upstream returns the maximum ``Retry-After`` hint
+    on every attempt. There's no wall-clock deadline gate (unlike
+    ``BaseProvider``'s pipeline retry, which bails out once a step's overall
+    ``timeout`` would be exceeded) — this is a single, unscheduled call with no
+    equivalent deadline to check against. Pass a tighter ``policy`` (e.g.
+    ``max_attempts=2``) if that worst case is unacceptable for your call site.
 
     Synchronous by design: callers on the async path (``achat``) already run
     the whole sync call — including this retry loop — via
@@ -270,13 +283,15 @@ def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | No
     Args:
         fn: Zero-arg callable to invoke. Should raise ``ProviderError`` (with
             ``error_code``/``retry_after`` set) on failure.
-        policy: Controls the attempt cap and backoff timing. Defaults to
-            ``RetryPolicy()`` (6 attempts, ``Retry-After`` honored, exponential
-            + full-jitter fallback when no hint is present).
+        policy: Controls the attempt cap, retryable-code set, and backoff
+            timing. Defaults to ``RetryPolicy()`` (6 attempts, ``Retry-After``
+            honored, exponential + full-jitter fallback when no hint is
+            present).
 
     Raises:
         ProviderError: Re-raised once attempts are exhausted, or immediately
-            if the error isn't classified as ``RATE_LIMIT``.
+            if the error isn't classified as ``RATE_LIMIT`` (or the policy
+            doesn't consider ``RATE_LIMIT`` retryable).
     """
     policy = policy or RetryPolicy()
     attempt = 1
@@ -284,7 +299,9 @@ def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | No
         try:
             return fn()
         except ProviderError as exc:
-            if exc.error_code != ProviderErrorCode.RATE_LIMIT or attempt >= policy.max_attempts:
+            if exc.error_code != ProviderErrorCode.RATE_LIMIT or not policy.should_retry(
+                exc.error_code, attempt
+            ):
                 raise
             time.sleep(policy.compute_delay(attempt, retry_after=exc.retry_after))
             attempt += 1

--- a/libs/core/genblaze_core/providers/retry.py
+++ b/libs/core/genblaze_core/providers/retry.py
@@ -11,17 +11,21 @@ keep working unchanged.
 from __future__ import annotations
 
 import random
+import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from genblaze_core._utils import utc_now
+from genblaze_core.exceptions import ProviderError
 from genblaze_core.models.enums import ProviderErrorCode
 
 if TYPE_CHECKING:
     from genblaze_core.models.step import Step
+
+_T = TypeVar("_T")
 
 # Upper bound on a server-supplied Retry-After hint. A misconfigured or hostile
 # upstream should not be able to freeze the pipeline for minutes. 120s is long
@@ -240,11 +244,58 @@ class RetryPolicy:
         return None
 
 
+def call_with_rate_limit_retry(fn: Callable[[], _T], *, policy: RetryPolicy | None = None) -> _T:
+    """Run ``fn()``, retrying on rate-limited ``ProviderError`` per ``policy`` (#221).
+
+    Backs the opt-in ``retry_on_rate_limit=`` flag on the standalone
+    ``chat()``/``achat()`` convenience helpers (``genblaze_openai.chat``,
+    ``genblaze_google.chat``). Those helpers already parse a server's
+    ``Retry-After`` hint onto ``ProviderError.retry_after`` but historically
+    raised immediately instead of waiting — this wraps the single API call
+    they make and sleeps between attempts using the same backoff math as
+    ``BaseProvider``'s pipeline retry loop (``RetryPolicy.compute_delay`` —
+    server hint wins when present, else exponential backoff with jitter).
+
+    Only ``ProviderErrorCode.RATE_LIMIT`` is retried here, regardless of
+    ``policy.retryable_codes`` — this helper exists to fix 429 backoff
+    specifically, not to become a general retry wrapper for the convenience
+    helpers. Any other exception (including other ``ProviderError`` codes)
+    propagates on the first attempt.
+
+    Synchronous by design: callers on the async path (``achat``) already run
+    the whole sync call — including this retry loop — via
+    ``asyncio.to_thread``, so the blocking ``time.sleep`` here only occupies
+    the worker thread, never the event loop.
+
+    Args:
+        fn: Zero-arg callable to invoke. Should raise ``ProviderError`` (with
+            ``error_code``/``retry_after`` set) on failure.
+        policy: Controls the attempt cap and backoff timing. Defaults to
+            ``RetryPolicy()`` (6 attempts, ``Retry-After`` honored, exponential
+            + full-jitter fallback when no hint is present).
+
+    Raises:
+        ProviderError: Re-raised once attempts are exhausted, or immediately
+            if the error isn't classified as ``RATE_LIMIT``.
+    """
+    policy = policy or RetryPolicy()
+    attempt = 1
+    while True:
+        try:
+            return fn()
+        except ProviderError as exc:
+            if exc.error_code != ProviderErrorCode.RATE_LIMIT or attempt >= policy.max_attempts:
+                raise
+            time.sleep(policy.compute_delay(attempt, retry_after=exc.retry_after))
+            attempt += 1
+
+
 __all__ = [
     "MAX_RETRY_AFTER_SEC",
     "PRE_RESPONSE_EXCEPTIONS",
     "IdempotencyStrategy",
     "JitterStrategy",
     "RetryPolicy",
+    "call_with_rate_limit_retry",
     "retry_after_from_response",
 ]

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -8,6 +8,7 @@ import time
 from typing import Any, ClassVar
 from unittest.mock import patch
 
+import pytest
 from genblaze_core.models.enums import ProviderErrorCode, StepStatus
 from genblaze_core.models.step import UPSTREAM_ID_KEY, Step
 from genblaze_core.providers.base import (
@@ -998,6 +999,87 @@ def test_retry_after_parser_invalid_value() -> None:
         headers = {"Retry-After": "not-a-number"}
 
     assert retry_after_from_response(_FakeResp()) is None
+
+
+# --- call_with_rate_limit_retry (#221) ---
+#
+# Backs the opt-in `retry_on_rate_limit=` flag on the standalone chat()/achat()
+# helpers in genblaze-openai and genblaze-google. Connector-level tests cover
+# the wiring; these cover the shared decision loop in isolation.
+
+
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_honors_retry_after(mock_sleep) -> None:
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import call_with_rate_limit_retry
+
+    calls = [
+        ProviderError("429", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=2.0),
+        "ok",
+    ]
+
+    def fn():
+        result = calls.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    assert call_with_rate_limit_retry(fn) == "ok"
+    mock_sleep.assert_called_once_with(2.0)
+
+
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_raises_after_max_attempts(mock_sleep) -> None:
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import RetryPolicy, call_with_rate_limit_retry
+
+    def fn():
+        raise ProviderError("429", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1)
+
+    with pytest.raises(ProviderError) as exc:
+        call_with_rate_limit_retry(fn, policy=RetryPolicy(max_attempts=3))
+
+    assert exc.value.error_code == ProviderErrorCode.RATE_LIMIT
+    assert mock_sleep.call_count == 2  # 3 attempts, 2 waits between them
+
+
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_ignores_non_rate_limit_codes(mock_sleep) -> None:
+    """Only RATE_LIMIT is retried — every other code (and bare exceptions) fails fast."""
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import call_with_rate_limit_retry
+
+    def fn():
+        raise ProviderError("blocked", error_code=ProviderErrorCode.CONTENT_POLICY)
+
+    with pytest.raises(ProviderError) as exc:
+        call_with_rate_limit_retry(fn)
+
+    assert exc.value.error_code == ProviderErrorCode.CONTENT_POLICY
+    mock_sleep.assert_not_called()
+
+
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_falls_back_to_computed_backoff(mock_sleep) -> None:
+    """No Retry-After hint — falls back to RetryPolicy's exponential+jitter backoff,
+    same math as the pipeline path (bounded by initial_backoff/max_backoff)."""
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import RetryPolicy, call_with_rate_limit_retry
+
+    calls = [
+        ProviderError("429", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=None),
+        "ok",
+    ]
+
+    def fn():
+        result = calls.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    policy = RetryPolicy(jitter="none", initial_backoff_sec=1.0, backoff_multiplier=2.0)
+    assert call_with_rate_limit_retry(fn, policy=policy) == "ok"
+    mock_sleep.assert_called_once_with(1.0)  # attempt 1: 1.0 * 2**0, no jitter
 
 
 # --- StepRetriedEvent emission ---

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -1082,6 +1082,23 @@ def test_call_with_rate_limit_retry_falls_back_to_computed_backoff(mock_sleep) -
     mock_sleep.assert_called_once_with(1.0)  # attempt 1: 1.0 * 2**0, no jitter
 
 
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_honors_policy_retryable_codes(mock_sleep) -> None:
+    """A policy that excludes RATE_LIMIT from `retryable_codes` (e.g. `.disabled()`)
+    must not retry, even though the raised code is RATE_LIMIT — `RetryPolicy` should
+    mean the same thing here as it does on the `BaseProvider` pipeline path."""
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import RetryPolicy, call_with_rate_limit_retry
+
+    def fn():
+        raise ProviderError("429", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1)
+
+    with pytest.raises(ProviderError):
+        call_with_rate_limit_retry(fn, policy=RetryPolicy.disabled())
+
+    mock_sleep.assert_not_called()
+
+
 # --- StepRetriedEvent emission ---
 
 

--- a/libs/core/tests/unit/test_provider_retry.py
+++ b/libs/core/tests/unit/test_provider_retry.py
@@ -1099,6 +1099,22 @@ def test_call_with_rate_limit_retry_honors_policy_retryable_codes(mock_sleep) ->
     mock_sleep.assert_not_called()
 
 
+@patch("genblaze_core.providers.retry.time.sleep")
+def test_call_with_rate_limit_retry_sets_attempts_on_exhaustion(mock_sleep) -> None:
+    """Matches BaseProvider._retry_phase: the re-raised ProviderError.attempts
+    reflects how many attempts actually ran, not the constructor default of 1."""
+    from genblaze_core.exceptions import ProviderError
+    from genblaze_core.providers.retry import RetryPolicy, call_with_rate_limit_retry
+
+    def fn():
+        raise ProviderError("429", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1)
+
+    with pytest.raises(ProviderError) as exc:
+        call_with_rate_limit_retry(fn, policy=RetryPolicy(max_attempts=3))
+
+    assert exc.value.attempts == 3
+
+
 # --- StepRetriedEvent emission ---
 
 


### PR DESCRIPTION
## Summary

The standalone `chat()`/`achat()` helpers in `genblaze-openai` and `genblaze-google` already parse a 429's `Retry-After` hint onto `ProviderError.retry_after`, but raised immediately instead of waiting — forcing every caller (e.g. archive-scale vision loops over video frames) to reimplement backoff. This adds an **opt-in** wait-and-retry loop to both connectors' `chat()`/`achat()`, backed by a small shared helper in `genblaze-core`. Default behavior is unchanged.

## Changes

- `libs/core/genblaze_core/providers/retry.py` — new `call_with_rate_limit_retry(fn, *, policy=None)`. Reuses the existing `RetryPolicy` (defers to `policy.should_retry` for the attempt-cap + retryable-codes gate, `policy.compute_delay` for backoff timing) — the same machinery `BaseProvider`'s pipeline retry loop already uses. Narrowed to `ProviderErrorCode.RATE_LIMIT` only; any other error propagates on the first attempt.
- `libs/connectors/openai/genblaze_openai/chat.py`, `libs/connectors/google/genblaze_google/chat.py` — added `retry_on_rate_limit: bool = False` and `retry_policy: RetryPolicy | None = None` to `chat()`. The single API call is wrapped in `call_with_rate_limit_retry` only when opted in; the client is created once and closed once after the whole retry loop (not per attempt). `achat()` needed no changes — it already forwards `**kwargs` to `chat()` via `asyncio.to_thread`, so the blocking `time.sleep` inside the retry loop runs in the worker thread, never the event loop.
- `docs/features/llm-calls.md` — new "Rate limits" section: the opt-in flag/param, the worst-case wait bound (`(max_attempts - 1) * MAX_RETRY_AFTER_SEC`, ~10 min with defaults), and that this is a per-call retry wrapper, not a queue-level rate limiter (documented thundering-herd limitation for concurrent callers).
- Tests: `libs/core/tests/unit/test_provider_retry.py` (shared helper — retry-after honored, falls back to computed backoff, attempt cap, `retryable_codes` respected) and `libs/connectors/{openai,google}/tests/test_chat.py` (default opt-out raises immediately with no sleep, opt-in waits-then-succeeds, attempt cap exhausted, non-RATE_LIMIT codes fail fast, `achat` passthrough, internally-created client closed exactly once across retries).

No package versions or `CHANGELOG.md` entries were touched — this PR is source + tests + a docs note only, per the batch release-gate convention.

## Test plan

- [x] `make test` (targeted) — ran the three affected packages directly (`core`, `openai`, `google`) since this PR doesn't touch any other package: **core 2103 passed / 3 skipped** (2 unrelated pre-existing failures only appear when `genblaze-s3` isn't installed in the venv — not present on `origin/main` either), **openai 161 passed / 7 skipped**, **google 135 passed / 10 skipped**. Did not run the full 16-package `make test` — CI is the authoritative full-suite gate.
- [ ] `make lint` — ran `ruff check libs/ cli/ examples/` (repo-wide): **all checks passed**. Ran `ruff format --check` on every file this PR touches: **all already formatted**. Left unchecked because repo-wide `ruff format --check libs/ cli/ examples/` currently flags 17 pre-existing `README.md` files unrelated to this change (present on `origin/main` before this branch) — not caused by this PR, but I can't tick the literal `make lint` gate while that's true.
- [x] Docs updated — `docs/features/llm-calls.md` updated in this PR with a new "Rate limits" section.

Also ran `mypy libs/core/genblaze_core/ --ignore-missing-imports`: no issues found.

### Pre-PR triangulated review (3 independent sub-agent reviewers)

- **Correctness & tests**: 1 P1 (missing test proving the internally-created client is closed exactly once across retries, not per-attempt) — fixed, added to both connectors. 1 P2 (pre-existing, unrelated: `client.close()` exceptions during unwind aren't handled — not a regression from this PR).
- **Security & invariants**: no P0/P1. 1 P2 (document the worst-case blocking time) — fixed in docs. Confirmed the existing `MAX_RETRY_AFTER_SEC` clamp is not bypassed or weakened, no secrets/credentials logged, no `BaseProvider`/manifest/UUID/`EmbedPolicy` invariants touched, `RetryPolicy` (frozen/slotted) is safe to share across concurrent callers.
- **Architecture, scalability & DRY**: 3 P1s — (1) the helper hardcoded a `RATE_LIMIT`-only check instead of consulting `policy.retryable_codes`/`should_retry`, so a custom `RetryPolicy` was silently ignored — **fixed**, now delegates to `policy.should_retry`; (2) no overall time-budget gate unlike `BaseProvider._retry_phase` — **addressed via documentation** of the bounded (not unbounded) worst case, since there's no natural wall-clock deadline for an unscheduled standalone call the way there is for a pipeline step's `timeout`; (3) thundering-herd risk from an unjittered `Retry-After` hint under concurrent callers — **documented as a known limitation** (per-call wrapper, not a queue-level limiter). Confirmed shared-core placement and reuse of `compute_delay` is the right layering.

Findings raised by ≥2 reviewers (worst-case wait time) and the policy-respect bug were treated as blocking and fixed before pushing; all other findings were resolved via documentation or accepted as pre-existing/out-of-scope.

## Related

Closes #221