### PR TITLE
fix(openai): set per-model pricing so estimate_cost() works (#222, #223)

### DIFF
--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -471,10 +471,11 @@ different shapes:
 - **TTS**: per-1M-character rates per model tier.
 - **Image** (DALL-E + GPT-Image): tiered by `(quality, size)` per model.
 - **Sora** (video): per-second rates that depend on `(model, size,
-  seconds)`. **The SDK ships no Sora pricing recipe** because a flat
-  table can't represent the per-second formula honestly. Use the
-  upstream's published rate calculator until OpenAI exposes a stable
-  programmatic shape.
+  seconds)`. A flat per-video dict would misreport cost by 10x+ across
+  duration/size combinations, so the SDK ships no *rate*, only the
+  *shape* of the strategy — see the "OpenAI Sora" section below, which
+  leaves the actual per-second rate for you to fill in after verifying
+  it at the upstream's published rate calculator.
 
 ```python
 from genblaze_core.providers import per_input_chars, tiered
@@ -555,15 +556,23 @@ tables and register the new slugs as they appear in the catalog.
 
 ## OpenAI Sora
 
-Sora bills per `(model, size, seconds)` — a flat per-video rate misreports
-cost by 10x+ across duration/size combinations, which is why the SDK ships
-no Sora recipe (see the module docstring in `genblaze_openai/provider.py`).
-Register a custom strategy that reads the native `seconds` param directly;
-Sora assets carry no probed `duration` metadata, so `ctx.output_duration_s`
-won't work here the way it does for Stability Audio (which probes the
-rendered file's real duration — see that section above). Veo and Luma's
-recipes also read `step.params` directly rather than `output_duration_s`,
-for the same reason: neither connector probes actual output duration either.
+Sora bills per `(model, size, seconds)`. See the module docstring in
+`genblaze_openai/provider.py` for why the SDK ships no *rate* for it: a
+flat per-video dict would misreport cost by 10x+ across duration/size
+combinations, and no widely-verified per-second rate table was available
+to source at the snapshot date above. The strategy *shape* below is
+still useful — register it once you've confirmed your own rate.
+
+The strategy reads `seconds` directly off `step.params`, falling back to
+the canonical `duration` alias — `estimate_cost()` never runs
+`normalize_params()`, so a caller passing `{"duration": 8}` (the alias
+`generate()` would otherwise rewrite to `seconds` at submit time) must
+still resolve to a cost, the same dual-key guard the Veo recipe below
+uses for `duration_seconds` / `duration`. Sora assets also carry no
+probed `duration` metadata (see `fetch_output()`), so
+`ctx.output_duration_s` won't work here the way it does for Stability
+Audio, which probes the rendered file's real duration (see that section
+below).
 
 ```python
 from genblaze_core.providers import PricingContext, PricingStrategy
@@ -572,7 +581,7 @@ from genblaze_openai import SoraProvider
 
 def per_second(rate: float) -> PricingStrategy:
     def _strategy(ctx: PricingContext) -> float | None:
-        seconds = ctx.step.params.get("seconds")
+        seconds = ctx.step.params.get("seconds") or ctx.step.params.get("duration")
         if seconds is None:
             return None
         try:
@@ -589,13 +598,15 @@ def per_second(rate: float) -> PricingStrategy:
 
 
 sora = SoraProvider(api_key="...")
-# Placeholder rates below — confirm current per-second pricing at
-# openai.com/pricing before relying on these for real cost tracking; Sora
-# rates vary by both model tier and requested size, which this simplified
+# RATE is intentionally left undefined — confirm current per-second pricing
+# at openai.com/pricing before registering; a guessed number here is worse
+# than the default `None`, since a budget gate reading a silently-wrong
+# concrete cost is harder to catch than one reading "unknown." Sora rates
+# also vary by both model tier and requested size, which this simplified
 # strategy ignores (extend the key to (model, size) via `tiered()` if you
 # need per-size accuracy).
-sora.models.register_pricing("sora-2", per_second(0.10))
-sora.models.register_pricing("sora-2-pro", per_second(0.30))
+sora.models.register_pricing("sora-2", per_second(RATE))  # RATE: confirm first
+sora.models.register_pricing("sora-2-pro", per_second(RATE))  # RATE: confirm first
 ```
 
 ---

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -560,7 +560,10 @@ cost by 10x+ across duration/size combinations, which is why the SDK ships
 no Sora recipe (see the module docstring in `genblaze_openai/provider.py`).
 Register a custom strategy that reads the native `seconds` param directly;
 Sora assets carry no probed `duration` metadata, so `ctx.output_duration_s`
-won't work here the way it does for Veo/Luma:
+won't work here the way it does for Stability Audio (which probes the
+rendered file's real duration — see that section above). Veo and Luma's
+recipes also read `step.params` directly rather than `output_duration_s`,
+for the same reason: neither connector probes actual output duration either.
 
 ```python
 from genblaze_core.providers import PricingContext, PricingStrategy
@@ -570,7 +573,17 @@ from genblaze_openai import SoraProvider
 def per_second(rate: float) -> PricingStrategy:
     def _strategy(ctx: PricingContext) -> float | None:
         seconds = ctx.step.params.get("seconds")
-        return float(seconds) * rate if seconds is not None else None
+        if seconds is None:
+            return None
+        try:
+            seconds_f = float(seconds)
+        except (TypeError, ValueError):
+            return None
+        # Reject non-finite/negative values (NaN, inf, malformed input)
+        # rather than silently returning a poisoned or negative cost.
+        if seconds_f < 0 or seconds_f != seconds_f or seconds_f in (float("inf"), float("-inf")):
+            return None
+        return seconds_f * rate
 
     return _strategy
 

--- a/docs/reference/pricing-recipes.md
+++ b/docs/reference/pricing-recipes.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-06-15 -->
+<!-- last_verified: 2026-07-28 -->
 # Pricing recipes
 
 > **Not maintained.** Prices in this document are snapshots taken at the
@@ -534,8 +534,12 @@ OPENAI_GPT_IMAGE_1_RATES: dict = {
     ("high", "auto"): 0.167,
 }
 
-# (Similar tables exist for gpt-image-1.5 and gpt-image-1-mini.
-# gpt-image-2 has no published rates — leave its pricing None.)
+# gpt-image-1.5, gpt-image-1-mini, and gpt-image-2 have no rate table here —
+# unlike gpt-image-1 there is no widely-verified per-(quality, size) price
+# list for these variants as of the snapshot date above. Don't guess at
+# numbers for them; build a table the same shape as OPENAI_GPT_IMAGE_1_RATES
+# once you've confirmed current rates at openai.com/pricing, then register
+# it the same way.
 
 dalle = DalleProvider(api_key="...")
 dalle.models.register_pricing("dall-e-3", tiered(OPENAI_DALLE3_RATES, key=image_key))
@@ -546,6 +550,40 @@ dalle.models.register_pricing("gpt-image-1", tiered(OPENAI_GPT_IMAGE_1_RATES, ke
 OpenAI ships new image variants frequently. Match the family pattern
 via `provider.discover_models(refresh=True)`, then extend the rate
 tables and register the new slugs as they appear in the catalog.
+
+---
+
+## OpenAI Sora
+
+Sora bills per `(model, size, seconds)` — a flat per-video rate misreports
+cost by 10x+ across duration/size combinations, which is why the SDK ships
+no Sora recipe (see the module docstring in `genblaze_openai/provider.py`).
+Register a custom strategy that reads the native `seconds` param directly;
+Sora assets carry no probed `duration` metadata, so `ctx.output_duration_s`
+won't work here the way it does for Veo/Luma:
+
+```python
+from genblaze_core.providers import PricingContext, PricingStrategy
+from genblaze_openai import SoraProvider
+
+
+def per_second(rate: float) -> PricingStrategy:
+    def _strategy(ctx: PricingContext) -> float | None:
+        seconds = ctx.step.params.get("seconds")
+        return float(seconds) * rate if seconds is not None else None
+
+    return _strategy
+
+
+sora = SoraProvider(api_key="...")
+# Placeholder rates below — confirm current per-second pricing at
+# openai.com/pricing before relying on these for real cost tracking; Sora
+# rates vary by both model tier and requested size, which this simplified
+# strategy ignores (extend the key to (model, size) via `tiered()` if you
+# need per-size accuracy).
+sora.models.register_pricing("sora-2", per_second(0.10))
+sora.models.register_pricing("sora-2-pro", per_second(0.30))
+```
 
 ---
 

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -247,9 +247,12 @@ def test_submit_rejects_unsafe_chain_input_url(mock_openai):
 #
 # As of genblaze-core 0.3.0 the SDK ships zero hardcoded prices for Sora —
 # a flat per-video rate would misreport cost by 10x+ since Sora bills per
-# (model, size, seconds). See the module docstring and the "OpenAI" section
-# of docs/reference/pricing-recipes.md for the canonical guidance: register
-# a per-second strategy that reads ``step.params["seconds"]`` yourself.
+# (model, size, seconds), and no widely-verified per-second rate table was
+# available to source. See the module docstring and the "OpenAI Sora"
+# section of docs/reference/pricing-recipes.md for the canonical guidance:
+# register a per-second strategy with your own verified rate — a fabricated
+# number would turn "unknown cost" into a silently-wrong concrete one, which
+# is worse for a budget gate than None.
 
 
 def test_estimate_cost_none_by_default():
@@ -263,17 +266,25 @@ def test_estimate_cost_none_by_default():
 
 
 def _per_second(rate: float):
-    """Reads the native ``seconds`` param directly — Sora bills by requested
-    duration, not by an asset's probed duration (Sora assets carry no
-    duration metadata; see fetch_output()). Matches the recipe registered
-    in docs/reference/pricing-recipes.md, including its input guards: a
-    non-numeric, negative, or non-finite ``seconds`` yields ``None`` (unknown
-    cost) rather than raising or silently reporting a poisoned/negative cost.
+    """Mirrors the ``per_second`` recipe in docs/reference/pricing-recipes.md
+    exactly, including its guards, so these tests double as a regression
+    check on that doc staying accurate:
+
+    - Reads the native ``seconds`` param, falling back to the canonical
+      ``duration`` alias — ``estimate_cost()`` never runs
+      ``normalize_params()``, so a caller passing ``duration`` (the alias
+      ``generate()`` would otherwise rewrite to ``seconds`` at submit time)
+      must still resolve to a cost. Sora assets also carry no probed
+      duration metadata (see ``fetch_output()``), so ``ctx.output_duration_s``
+      isn't an option either.
+    - A non-numeric, negative, or non-finite value yields ``None`` (unknown
+      cost) rather than raising or silently reporting a poisoned/negative
+      cost.
     """
     from genblaze_core.providers import PricingContext
 
     def _strategy(ctx: PricingContext) -> float | None:
-        seconds = ctx.step.params.get("seconds")
+        seconds = ctx.step.params.get("seconds") or ctx.step.params.get("duration")
         if seconds is None:
             return None
         try:
@@ -304,6 +315,51 @@ def test_estimate_cost_with_registered_per_second_pricing():
     assert isinstance(short_cost, Decimal)
     assert isinstance(long_cost, Decimal)
     assert float(long_cost) == pytest.approx(float(short_cost) * 2)
+
+
+def test_estimate_cost_falls_back_to_duration_alias():
+    """estimate_cost() never runs normalize_params(), so a caller passing
+    the canonical ``duration`` alias (rather than native ``seconds``) must
+    still get a real cost out of the registered recipe — not a silent
+    None. Regression guard for the dual-key read."""
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        from genblaze_openai import SoraProvider
+
+        provider = SoraProvider(api_key="test-key")
+    provider._models = provider.models.fork()
+    provider.models.register_pricing("sora-2", _per_second(0.10))
+
+    seconds_cost = provider.estimate_cost("sora-2", {"seconds": 8})
+    duration_cost = provider.estimate_cost("sora-2", {"duration": 8})
+
+    assert duration_cost is not None
+    assert duration_cost == seconds_cost
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"seconds": "not-a-number"},
+        {"seconds": None},
+        {"seconds": -4},
+        {"seconds": float("nan")},
+        {"seconds": float("inf")},
+        {"seconds": object()},
+        {},
+    ],
+)
+def test_estimate_cost_returns_none_on_malformed_seconds(params):
+    """The registered strategy's input guards must return None — not
+    raise, not silently report a negative/NaN/infinite cost — for every
+    malformed shape of the ``seconds``/``duration`` param."""
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        from genblaze_openai import SoraProvider
+
+        provider = SoraProvider(api_key="test-key")
+    provider._models = provider.models.fork()
+    provider.models.register_pricing("sora-2", _per_second(0.10))
+
+    assert provider.estimate_cost("sora-2", params) is None
 
 
 # --- Compliance harness ---

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -240,6 +241,59 @@ def test_submit_rejects_unsafe_chain_input_url(mock_openai):
     step = Step(provider="openai-sora", model="sora-2", prompt="animate", inputs=[img])
     with pytest.raises(ProviderError, match="Unsafe chain input URL"):
         provider.submit(step)
+
+
+# --- Cost tracking ---
+#
+# As of genblaze-core 0.3.0 the SDK ships zero hardcoded prices for Sora —
+# a flat per-video rate would misreport cost by 10x+ since Sora bills per
+# (model, size, seconds). See the module docstring and the "OpenAI" section
+# of docs/reference/pricing-recipes.md for the canonical guidance: register
+# a per-second strategy that reads ``step.params["seconds"]`` yourself.
+
+
+def test_estimate_cost_none_by_default():
+    """No ModelSpec ships pricing, so estimate_cost() returns None until the
+    caller registers a strategy — this is the bug reported in #222/#223."""
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        from genblaze_openai import SoraProvider
+
+        provider = SoraProvider(api_key="test-key")
+    assert provider.estimate_cost("sora-2", {"seconds": 8, "size": "1280x720"}) is None
+
+
+def test_estimate_cost_with_registered_per_second_pricing():
+    """Registering a per-second strategy (the documented recipe) makes
+    estimate_cost() return a Decimal that scales with requested duration —
+    doubling ``seconds`` doubles the estimate."""
+    from genblaze_core.providers import PricingContext, PricingStrategy
+
+    def per_second(rate: float) -> PricingStrategy:
+        """Reads the native ``seconds`` param directly — Sora bills by
+        requested duration, not by an asset's probed duration (Sora assets
+        carry no duration metadata; see fetch_output())."""
+
+        def _strategy(ctx: PricingContext) -> float | None:
+            seconds = ctx.step.params.get("seconds")
+            if seconds is None:
+                return None
+            return float(seconds) * rate
+
+        return _strategy
+
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        from genblaze_openai import SoraProvider
+
+        provider = SoraProvider(api_key="test-key")
+    provider._models = provider.models.fork()
+    provider.models.register_pricing("sora-2", per_second(0.10))
+
+    short_cost = provider.estimate_cost("sora-2", {"seconds": 4})
+    long_cost = provider.estimate_cost("sora-2", {"seconds": 8})
+
+    assert isinstance(short_cost, Decimal)
+    assert isinstance(long_cost, Decimal)
+    assert float(long_cost) == pytest.approx(float(short_cost) * 2)
 
 
 # --- Compliance harness ---

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -262,31 +262,41 @@ def test_estimate_cost_none_by_default():
     assert provider.estimate_cost("sora-2", {"seconds": 8, "size": "1280x720"}) is None
 
 
+def _per_second(rate: float):
+    """Reads the native ``seconds`` param directly — Sora bills by requested
+    duration, not by an asset's probed duration (Sora assets carry no
+    duration metadata; see fetch_output()). Matches the recipe registered
+    in docs/reference/pricing-recipes.md, including its input guards: a
+    non-numeric, negative, or non-finite ``seconds`` yields ``None`` (unknown
+    cost) rather than raising or silently reporting a poisoned/negative cost.
+    """
+    from genblaze_core.providers import PricingContext
+
+    def _strategy(ctx: PricingContext) -> float | None:
+        seconds = ctx.step.params.get("seconds")
+        if seconds is None:
+            return None
+        try:
+            seconds_f = float(seconds)
+        except (TypeError, ValueError):
+            return None
+        if seconds_f < 0 or seconds_f != seconds_f or seconds_f in (float("inf"), float("-inf")):
+            return None
+        return seconds_f * rate
+
+    return _strategy
+
+
 def test_estimate_cost_with_registered_per_second_pricing():
     """Registering a per-second strategy (the documented recipe) makes
     estimate_cost() return a Decimal that scales with requested duration —
     doubling ``seconds`` doubles the estimate."""
-    from genblaze_core.providers import PricingContext, PricingStrategy
-
-    def per_second(rate: float) -> PricingStrategy:
-        """Reads the native ``seconds`` param directly — Sora bills by
-        requested duration, not by an asset's probed duration (Sora assets
-        carry no duration metadata; see fetch_output())."""
-
-        def _strategy(ctx: PricingContext) -> float | None:
-            seconds = ctx.step.params.get("seconds")
-            if seconds is None:
-                return None
-            return float(seconds) * rate
-
-        return _strategy
-
     with patch.dict("sys.modules", {"openai": MagicMock()}):
         from genblaze_openai import SoraProvider
 
         provider = SoraProvider(api_key="test-key")
     provider._models = provider.models.fork()
-    provider.models.register_pricing("sora-2", per_second(0.10))
+    provider.models.register_pricing("sora-2", _per_second(0.10))
 
     short_cost = provider.estimate_cost("sora-2", {"seconds": 4})
     long_cost = provider.estimate_cost("sora-2", {"seconds": 8})

--- a/libs/connectors/openai/tests/test_tts_provider.py
+++ b/libs/connectors/openai/tests/test_tts_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -114,6 +115,64 @@ def test_api_error_raises_provider_error(mock_tts):
     step = Step(provider="openai-tts", model="tts-1", prompt="test")
     with pytest.raises(ProviderError, match="TTS generation failed"):
         provider.generate(step)
+
+
+# --- Cost tracking ---
+#
+# As of genblaze-core 0.3.0 the SDK ships zero hardcoded prices (see
+# docs/exec-plans/completed/model-registry-decoupling.md and the
+# `test_pricing_phaseout.py` CI guard) — rate tables baked into connectors
+# rot faster than releases ship. Cost tracking is opt-in via
+# ``provider.models.register_pricing()``; the recipe below mirrors the
+# "OpenAI" section of ``docs/reference/pricing-recipes.md`` exactly, so
+# these tests double as a regression guard on that doc staying accurate.
+
+
+def test_estimate_cost_none_by_default():
+    """No ModelSpec ships pricing, so estimate_cost() returns None until the
+    caller registers a strategy — this is the bug reported in #222/#223."""
+    from genblaze_openai.tts import OpenAITTSProvider
+
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        provider = OpenAITTSProvider(api_key="test-key")
+    assert provider.estimate_cost("tts-1", {"prompt": "hello"}) is None
+
+
+def test_estimate_cost_with_registered_per_char_pricing():
+    """Registering the documented ``per_input_chars`` recipe makes
+    estimate_cost() return a real Decimal, and cost scales with input size —
+    doubling the prompt roughly doubles the estimate."""
+    from genblaze_core.providers import per_input_chars
+    from genblaze_openai.tts import OpenAITTSProvider
+
+    with patch.dict("sys.modules", {"openai": MagicMock()}):
+        provider = OpenAITTSProvider(api_key="test-key")
+    # Fork to avoid polluting the class-level models_default() cache.
+    provider._models = provider.models.fork()
+    # USD per 1M input chars — tts-1 rate from the canonical recipe.
+    provider.models.register_pricing("tts-1", per_input_chars(15.00, per=1_000_000))
+
+    short_cost = provider.estimate_cost("tts-1", {"prompt": "hello " * 100})
+    long_cost = provider.estimate_cost("tts-1", {"prompt": "hello " * 200})
+
+    assert isinstance(short_cost, Decimal)
+    assert isinstance(long_cost, Decimal)
+    assert long_cost == pytest.approx(short_cost * 2, rel=0.01)
+
+
+def test_cost_tracked_on_generated_step(mock_tts):
+    """User-registered pricing also flows through generate() → cost_usd,
+    not just the estimate_cost() preview path. ``cost_usd`` is a plain
+    ``float`` on ``Step`` (unlike ``estimate_cost()``'s ``Decimal``)."""
+    from genblaze_core.providers import per_input_chars
+
+    provider, _ = mock_tts
+    provider._models = provider.models.fork()
+    provider.models.register_pricing("tts-1", per_input_chars(15.00, per=1_000_000))
+
+    step = Step(provider="openai-tts", model="tts-1", prompt="hello " * 1000)
+    result = provider.generate(step)
+    assert result.cost_usd == pytest.approx(len(step.prompt) / 1_000_000 * 15.00)
 
 
 # --- Compliance harness ---


### PR DESCRIPTION
## Summary

#222 and #223 (duplicates, same reporter) report that `BaseProvider.estimate_cost()` always returns `None` for every genblaze-openai model (3 TTS, 5 DALL-E/gpt-image, 2 Sora) because no `ModelSpec` in the connector sets `pricing`.

**Investigation found this is not a regression to patch by hardcoding rates.** As of `genblaze-core 0.3.0` the SDK deliberately ships zero hardcoded USD pricing in any connector — a CI-enforced lint guard (`libs/core/tests/unit/test_pricing_phaseout.py`) fails the build on any money-named dict literal under `libs/connectors/*/genblaze_*/`, and every other connector (lmnt, elevenlabs, decart, runway, replicate, google, luma, stability-audio, hume, assemblyai, gmicloud) already follows the same pattern: `pricing=None` on every `ModelSpec`, cost tracking opt-in via `provider.models.register_pricing()`, with recipes centralized in `docs/reference/pricing-recipes.md` (see `docs/exec-plans/completed/model-registry-decoupling.md` for the rationale — rate tables rot faster than releases ship). `tts.py`, `dalle.py`, and `provider.py` (Sora) in genblaze-openai already document this policy and already call `self._apply_registry_pricing(step)`; reintroducing hardcoded rates would reverse that decision and require gaming the lint guard.

The actual, narrower gaps this PR fixes:
1. `test_tts_provider.py` and `test_sora_provider.py` were missing the "cost tracking" test coverage that `test_dalle_provider.py` already had — nothing proved the documented `register_pricing()` recipe actually works for TTS or Sora.
2. `docs/reference/pricing-recipes.md`'s OpenAI section claimed "similar tables exist for gpt-image-1.5 and gpt-image-1-mini" — they didn't exist anywhere in the doc — and had no Sora recipe at all.

## Changes

- `libs/connectors/openai/tests/test_tts_provider.py`: new tests proving `estimate_cost()` returns `None` by default and a real `Decimal` (scaling with input length) once `per_input_chars` pricing is registered per the documented TTS recipe; also verifies `generate()` → `cost_usd` (a `float` on `Step`).
- `libs/connectors/openai/tests/test_sora_provider.py`: new tests proving `estimate_cost()` returns `None` by default, and a `Decimal` scaling with `seconds` once a custom per-second strategy is registered (Sora bills per `(model, size, seconds)` and its assets carry no probed `duration`, so it can't use `output_duration_s`).
- `docs/reference/pricing-recipes.md`: removed the false "similar tables exist" claim for gpt-image-1.5/gpt-image-1-mini (replaced with an honest note to verify and build one before registering); added a new "OpenAI Sora" recipe section with a per-second `PricingStrategy` sample (rates explicitly marked as unverified placeholders — no real Sora per-second rate was available to source). Bumped `last_verified` to 2026-07-28.

No connector source files changed — no version bump, no CHANGELOG entry (docs/tests only, no runtime behavior change).

### Reviewer verdicts (triangulated pre-PR review)

- **Correctness & tests**: no P0/P1. Verified `estimate_cost()`/`register_pricing()`/`fork()` behavior against the actual runtime code, confirmed Sora truly has no probed asset duration, ran the tests (all pass). One P2 (Sora recipe ignores `size`) — already flagged in the doc as an accepted simplification.
- **Security & invariants**: no P0/P1. No secrets, no scope creep outside the 3 changed files, no invariant-path touches, `fork()` correctly isolates test state. One P2 (the per-second recipe could crash/misreport on malformed `seconds`) — **fixed**: both the doc sample and the test helper now guard against non-numeric, negative, and non-finite input.
- **Architecture/DRY**: no P0/P1. Confirmed the custom Sora strategy isn't duplicative (genuinely justified — no other connector needs it), no new pricing infra added, `fork()` idiom matches existing connectors exactly. Three P2s — one (an inaccurate Veo/Luma comparison in the new doc text) **fixed**; the other two (test-naming convergence, minor fixture duplication) are pre-existing repo-wide inconsistencies out of scope for this fix.

No P0s, and no finding was raised by more than one reviewer — nothing blocking.

## Test plan

- [x] `make test` passes — 2099+ passed, 3 skipped across libs/core; 159 passed, 7 skipped in libs/connectors/openai; all other packages green (ran full monorepo suite this session).
- [x] `make lint` passes — ruff + deptry clean across all packages (ran this session).
- [x] Docs updated — `docs/reference/pricing-recipes.md` OpenAI/Sora sections corrected and completed in this PR.

## Related

Closes #222
Closes #223