### PR TITLE
fix(runway): require input image with clear error; correct ratio literals + catalog (#226)

### DIFF
--- a/libs/connectors/runway/README.md
+++ b/libs/connectors/runway/README.md
@@ -17,8 +17,9 @@
 
 | Model | Notes |
 |---|---|
-| `gen4_turbo` | Latest Runway video model — fast, highest quality |
-| `gen3a_turbo` | Previous generation — still supported |
+| `gen4_turbo` | Latest Runway Gen model — fast, highest quality. **Image-to-video only**: every request needs an input image (`inputs=`/`external_inputs=`/`params={'prompt_image': url}`). |
+| `gen3a_turbo` | Previous generation — still supported. Also **image-to-video only**. |
+| `gen4.5`, `veo3`, `veo3.1`, `veo3.1_fast` | Support **both** image-to-video and text-only prompts — with no input image, the provider routes to Runway's text-to-video endpoint automatically. |
 
 ## Install
 
@@ -28,7 +29,10 @@ pip install genblaze-runway
 
 Registers the `runway` provider via entry points; [`genblaze-core`](https://pypi.org/project/genblaze-core/) discovers it automatically.
 
-## Quickstart — Gen-4 Turbo text-to-video
+## Quickstart — text-to-video
+
+`gen4_turbo`/`gen3a_turbo` are image-to-video only; use a text-capable model
+(`gen4.5`, `veo3`, `veo3.1`, `veo3.1_fast`) for text-only prompts:
 
 ```bash
 pip install genblaze-core genblaze-runway
@@ -41,9 +45,31 @@ from genblaze_runway import RunwayProvider
 
 run, manifest = (
     Pipeline("runway-demo")
+    .step(RunwayProvider(), model="veo3.1",
+          prompt="A timelapse of wildflowers blooming in a meadow, soft morning light, macro detail",
+          modality=Modality.VIDEO, duration=8)
+    .run(timeout=300)
+)
+print(run.steps[0].assets[0].url, manifest.canonical_hash)
+assert manifest.verify()
+```
+
+## Quickstart — Gen-4 Turbo image-to-video
+
+`gen4_turbo` always requires a source image — pass one via `external_inputs`:
+
+```python
+from genblaze_core import Asset, Modality, Pipeline
+from genblaze_runway import RunwayProvider
+
+reference_image = Asset(url="https://example.com/reference.jpg", media_type="image/jpeg")
+
+run, manifest = (
+    Pipeline("runway-demo")
     .step(RunwayProvider(), model="gen4_turbo",
           prompt="A timelapse of wildflowers blooming in a meadow, soft morning light, macro detail",
-          modality=Modality.VIDEO, duration=10)
+          modality=Modality.VIDEO, duration=10,
+          external_inputs=[reference_image])
     .run(timeout=300)
 )
 print(run.steps[0].assets[0].url, manifest.canonical_hash)

--- a/libs/connectors/runway/genblaze_runway/provider.py
+++ b/libs/connectors/runway/genblaze_runway/provider.py
@@ -159,26 +159,27 @@ def _check_duration(params: dict[str, Any]) -> None:
     params["duration"] = dur
 
 
-def _check_prompt_image(params: dict[str, Any]) -> None:
+def _check_prompt_image(model_id: str, params: dict[str, Any]) -> None:
     """Require a source image, with an actionable error instead of the SDK's leak.
 
     Called explicitly from ``submit()`` — NOT wired as a blanket
     ``param_constraint`` — because the image requirement is endpoint-specific,
-    not model-specific: gen4_turbo/gen3a_turbo only ever go through
-    ``image_to_video`` (see ``@required_args`` on
-    ``ImageToVideoResource.create`` in the runwayml SDK, which never omits
-    ``prompt_image``), so a text-only request to one of those has no valid
-    endpoint to route to. Every other model can take the ``text_to_video``
-    path instead when no image is given (see ``_submit_text_to_video``).
-    Without this check, a text-only gen4_turbo/gen3a_turbo request would
-    surface the SDK's generic "Missing required arguments; Expected either
-    (...)" message (#226) instead of telling the caller what to do about it.
+    not model-specific: models with ``extras["image_only"]`` set (see
+    ``_RUNWAY_GEN_FAMILY``) only ever go through ``image_to_video`` (see
+    ``@required_args`` on ``ImageToVideoResource.create`` in the runwayml
+    SDK, which never omits ``prompt_image``), so a text-only request to one
+    of those has no valid endpoint to route to. Every other model can take
+    the ``text_to_video`` path instead when no image is given (see
+    ``_submit_text_to_video``). Without this check, a text-only request to
+    an image-only model would surface the SDK's generic "Missing required
+    arguments; Expected either (...)" message (#226) instead of telling the
+    caller what to do about it.
     """
     if not params.get("prompt_image"):
         raise ProviderError(
-            "gen4_turbo and gen3a_turbo are image-to-video only and require "
-            "an input image (routed to 'prompt_image'). Chain an "
-            "image-producing step (e.g. `.step(..., input_from=[N])` or "
+            f"{model_id} is image-to-video only and requires an input "
+            "image (routed to 'prompt_image'). Chain an image-producing "
+            "step (e.g. `.step(..., input_from=[N])` or "
             "`external_inputs=[image_asset]`), pass one directly via "
             "params={'prompt_image': '<https-url>'}, or use a text-capable "
             "model (gen4.5, veo3, veo3.1, veo3.1_fast) for text-only prompts.",
@@ -227,15 +228,21 @@ def _check_text_ratio(params: dict[str, Any]) -> None:
 # Every matched slug is image-to-video only (see submit()'s routing) — the
 # pinned SDK's text_to_video.create doesn't accept any of them as a `model`
 # literal — so a text-only request to one raises the actionable
-# _check_prompt_image error. Constraints (duration ∈ {5, 10},
-# ratio ∈ _VALID_RATIOS) are Runway-wide rather than per-model, so they
-# live on the family spec_template; _check_prompt_image is NOT one of
-# them — it's called explicitly from submit()'s routing decision (endpoint
-# choice is per-request, not a fixed property of the spec). The ``ratio``
-# *default* is deliberately NOT set here either — it differs for
-# gen3a_turbo (see ``_default_ratio_for_model``) and ``param_defaults``
-# can't express a per-model value across one shared template — submit()
-# fills it in instead.
+# _check_prompt_image error. That capability is carried as
+# ``extras["image_only"]`` (the framework's documented per-model escape
+# hatch — see the Google Veo connector's ``extras["has_audio"]`` for the
+# same pattern) rather than re-deriving it from the family's *parameter-shape*
+# regex at submit() time, so the two concerns (param shape vs. endpoint
+# capability) stay decoupled even though today they happen to coincide for
+# every *_turbo slug. Constraints (duration ∈ {5, 10}, ratio ∈ _VALID_RATIOS)
+# are Runway-wide rather than per-model, so they live on the family
+# spec_template; _check_prompt_image is NOT one of them — it's called
+# explicitly from submit()'s routing decision (endpoint choice is
+# per-request, not a fixed property of the spec). The ``ratio`` *default*
+# is deliberately NOT set here either — it differs for gen3a_turbo (see
+# ``_default_ratio_for_model``) and ``param_defaults`` can't express a
+# per-model value across one shared template — submit() fills it in
+# instead.
 _RUNWAY_GEN_FAMILY = ModelFamily(
     name="runway-gen-video",
     pattern=re.compile(r"^gen\w+_turbo$"),
@@ -245,6 +252,7 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
         param_aliases={"aspect_ratio": "ratio"},
         param_constraints=(_check_duration, _check_ratio),
         input_mapping=route_images(slots=("prompt_image",)),
+        extras={"image_only": True},
     ),
     description="Runway Gen video family (Gen-3a, Gen-4, future *_turbo variants).",
     example_slugs=("gen4_turbo", "gen3a_turbo"),
@@ -255,12 +263,12 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
 # SDK accepts but that don't fit the ``*_turbo`` pattern (gen4.5, veo3,
 # veo3.1, veo3.1_fast) plus any future/unrecognized slug — falls back here.
 # These models are text-capable (text_to_video.create accepts them), so
-# submit() routes them to image_to_video when an image is given and to
-# text_to_video otherwise — no image requirement applies at the spec level.
-# Duration/ratio *value* validation is intentionally skipped for both
-# endpoints here (valid ranges differ per model, e.g. veo3's duration is
-# fixed at 8s; submit-time errors are the authoritative signal — see
-# ``DiscoverySupport.NONE`` above).
+# ``extras["image_only"]`` is absent (falsy) — submit() routes them to
+# image_to_video when an image is given and to text_to_video otherwise; no
+# image requirement applies at the spec level. Duration/ratio *value*
+# validation is intentionally skipped for both endpoints here (valid ranges
+# differ per model, e.g. veo3's duration is fixed at 8s; submit-time errors
+# are the authoritative signal — see ``DiscoverySupport.NONE`` above).
 _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
@@ -390,10 +398,14 @@ class RunwayProvider(BaseProvider):
             payload = self.prepare_payload(step)
             has_image = bool(payload.get("prompt_image"))
 
-            if not has_image and _RUNWAY_GEN_FAMILY.matches(step.model):
-                # gen4_turbo/gen3a_turbo: image-to-video only, no image
-                # given — always raises (has_image is False here).
-                _check_prompt_image(payload)
+            # Endpoint capability is a resolved-spec property
+            # (extras["image_only"]), not re-derived from the family's
+            # parameter-shape regex — see _RUNWAY_GEN_FAMILY's comment.
+            is_image_only = bool(self._models.get(step.model).extras.get("image_only"))
+            if not has_image and is_image_only:
+                # e.g. gen4_turbo/gen3a_turbo: image-to-video only, no
+                # image given — always raises (has_image is False here).
+                _check_prompt_image(step.model, payload)
 
             if has_image:
                 task = self._submit_image_to_video(client, step, payload)

--- a/libs/connectors/runway/genblaze_runway/provider.py
+++ b/libs/connectors/runway/genblaze_runway/provider.py
@@ -22,6 +22,18 @@ $0.50). As of 0.3.0 the SDK no longer ships pricing — register the
 recipe yourself if you want cost tracking. See
 ``docs/reference/pricing-recipes.md`` for the canonical Runway recipe.
 
+**Image requirement (#226)**: every model this connector submits to goes
+through ``client.image_to_video.create()`` — the only endpoint used here —
+and the pinned SDK (``runwayml>=0.6,<5``, resolving to 4.7.0 today) always
+requires ``prompt_image`` for that endpoint; there is no text-only
+combination. A step with no chained/attached image now raises a clear
+``ProviderError`` instead of the SDK's generic "Missing required arguments"
+message. Slugs outside the ``*_turbo`` family pattern that the pinned SDK
+also accepts (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``) route
+through the permissive fallback — duration/ratio value ranges differ per
+model and aren't strictly validated there, but the image requirement and
+``ratio`` default still apply.
+
 Docs: https://docs.runwayml.com/
 """
 
@@ -51,7 +63,33 @@ from genblaze_core.runnable.config import RunnableConfig
 from ._errors import map_runway_error
 
 _VALID_DURATIONS = frozenset({5, 10})
-_VALID_RATIOS = frozenset({"16:9", "9:16"})
+
+# Runway's ``ratio`` is a pixel-dimension string (e.g. "1280:720"), not a
+# colon aspect ratio like "16:9" — verified against runwayml SDK 4.7.0's
+# ``image_to_video.create`` overloads (the pin is ``runwayml>=0.6,<5``,
+# which resolves to 4.x today). This is the union of every ratio literal
+# across the models that route through this endpoint (gen4_turbo,
+# gen3a_turbo, gen4.5, veo3, veo3.1, veo3.1_fast); each model only accepts a
+# subset of these, so a value accepted here can still be rejected
+# server-side for the wrong model. That's fine — submit-time errors are the
+# authoritative signal (see ``DiscoverySupport.NONE`` above).
+_VALID_RATIOS = frozenset(
+    {
+        "1280:720",
+        "720:1280",
+        "1104:832",
+        "832:1104",
+        "960:960",
+        "1584:672",
+        "1080:1920",
+        "1920:1080",
+    }
+)
+
+# Every current Runway video model accepts 1280:720 (16:9 landscape), so
+# it's a safe default when the caller doesn't supply one — the SDK requires
+# ``ratio`` in most (though not all) valid argument combinations.
+_DEFAULT_RATIO = "1280:720"
 
 
 def _check_ratio(params: dict[str, Any]) -> None:
@@ -83,11 +121,32 @@ def _check_duration(params: dict[str, Any]) -> None:
     params["duration"] = dur
 
 
-# Single family covering the Runway Gen video catalog. The pattern
+def _check_prompt_image(params: dict[str, Any]) -> None:
+    """Require a source image, with an actionable error instead of the SDK's leak.
+
+    Runway's ``image_to_video`` endpoint — the only one this connector
+    calls — always requires ``prompt_image``; there is no argument
+    combination that omits it (see ``@required_args`` on
+    ``ImageToVideoResource.create`` in the runwayml SDK). Without this
+    check, a step submitted with no input image surfaces the SDK's generic
+    "Missing required arguments; Expected either (...)" message (#226)
+    instead of telling the caller what to actually do about it.
+    """
+    if "prompt_image" not in params:
+        raise ProviderError(
+            "Runway video models require an input image (routed to "
+            "'prompt_image'). Chain an image-producing step "
+            "(e.g. `.step(..., input_from=[N])` or `external_inputs=[image_asset]`) "
+            "or pass one directly via params={'prompt_image': '<https-url>'}.",
+            error_code=ProviderErrorCode.INVALID_INPUT,
+        )
+
+
+# Single family covering the Runway Gen *_turbo video catalog. The pattern
 # ``^gen\w+_turbo$`` absorbs current (gen3a_turbo, gen4_turbo) and any
-# future (gen4a_turbo, gen5_turbo, etc.) variants without a code
-# change. Constraints (duration ∈ {5, 10}, ratio ∈ {16:9, 9:16}) are
-# Runway-wide rather than per-model, so they live on the family
+# future (gen4a_turbo, gen5_turbo, etc.) variants without a code change.
+# Constraints (duration ∈ {5, 10}, ratio ∈ _VALID_RATIOS, image required)
+# are Runway-wide rather than per-model, so they live on the family
 # spec_template.
 _RUNWAY_GEN_FAMILY = ModelFamily(
     name="runway-gen-video",
@@ -96,7 +155,8 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
         model_id="*",
         modality=Modality.VIDEO,
         param_aliases={"aspect_ratio": "ratio"},
-        param_constraints=(_check_duration, _check_ratio),
+        param_defaults={"ratio": _DEFAULT_RATIO},
+        param_constraints=(_check_duration, _check_ratio, _check_prompt_image),
         input_mapping=route_images(slots=("prompt_image",)),
     ),
     description="Runway Gen video family (Gen-3a, Gen-4, future *_turbo variants).",
@@ -104,19 +164,36 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
 )
 
 
+# Anything not matching the Gen-turbo family — including slugs the pinned
+# SDK accepts but that don't fit the ``*_turbo`` pattern (gen4.5, veo3,
+# veo3.1, veo3.1_fast) plus any future/unrecognized slug — falls back here.
+# Duration/ratio *value* validation is intentionally skipped (valid ranges
+# differ per model, e.g. veo3's duration is fixed at 8s; submit-time errors
+# are the authoritative signal — see ``DiscoverySupport.NONE`` above), but
+# the one invariant that's true for every model on this endpoint — an input
+# image is required — still applies, along with the ``ratio`` default.
 _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"aspect_ratio": "ratio"},
+    param_defaults={"ratio": _DEFAULT_RATIO},
+    param_constraints=(_check_prompt_image,),
     input_mapping=route_images(slots=("prompt_image",)),
 )
 
 
 class RunwayProvider(BaseProvider):
-    """Provider adapter for Runway video generation (Gen-3, Gen-4).
+    """Provider adapter for Runway video generation (Gen-3, Gen-4, veo3*).
 
     Models match the ``runway-gen-video`` family (any ``gen<N>[a]_turbo``
-    slug). Duration must be 5 or 10; aspect ratio must be 16:9 or 9:16.
+    slug — duration must be 5 or 10, ratio a pixel string like "1280:720")
+    or fall back permissively to any other slug the pinned SDK accepts
+    (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``). Every model on
+    this endpoint requires an input image: chain an image-producing step,
+    pass ``external_inputs=[image_asset]``, or set
+    ``params={'prompt_image': url}`` directly — omitting it raises a clear
+    ``ProviderError`` rather than the SDK's generic "Missing required
+    arguments" message (#226).
 
     Auth: Set ``RUNWAYML_API_SECRET`` env var or pass ``api_secret``.
 

--- a/libs/connectors/runway/genblaze_runway/provider.py
+++ b/libs/connectors/runway/genblaze_runway/provider.py
@@ -31,8 +31,11 @@ combination. A step with no chained/attached image now raises a clear
 message. Slugs outside the ``*_turbo`` family pattern that the pinned SDK
 also accepts (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``) route
 through the permissive fallback — duration/ratio value ranges differ per
-model and aren't strictly validated there, but the image requirement and
-``ratio`` default still apply.
+model and aren't strictly validated there, but the image requirement still
+applies. ``submit()`` also fills in a landscape ``ratio`` default when the
+caller omits one; gen3a_turbo gets its own default since its accepted
+ratio set is disjoint from every other model's (see
+``_default_ratio_for_model``).
 
 Docs: https://docs.runwayml.com/
 """
@@ -68,11 +71,14 @@ _VALID_DURATIONS = frozenset({5, 10})
 # colon aspect ratio like "16:9" — verified against runwayml SDK 4.7.0's
 # ``image_to_video.create`` overloads (the pin is ``runwayml>=0.6,<5``,
 # which resolves to 4.x today). This is the union of every ratio literal
-# across the models that route through this endpoint (gen4_turbo,
-# gen3a_turbo, gen4.5, veo3, veo3.1, veo3.1_fast); each model only accepts a
-# subset of these, so a value accepted here can still be rejected
-# server-side for the wrong model. That's fine — submit-time errors are the
-# authoritative signal (see ``DiscoverySupport.NONE`` above).
+# across the models that route through this endpoint (gen4_turbo, gen4.5,
+# veo3, veo3.1, veo3.1_fast share one set; gen3a_turbo has its own disjoint
+# set — {"768:1280", "1280:768"} — hence the union rather than one shared
+# constant). Each model only accepts a subset of these, so a value accepted
+# here can still be rejected server-side for the wrong model. That's fine —
+# submit-time errors are the authoritative signal (see
+# ``DiscoverySupport.NONE`` above); this check only rejects values no model
+# accepts.
 _VALID_RATIOS = frozenset(
     {
         "1280:720",
@@ -83,13 +89,36 @@ _VALID_RATIOS = frozenset(
         "1584:672",
         "1080:1920",
         "1920:1080",
+        "768:1280",
+        "1280:768",
     }
 )
 
-# Every current Runway video model accepts 1280:720 (16:9 landscape), so
-# it's a safe default when the caller doesn't supply one — the SDK requires
-# ``ratio`` in most (though not all) valid argument combinations.
+# Landscape default when the caller doesn't supply a ratio — valid for every
+# current model *except* gen3a_turbo, whose accepted set doesn't include it
+# (see ``_default_ratio_for_model`` below). The SDK requires ``ratio`` in
+# most (though not all) valid argument combinations.
 _DEFAULT_RATIO = "1280:720"
+
+# gen3a_turbo's ratio set — {"768:1280", "1280:768"} — is disjoint from every
+# other model's, so it needs its own default. ``param_defaults`` on
+# ModelSpec can't express a per-model value (the family template is shared
+# across every matched slug), so the default is resolved here, in submit(),
+# where ``step.model`` is available, instead.
+_GEN3A_TURBO_DEFAULT_RATIO = "1280:768"
+
+
+def _default_ratio_for_model(model_id: str) -> str:
+    """Pick a landscape default ratio valid for the resolved model.
+
+    gen3a_turbo is the one model this connector targets with a ratio set
+    disjoint from everyone else's; every other current and expected future
+    slug (gen4_turbo, gen4.5, veo3, veo3.1, veo3.1_fast, and future
+    ``*_turbo`` variants) accepts ``_DEFAULT_RATIO``.
+    """
+    if model_id == "gen3a_turbo":
+        return _GEN3A_TURBO_DEFAULT_RATIO
+    return _DEFAULT_RATIO
 
 
 def _check_ratio(params: dict[str, Any]) -> None:
@@ -132,7 +161,7 @@ def _check_prompt_image(params: dict[str, Any]) -> None:
     "Missing required arguments; Expected either (...)" message (#226)
     instead of telling the caller what to actually do about it.
     """
-    if "prompt_image" not in params:
+    if not params.get("prompt_image"):
         raise ProviderError(
             "Runway video models require an input image (routed to "
             "'prompt_image'). Chain an image-producing step "
@@ -147,7 +176,10 @@ def _check_prompt_image(params: dict[str, Any]) -> None:
 # future (gen4a_turbo, gen5_turbo, etc.) variants without a code change.
 # Constraints (duration ∈ {5, 10}, ratio ∈ _VALID_RATIOS, image required)
 # are Runway-wide rather than per-model, so they live on the family
-# spec_template.
+# spec_template. The ``ratio`` *default* is deliberately NOT set here — it
+# differs for gen3a_turbo (see ``_default_ratio_for_model``) and
+# ``param_defaults`` can't express a per-model value across one shared
+# template — submit() fills it in instead.
 _RUNWAY_GEN_FAMILY = ModelFamily(
     name="runway-gen-video",
     pattern=re.compile(r"^gen\w+_turbo$"),
@@ -155,7 +187,6 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
         model_id="*",
         modality=Modality.VIDEO,
         param_aliases={"aspect_ratio": "ratio"},
-        param_defaults={"ratio": _DEFAULT_RATIO},
         param_constraints=(_check_duration, _check_ratio, _check_prompt_image),
         input_mapping=route_images(slots=("prompt_image",)),
     ),
@@ -171,12 +202,11 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
 # differ per model, e.g. veo3's duration is fixed at 8s; submit-time errors
 # are the authoritative signal — see ``DiscoverySupport.NONE`` above), but
 # the one invariant that's true for every model on this endpoint — an input
-# image is required — still applies, along with the ``ratio`` default.
+# image is required — still applies.
 _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"aspect_ratio": "ratio"},
-    param_defaults={"ratio": _DEFAULT_RATIO},
     param_constraints=(_check_prompt_image,),
     input_mapping=route_images(slots=("prompt_image",)),
 )
@@ -301,6 +331,20 @@ class RunwayProvider(BaseProvider):
                     request[key] = payload[key]
             if "watermark" in request:
                 request["watermark"] = bool(request["watermark"])
+            # Model-aware default: gen3a_turbo's valid ratio set is disjoint
+            # from every other model's, so the default can't live on the
+            # shared ModelSpec (see _default_ratio_for_model docstring).
+            request.setdefault("ratio", _default_ratio_for_model(step.model))
+
+            # prompt_image reaches here two ways: routed from step.inputs
+            # (already SSRF-validated by validate_chain_input_url in
+            # prepare_payload) or supplied directly via step.params — which
+            # is NOT validated upstream. _check_prompt_image's error message
+            # explicitly suggests the params={'prompt_image': ...} path, so
+            # validate it here regardless of origin before it reaches the SDK.
+            prompt_image = request.get("prompt_image")
+            if isinstance(prompt_image, str):
+                validate_asset_url(prompt_image)
 
             task = client.image_to_video.create(**request)
             return task.id

--- a/libs/connectors/runway/genblaze_runway/provider.py
+++ b/libs/connectors/runway/genblaze_runway/provider.py
@@ -130,6 +130,28 @@ def _default_ratio_for_model(model_id: str) -> str:
     return _DEFAULT_RATIO
 
 
+# gen4.5 and veo3's image_to_video.create overloads mark `duration` as
+# required (no Omit) — unlike gen4_turbo/gen3a_turbo/veo3.1/veo3.1_fast,
+# where it's optional. veo3 additionally pins it to exactly 8 (Literal[8]);
+# 8 is also within gen4.5's documented 2-10 range, so one constant covers
+# both without a per-model split.
+_IMAGE_REQUIRED_DURATION_MODELS = frozenset({"gen4.5", "veo3"})
+_IMAGE_REQUIRED_DURATION_DEFAULT = 8
+
+
+def _default_duration_for_image_model(model_id: str) -> int | None:
+    """Return a required duration default for image_to_video, or None.
+
+    Every other model on this endpoint (gen4_turbo, gen3a_turbo, veo3.1,
+    veo3.1_fast) accepts an *absent* duration — for those, returning None
+    preserves the pre-existing behavior of only forwarding duration when
+    the caller supplied one.
+    """
+    if model_id in _IMAGE_REQUIRED_DURATION_MODELS:
+        return _IMAGE_REQUIRED_DURATION_DEFAULT
+    return None
+
+
 def _check_ratio(params: dict[str, Any]) -> None:
     """Validate the (post-alias) Runway-native ``ratio`` value."""
     ratio = params.get("ratio")
@@ -159,8 +181,8 @@ def _check_duration(params: dict[str, Any]) -> None:
     params["duration"] = dur
 
 
-def _check_prompt_image(model_id: str, params: dict[str, Any]) -> None:
-    """Require a source image, with an actionable error instead of the SDK's leak.
+def _raise_image_required_error(model_id: str) -> None:
+    """Raise an actionable error instead of letting the SDK's leak through.
 
     Called explicitly from ``submit()`` — NOT wired as a blanket
     ``param_constraint`` — because the image requirement is endpoint-specific,
@@ -173,18 +195,46 @@ def _check_prompt_image(model_id: str, params: dict[str, Any]) -> None:
     ``_submit_text_to_video``). Without this check, a text-only request to
     an image-only model would surface the SDK's generic "Missing required
     arguments; Expected either (...)" message (#226) instead of telling the
-    caller what to do about it.
+    caller what to do about it. The caller (``submit()``) has already
+    confirmed no image was given, so this always raises — there's no
+    condition left to check here.
     """
-    if not params.get("prompt_image"):
-        raise ProviderError(
-            f"{model_id} is image-to-video only and requires an input "
-            "image (routed to 'prompt_image'). Chain an image-producing "
-            "step (e.g. `.step(..., input_from=[N])` or "
-            "`external_inputs=[image_asset]`), pass one directly via "
-            "params={'prompt_image': '<https-url>'}, or use a text-capable "
-            "model (gen4.5, veo3, veo3.1, veo3.1_fast) for text-only prompts.",
-            error_code=ProviderErrorCode.INVALID_INPUT,
-        )
+    raise ProviderError(
+        f"{model_id} is image-to-video only and requires an input "
+        "image (routed to 'prompt_image'). Chain an image-producing "
+        "step (e.g. `.step(..., input_from=[N])` or "
+        "`external_inputs=[image_asset]`), pass one directly via "
+        "params={'prompt_image': '<https-url>'}, or use a text-capable "
+        "model (gen4.5, veo3, veo3.1, veo3.1_fast) for text-only prompts.",
+        error_code=ProviderErrorCode.INVALID_INPUT,
+    )
+
+
+def _validate_prompt_image(prompt_image: Any) -> None:
+    """SSRF-guard ``prompt_image`` regardless of which shape it arrives in.
+
+    The SDK accepts ``prompt_image`` as either a single URL/data-URI string
+    or an iterable of dicts with a ``uri`` field (multi-frame first/last-
+    frame arrays, e.g. for veo3.1/veo3.1_fast). Images routed from
+    ``step.inputs`` already passed ``validate_chain_input_url`` upstream (in
+    ``prepare_payload``); this closes the gap for values supplied directly
+    via ``step.params``, which aren't validated anywhere else.
+
+    ``data:`` URIs are a local, no-network-fetch image submission — not an
+    SSRF vector — and are left alone. Every ``http``/``https`` value (in
+    either shape) is validated with ``validate_asset_url`` (https-only,
+    matching the SDK's documented "A HTTPS URL" contract for this field).
+    """
+
+    def _check_one(uri: Any) -> None:
+        if isinstance(uri, str) and not uri.startswith("data:"):
+            validate_asset_url(uri)
+
+    if isinstance(prompt_image, str):
+        _check_one(prompt_image)
+    elif isinstance(prompt_image, (list, tuple)):
+        for item in prompt_image:
+            _check_one(item.get("uri") if isinstance(item, dict) else item)
 
 
 # --- text_to_video (no image input) ----------------------------------------
@@ -228,7 +278,7 @@ def _check_text_ratio(params: dict[str, Any]) -> None:
 # Every matched slug is image-to-video only (see submit()'s routing) — the
 # pinned SDK's text_to_video.create doesn't accept any of them as a `model`
 # literal — so a text-only request to one raises the actionable
-# _check_prompt_image error. That capability is carried as
+# _raise_image_required_error error. That capability is carried as
 # ``extras["image_only"]`` (the framework's documented per-model escape
 # hatch — see the Google Veo connector's ``extras["has_audio"]`` for the
 # same pattern) rather than re-deriving it from the family's *parameter-shape*
@@ -236,7 +286,7 @@ def _check_text_ratio(params: dict[str, Any]) -> None:
 # capability) stay decoupled even though today they happen to coincide for
 # every *_turbo slug. Constraints (duration ∈ {5, 10}, ratio ∈ _VALID_RATIOS)
 # are Runway-wide rather than per-model, so they live on the family
-# spec_template; _check_prompt_image is NOT one of them — it's called
+# spec_template; the image-required check is NOT one of them — it's called
 # explicitly from submit()'s routing decision (endpoint choice is
 # per-request, not a fixed property of the spec). The ``ratio`` *default*
 # is deliberately NOT set here either — it differs for gen3a_turbo (see
@@ -404,8 +454,9 @@ class RunwayProvider(BaseProvider):
             is_image_only = bool(self._models.get(step.model).extras.get("image_only"))
             if not has_image and is_image_only:
                 # e.g. gen4_turbo/gen3a_turbo: image-to-video only, no
-                # image given — always raises (has_image is False here).
-                _check_prompt_image(step.model, payload)
+                # image given — this is the only place that can be reached
+                # with is_image_only True and no image, so it always raises.
+                _raise_image_required_error(step.model)
 
             if has_image:
                 task = self._submit_image_to_video(client, step, payload)
@@ -422,44 +473,63 @@ class RunwayProvider(BaseProvider):
             ) from exc
 
     def _submit_image_to_video(self, client: Any, step: Step, payload: dict[str, Any]) -> Any:
-        """Submit via Runway's ``image_to_video`` endpoint (image input required)."""
+        """Submit via Runway's ``image_to_video`` endpoint (image input required).
+
+        Note: the pinned SDK's ``image_to_video.create`` has no ``watermark``
+        parameter at all (it's keyword-only with no ``**kwargs``), so it's
+        deliberately not forwarded here — a ``params={'watermark': ...}``
+        would otherwise raise an opaque ``TypeError`` wrapped as a generic
+        "Runway submit failed" (exactly the class of error #226 set out to
+        kill).
+        """
         # Translate canonical 'prompt' to Runway's 'prompt_text'; only the
         # SDK-recognized keys are forwarded to image_to_video.create.
         request: dict = {
             "model": step.model,
             "prompt_text": payload.get("prompt", step.prompt or ""),
         }
-        for key in ("duration", "ratio", "seed", "watermark", "prompt_image"):
+        for key in ("duration", "ratio", "seed", "prompt_image"):
             if key in payload:
                 request[key] = payload[key]
-        if "watermark" in request:
-            request["watermark"] = bool(request["watermark"])
         # Model-aware default: gen3a_turbo's valid ratio set is disjoint
         # from every other model's, so the default can't live on the
         # shared ModelSpec (see _default_ratio_for_model docstring).
         request.setdefault("ratio", _default_ratio_for_model(step.model))
+        # gen4.5/veo3 mark `duration` required on this endpoint; every other
+        # model accepts an absent one (see _default_duration_for_image_model).
+        default_duration = _default_duration_for_image_model(step.model)
+        if default_duration is not None:
+            request.setdefault("duration", default_duration)
 
         # prompt_image reaches here two ways: routed from step.inputs
         # (already SSRF-validated by validate_chain_input_url in
         # prepare_payload) or supplied directly via step.params — which
-        # is NOT validated upstream. _check_prompt_image's error message
+        # is NOT validated upstream. _raise_image_required_error's message
         # explicitly suggests the params={'prompt_image': ...} path, so
-        # validate it here regardless of origin before it reaches the SDK.
-        prompt_image = request.get("prompt_image")
-        if isinstance(prompt_image, str):
-            validate_asset_url(prompt_image)
+        # validate it here regardless of origin, and regardless of shape
+        # (single URL/data-URI string, or a list of {"uri": ...} dicts for
+        # multi-frame models) before it reaches the SDK.
+        if "prompt_image" in request:
+            _validate_prompt_image(request["prompt_image"])
+
+        # Record what was actually submitted so fetch_output's duration
+        # metadata (and any duration-keyed pricing) matches reality instead
+        # of guessing 5s for a model that just got a real default applied.
+        if "duration" in request:
+            step.params.setdefault("duration", request["duration"])
 
         return client.image_to_video.create(**request)
 
     def _submit_text_to_video(self, client: Any, step: Step, payload: dict[str, Any]) -> Any:
         """Submit via Runway's ``text_to_video`` endpoint (no image input).
 
-        Only reached for models the family-pattern check in ``submit()``
-        already excluded from the image-only set. The pinned SDK's
-        ``text_to_video.create`` accepts gen4.5, veo3, veo3.1, veo3.1_fast;
-        any other slug is forwarded permissively — submit-time errors are
-        the authoritative signal (see ``DiscoverySupport.NONE`` above) — so
-        a future text-capable model works without a code change.
+        Only reached for models ``submit()`` has already determined are not
+        image-only (``extras["image_only"]`` unset — see ``_RUNWAY_GEN_FAMILY``
+        and ``_FALLBACK``). The pinned SDK's ``text_to_video.create`` accepts
+        gen4.5, veo3, veo3.1, veo3.1_fast; any other slug is forwarded
+        permissively — submit-time errors are the authoritative signal (see
+        ``DiscoverySupport.NONE`` above) — so a future text-capable model
+        works without a code change.
         """
         _check_text_ratio(payload)
         request: dict = {
@@ -473,6 +543,13 @@ class RunwayProvider(BaseProvider):
         # see _TEXT_VALID_RATIOS / _TEXT_DEFAULT_DURATION.
         request.setdefault("ratio", _TEXT_DEFAULT_RATIO)
         request.setdefault("duration", _TEXT_DEFAULT_DURATION)
+
+        # Record what was actually submitted — duration is always resolved
+        # here (defaulted if the caller omitted it), so fetch_output's
+        # duration metadata reflects the real submission instead of its own
+        # image_to_video-oriented 5s fallback.
+        step.params.setdefault("duration", request["duration"])
+
         return client.text_to_video.create(**request)
 
     def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:

--- a/libs/connectors/runway/genblaze_runway/provider.py
+++ b/libs/connectors/runway/genblaze_runway/provider.py
@@ -22,20 +22,29 @@ $0.50). As of 0.3.0 the SDK no longer ships pricing — register the
 recipe yourself if you want cost tracking. See
 ``docs/reference/pricing-recipes.md`` for the canonical Runway recipe.
 
-**Image requirement (#226)**: every model this connector submits to goes
-through ``client.image_to_video.create()`` — the only endpoint used here —
-and the pinned SDK (``runwayml>=0.6,<5``, resolving to 4.7.0 today) always
-requires ``prompt_image`` for that endpoint; there is no text-only
-combination. A step with no chained/attached image now raises a clear
-``ProviderError`` instead of the SDK's generic "Missing required arguments"
-message. Slugs outside the ``*_turbo`` family pattern that the pinned SDK
-also accepts (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``) route
-through the permissive fallback — duration/ratio value ranges differ per
-model and aren't strictly validated there, but the image requirement still
-applies. ``submit()`` also fills in a landscape ``ratio`` default when the
-caller omits one; gen3a_turbo gets its own default since its accepted
-ratio set is disjoint from every other model's (see
-``_default_ratio_for_model``).
+**Two submit endpoints, routed by input presence (#226)**: the pinned SDK
+(``runwayml>=0.6,<5``, resolving to 4.7.0 today) exposes both
+``image_to_video.create()`` (always requires ``prompt_image``; no
+text-only combination) and ``text_to_video.create()`` (no image input at
+all — ``model``/``prompt_text``/``ratio`` required). ``submit()`` picks
+the endpoint from whether the step has an input image:
+
+- **Image present** → ``image_to_video``. gen3a_turbo's accepted ratio set
+  is disjoint from every other image_to_video model's, so its default is
+  resolved per-model (see ``_default_ratio_for_model``); a
+  ``params``-supplied ``prompt_image`` is SSRF-validated the same as a
+  chained one.
+- **No image** → gen4_turbo/gen3a_turbo are image-to-video *only* — the
+  pinned SDK's ``text_to_video.create`` doesn't accept them as a ``model``
+  literal at all — so a text-only request to either raises a clear
+  ``ProviderError`` instead of the SDK's generic "Missing required
+  arguments" message or a route to an endpoint that would reject the
+  model outright. Every other slug (``gen4.5``, ``veo3``, ``veo3.1``,
+  ``veo3.1_fast``, and any future/unrecognized slug via the permissive
+  fallback) routes to ``text_to_video`` — duration/ratio value ranges
+  differ per model there too and aren't strictly validated client-side;
+  submit-time errors are authoritative (see ``DiscoverySupport.NONE``
+  below).
 
 Docs: https://docs.runwayml.com/
 """
@@ -153,20 +162,61 @@ def _check_duration(params: dict[str, Any]) -> None:
 def _check_prompt_image(params: dict[str, Any]) -> None:
     """Require a source image, with an actionable error instead of the SDK's leak.
 
-    Runway's ``image_to_video`` endpoint — the only one this connector
-    calls — always requires ``prompt_image``; there is no argument
-    combination that omits it (see ``@required_args`` on
-    ``ImageToVideoResource.create`` in the runwayml SDK). Without this
-    check, a step submitted with no input image surfaces the SDK's generic
-    "Missing required arguments; Expected either (...)" message (#226)
-    instead of telling the caller what to actually do about it.
+    Called explicitly from ``submit()`` — NOT wired as a blanket
+    ``param_constraint`` — because the image requirement is endpoint-specific,
+    not model-specific: gen4_turbo/gen3a_turbo only ever go through
+    ``image_to_video`` (see ``@required_args`` on
+    ``ImageToVideoResource.create`` in the runwayml SDK, which never omits
+    ``prompt_image``), so a text-only request to one of those has no valid
+    endpoint to route to. Every other model can take the ``text_to_video``
+    path instead when no image is given (see ``_submit_text_to_video``).
+    Without this check, a text-only gen4_turbo/gen3a_turbo request would
+    surface the SDK's generic "Missing required arguments; Expected either
+    (...)" message (#226) instead of telling the caller what to do about it.
     """
     if not params.get("prompt_image"):
         raise ProviderError(
-            "Runway video models require an input image (routed to "
-            "'prompt_image'). Chain an image-producing step "
-            "(e.g. `.step(..., input_from=[N])` or `external_inputs=[image_asset]`) "
-            "or pass one directly via params={'prompt_image': '<https-url>'}.",
+            "gen4_turbo and gen3a_turbo are image-to-video only and require "
+            "an input image (routed to 'prompt_image'). Chain an "
+            "image-producing step (e.g. `.step(..., input_from=[N])` or "
+            "`external_inputs=[image_asset]`), pass one directly via "
+            "params={'prompt_image': '<https-url>'}, or use a text-capable "
+            "model (gen4.5, veo3, veo3.1, veo3.1_fast) for text-only prompts.",
+            error_code=ProviderErrorCode.INVALID_INPUT,
+        )
+
+
+# --- text_to_video (no image input) ----------------------------------------
+
+# Text-capable models per the pinned SDK's text_to_video.create @required_args
+# — gen4_turbo/gen3a_turbo are NOT accepted `model` literals there at all;
+# Runway's *_turbo line is image-to-video only. Ratio sets differ from
+# image_to_video's (e.g. gen4.5's text-to-video set is narrower than its
+# image-to-video set), hence a separate constant rather than reusing
+# _VALID_RATIOS.
+_TEXT_VALID_RATIOS = frozenset({"1280:720", "720:1280", "1080:1920", "1920:1080"})
+
+# Valid for every text-capable model (gen4.5's narrower {"1280:720",
+# "720:1280"} set included) — same reasoning as _DEFAULT_RATIO, different
+# value space.
+_TEXT_DEFAULT_RATIO = "1280:720"
+
+# gen4.5 and veo3 effectively require `duration` (no Omit in their
+# text_to_video.create overload); veo3.1/veo3.1_fast make it optional. 8 is
+# valid for all four (gen4.5: 2-10 range; veo3: must be exactly 8;
+# veo3.1/veo3.1_fast: {4, 6, 8}), so it's a safe universal default rather
+# than guessing per-model.
+_TEXT_DEFAULT_DURATION = 8
+
+
+def _check_text_ratio(params: dict[str, Any]) -> None:
+    """Validate ``ratio`` for the text_to_video path (separate value space
+    from ``_check_ratio``'s image_to_video set — see _TEXT_VALID_RATIOS)."""
+    ratio = params.get("ratio")
+    if ratio is not None and ratio not in _TEXT_VALID_RATIOS:
+        raise ProviderError(
+            f"Invalid ratio={ratio!r} for Runway text-to-video. "
+            f"Must be one of {set(_TEXT_VALID_RATIOS)}",
             error_code=ProviderErrorCode.INVALID_INPUT,
         )
 
@@ -174,12 +224,18 @@ def _check_prompt_image(params: dict[str, Any]) -> None:
 # Single family covering the Runway Gen *_turbo video catalog. The pattern
 # ``^gen\w+_turbo$`` absorbs current (gen3a_turbo, gen4_turbo) and any
 # future (gen4a_turbo, gen5_turbo, etc.) variants without a code change.
-# Constraints (duration ∈ {5, 10}, ratio ∈ _VALID_RATIOS, image required)
-# are Runway-wide rather than per-model, so they live on the family
-# spec_template. The ``ratio`` *default* is deliberately NOT set here — it
-# differs for gen3a_turbo (see ``_default_ratio_for_model``) and
-# ``param_defaults`` can't express a per-model value across one shared
-# template — submit() fills it in instead.
+# Every matched slug is image-to-video only (see submit()'s routing) — the
+# pinned SDK's text_to_video.create doesn't accept any of them as a `model`
+# literal — so a text-only request to one raises the actionable
+# _check_prompt_image error. Constraints (duration ∈ {5, 10},
+# ratio ∈ _VALID_RATIOS) are Runway-wide rather than per-model, so they
+# live on the family spec_template; _check_prompt_image is NOT one of
+# them — it's called explicitly from submit()'s routing decision (endpoint
+# choice is per-request, not a fixed property of the spec). The ``ratio``
+# *default* is deliberately NOT set here either — it differs for
+# gen3a_turbo (see ``_default_ratio_for_model``) and ``param_defaults``
+# can't express a per-model value across one shared template — submit()
+# fills it in instead.
 _RUNWAY_GEN_FAMILY = ModelFamily(
     name="runway-gen-video",
     pattern=re.compile(r"^gen\w+_turbo$"),
@@ -187,7 +243,7 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
         model_id="*",
         modality=Modality.VIDEO,
         param_aliases={"aspect_ratio": "ratio"},
-        param_constraints=(_check_duration, _check_ratio, _check_prompt_image),
+        param_constraints=(_check_duration, _check_ratio),
         input_mapping=route_images(slots=("prompt_image",)),
     ),
     description="Runway Gen video family (Gen-3a, Gen-4, future *_turbo variants).",
@@ -198,16 +254,17 @@ _RUNWAY_GEN_FAMILY = ModelFamily(
 # Anything not matching the Gen-turbo family — including slugs the pinned
 # SDK accepts but that don't fit the ``*_turbo`` pattern (gen4.5, veo3,
 # veo3.1, veo3.1_fast) plus any future/unrecognized slug — falls back here.
-# Duration/ratio *value* validation is intentionally skipped (valid ranges
-# differ per model, e.g. veo3's duration is fixed at 8s; submit-time errors
-# are the authoritative signal — see ``DiscoverySupport.NONE`` above), but
-# the one invariant that's true for every model on this endpoint — an input
-# image is required — still applies.
+# These models are text-capable (text_to_video.create accepts them), so
+# submit() routes them to image_to_video when an image is given and to
+# text_to_video otherwise — no image requirement applies at the spec level.
+# Duration/ratio *value* validation is intentionally skipped for both
+# endpoints here (valid ranges differ per model, e.g. veo3's duration is
+# fixed at 8s; submit-time errors are the authoritative signal — see
+# ``DiscoverySupport.NONE`` above).
 _FALLBACK = ModelSpec(
     model_id="*",
     modality=Modality.VIDEO,
     param_aliases={"aspect_ratio": "ratio"},
-    param_constraints=(_check_prompt_image,),
     input_mapping=route_images(slots=("prompt_image",)),
 )
 
@@ -218,12 +275,14 @@ class RunwayProvider(BaseProvider):
     Models match the ``runway-gen-video`` family (any ``gen<N>[a]_turbo``
     slug — duration must be 5 or 10, ratio a pixel string like "1280:720")
     or fall back permissively to any other slug the pinned SDK accepts
-    (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``). Every model on
-    this endpoint requires an input image: chain an image-producing step,
-    pass ``external_inputs=[image_asset]``, or set
-    ``params={'prompt_image': url}`` directly — omitting it raises a clear
-    ``ProviderError`` rather than the SDK's generic "Missing required
-    arguments" message (#226).
+    (``gen4.5``, ``veo3``, ``veo3.1``, ``veo3.1_fast``). ``submit()`` routes
+    to Runway's ``image_to_video`` endpoint when the step has an input
+    image (chained, via ``external_inputs=[image_asset]``, or
+    ``params={'prompt_image': url}``) and to ``text_to_video`` otherwise.
+    gen4_turbo/gen3a_turbo are image-to-video *only* — a text-only request
+    to either raises a clear ``ProviderError`` rather than the SDK's
+    generic "Missing required arguments" message (#226); every other model
+    supports text-only prompts via ``text_to_video``.
 
     Auth: Set ``RUNWAYML_API_SECRET`` env var or pass ``api_secret``.
 
@@ -315,38 +374,31 @@ class RunwayProvider(BaseProvider):
         return self._client
 
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
-        """Create a video generation task."""
+        """Create a video generation task.
+
+        Routes to Runway's ``image_to_video`` endpoint when the step has an
+        input image (chained via step.inputs or supplied directly via
+        ``params['prompt_image']``), or to ``text_to_video`` otherwise.
+        gen4_turbo/gen3a_turbo are image-to-video only — the pinned SDK's
+        ``text_to_video.create`` doesn't accept either as a ``model``
+        literal — so a text-only request to one of those raises a clear
+        error (#226) rather than routing to an endpoint that would reject
+        the model outright.
+        """
         client = self._get_client()
         try:
             payload = self.prepare_payload(step)
+            has_image = bool(payload.get("prompt_image"))
 
-            # Translate canonical 'prompt' to Runway's 'prompt_text'; only the
-            # SDK-recognized keys are forwarded to image_to_video.create.
-            request: dict = {
-                "model": step.model,
-                "prompt_text": payload.get("prompt", step.prompt or ""),
-            }
-            for key in ("duration", "ratio", "seed", "watermark", "prompt_image"):
-                if key in payload:
-                    request[key] = payload[key]
-            if "watermark" in request:
-                request["watermark"] = bool(request["watermark"])
-            # Model-aware default: gen3a_turbo's valid ratio set is disjoint
-            # from every other model's, so the default can't live on the
-            # shared ModelSpec (see _default_ratio_for_model docstring).
-            request.setdefault("ratio", _default_ratio_for_model(step.model))
+            if not has_image and _RUNWAY_GEN_FAMILY.matches(step.model):
+                # gen4_turbo/gen3a_turbo: image-to-video only, no image
+                # given — always raises (has_image is False here).
+                _check_prompt_image(payload)
 
-            # prompt_image reaches here two ways: routed from step.inputs
-            # (already SSRF-validated by validate_chain_input_url in
-            # prepare_payload) or supplied directly via step.params — which
-            # is NOT validated upstream. _check_prompt_image's error message
-            # explicitly suggests the params={'prompt_image': ...} path, so
-            # validate it here regardless of origin before it reaches the SDK.
-            prompt_image = request.get("prompt_image")
-            if isinstance(prompt_image, str):
-                validate_asset_url(prompt_image)
-
-            task = client.image_to_video.create(**request)
+            if has_image:
+                task = self._submit_image_to_video(client, step, payload)
+            else:
+                task = self._submit_text_to_video(client, step, payload)
             return task.id
         except ProviderError:
             raise
@@ -356,6 +408,60 @@ class RunwayProvider(BaseProvider):
                 error_code=map_runway_error(exc),
                 retry_after=retry_after_from_response(exc),
             ) from exc
+
+    def _submit_image_to_video(self, client: Any, step: Step, payload: dict[str, Any]) -> Any:
+        """Submit via Runway's ``image_to_video`` endpoint (image input required)."""
+        # Translate canonical 'prompt' to Runway's 'prompt_text'; only the
+        # SDK-recognized keys are forwarded to image_to_video.create.
+        request: dict = {
+            "model": step.model,
+            "prompt_text": payload.get("prompt", step.prompt or ""),
+        }
+        for key in ("duration", "ratio", "seed", "watermark", "prompt_image"):
+            if key in payload:
+                request[key] = payload[key]
+        if "watermark" in request:
+            request["watermark"] = bool(request["watermark"])
+        # Model-aware default: gen3a_turbo's valid ratio set is disjoint
+        # from every other model's, so the default can't live on the
+        # shared ModelSpec (see _default_ratio_for_model docstring).
+        request.setdefault("ratio", _default_ratio_for_model(step.model))
+
+        # prompt_image reaches here two ways: routed from step.inputs
+        # (already SSRF-validated by validate_chain_input_url in
+        # prepare_payload) or supplied directly via step.params — which
+        # is NOT validated upstream. _check_prompt_image's error message
+        # explicitly suggests the params={'prompt_image': ...} path, so
+        # validate it here regardless of origin before it reaches the SDK.
+        prompt_image = request.get("prompt_image")
+        if isinstance(prompt_image, str):
+            validate_asset_url(prompt_image)
+
+        return client.image_to_video.create(**request)
+
+    def _submit_text_to_video(self, client: Any, step: Step, payload: dict[str, Any]) -> Any:
+        """Submit via Runway's ``text_to_video`` endpoint (no image input).
+
+        Only reached for models the family-pattern check in ``submit()``
+        already excluded from the image-only set. The pinned SDK's
+        ``text_to_video.create`` accepts gen4.5, veo3, veo3.1, veo3.1_fast;
+        any other slug is forwarded permissively — submit-time errors are
+        the authoritative signal (see ``DiscoverySupport.NONE`` above) — so
+        a future text-capable model works without a code change.
+        """
+        _check_text_ratio(payload)
+        request: dict = {
+            "model": step.model,
+            "prompt_text": payload.get("prompt", step.prompt or ""),
+        }
+        for key in ("duration", "ratio", "seed"):
+            if key in payload:
+                request[key] = payload[key]
+        # Valid ratio/duration value spaces differ from image_to_video's —
+        # see _TEXT_VALID_RATIOS / _TEXT_DEFAULT_DURATION.
+        request.setdefault("ratio", _TEXT_DEFAULT_RATIO)
+        request.setdefault("duration", _TEXT_DEFAULT_DURATION)
+        return client.text_to_video.create(**request)
 
     def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
         """Check if the Runway task is complete."""

--- a/libs/connectors/runway/tests/test_catalog_decoupling.py
+++ b/libs/connectors/runway/tests/test_catalog_decoupling.py
@@ -76,16 +76,46 @@ class TestRunwayGenFamily:
             assert match is None, slug
 
     def test_resolved_spec_carries_constraints(self) -> None:
-        """The family's constraints (duration ∈ {5, 10}, ratio ∈ {16:9,
-        9:16}) ride on every resolved spec. Subclasses inherit Runway's
-        validation without code duplication."""
+        """The family's constraints (duration ∈ {5, 10}, ratio value set,
+        input image required — #226) ride on every resolved spec. Subclasses
+        inherit Runway's validation without code duplication."""
         from genblaze_runway import RunwayProvider
 
         provider = RunwayProvider(api_secret="test")
         spec = provider._models.get("gen4_turbo")
-        assert len(spec.param_constraints) == 2
+        assert len(spec.param_constraints) == 3
         # The aspect_ratio → ratio alias travels with the spec_template.
         assert spec.param_aliases.get("aspect_ratio") == "ratio"
+        # A default ratio is filled in when the caller doesn't supply one.
+        assert spec.param_defaults.get("ratio") == "1280:720"
+
+
+# --- Broadened catalog (#226): SDK-accepted slugs outside *_turbo ---------
+
+
+class TestBroadenedFallbackCatalog:
+    """gen4.5, veo3, veo3.1, veo3.1_fast are accepted by the pinned SDK
+    (runwayml>=0.6,<5, resolving to 4.7.0) but don't match the ``*_turbo``
+    family pattern — they route through the permissive fallback. Duration/
+    ratio value ranges differ per model so aren't strictly validated there,
+    but the fallback still carries the ratio default and the image-required
+    constraint that's true for every model on this endpoint."""
+
+    @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
+    def test_broadened_slugs_do_not_match_turbo_family(self, slug: str) -> None:
+        from genblaze_runway import RunwayProvider
+
+        provider = RunwayProvider(api_secret="test")
+        assert provider._models.match_family(slug) is None, slug
+
+    @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
+    def test_broadened_slugs_still_require_image_and_get_ratio_default(self, slug: str) -> None:
+        from genblaze_runway import RunwayProvider
+
+        provider = RunwayProvider(api_secret="test")
+        spec = provider._models.get(slug)
+        assert spec.param_defaults.get("ratio") == "1280:720"
+        assert len(spec.param_constraints) == 1  # only _check_prompt_image
 
 
 # --- validate_model end-to-end --------------------------------------------

--- a/libs/connectors/runway/tests/test_catalog_decoupling.py
+++ b/libs/connectors/runway/tests/test_catalog_decoupling.py
@@ -102,6 +102,18 @@ class TestRunwayGenFamily:
         # The aspect_ratio → ratio alias travels with the spec_template.
         assert spec.param_aliases.get("aspect_ratio") == "ratio"
 
+    def test_family_matched_specs_carry_image_only_capability_flag(self) -> None:
+        """Endpoint-capability (image_to_video vs. text_to_video) rides as
+        ``extras["image_only"]`` on the resolved spec — the framework's
+        documented per-model escape hatch (same pattern as the Google Veo
+        connector's ``extras["has_audio"]``) — not a re-derivation of the
+        family's parameter-shape regex at submit() time."""
+        from genblaze_runway import RunwayProvider
+
+        provider = RunwayProvider(api_secret="test")
+        for slug in ("gen4_turbo", "gen3a_turbo", "gen5_turbo"):
+            assert provider._models.get(slug).extras.get("image_only") is True, slug
+
 
 # --- Broadened catalog (#226): SDK-accepted slugs outside *_turbo ---------
 
@@ -133,6 +145,16 @@ class TestBroadenedFallbackCatalog:
         provider = RunwayProvider(api_secret="test")
         spec = provider._models.get(slug)
         assert spec.param_constraints == ()
+
+    @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
+    def test_broadened_slugs_are_not_flagged_image_only(self, slug: str) -> None:
+        """extras["image_only"] is absent (falsy) for fallback-routed
+        specs — submit() must not treat these as image-only."""
+        from genblaze_runway import RunwayProvider
+
+        provider = RunwayProvider(api_secret="test")
+        spec = provider._models.get(slug)
+        assert not spec.extras.get("image_only")
 
 
 # --- validate_model end-to-end --------------------------------------------

--- a/libs/connectors/runway/tests/test_catalog_decoupling.py
+++ b/libs/connectors/runway/tests/test_catalog_decoupling.py
@@ -78,7 +78,15 @@ class TestRunwayGenFamily:
     def test_resolved_spec_carries_constraints(self) -> None:
         """The family's constraints (duration ∈ {5, 10}, ratio value set,
         input image required — #226) ride on every resolved spec. Subclasses
-        inherit Runway's validation without code duplication."""
+        inherit Runway's validation without code duplication.
+
+        The ``ratio`` default is deliberately NOT on the spec — gen3a_turbo's
+        accepted ratio set is disjoint from gen4_turbo's, so a single
+        model-blind ``param_defaults`` value would be wrong for one of the
+        two family-matched slugs. ``submit()`` fills it in per-model instead
+        (see ``_default_ratio_for_model``, exercised in
+        test_runway_provider.py).
+        """
         from genblaze_runway import RunwayProvider
 
         provider = RunwayProvider(api_secret="test")
@@ -86,8 +94,6 @@ class TestRunwayGenFamily:
         assert len(spec.param_constraints) == 3
         # The aspect_ratio → ratio alias travels with the spec_template.
         assert spec.param_aliases.get("aspect_ratio") == "ratio"
-        # A default ratio is filled in when the caller doesn't supply one.
-        assert spec.param_defaults.get("ratio") == "1280:720"
 
 
 # --- Broadened catalog (#226): SDK-accepted slugs outside *_turbo ---------
@@ -98,8 +104,9 @@ class TestBroadenedFallbackCatalog:
     (runwayml>=0.6,<5, resolving to 4.7.0) but don't match the ``*_turbo``
     family pattern — they route through the permissive fallback. Duration/
     ratio value ranges differ per model so aren't strictly validated there,
-    but the fallback still carries the ratio default and the image-required
-    constraint that's true for every model on this endpoint."""
+    but the fallback still carries the image-required constraint that's
+    true for every model on this endpoint (the ratio default is applied in
+    submit(), not on the spec — see test_runway_provider.py)."""
 
     @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
     def test_broadened_slugs_do_not_match_turbo_family(self, slug: str) -> None:
@@ -109,12 +116,11 @@ class TestBroadenedFallbackCatalog:
         assert provider._models.match_family(slug) is None, slug
 
     @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
-    def test_broadened_slugs_still_require_image_and_get_ratio_default(self, slug: str) -> None:
+    def test_broadened_slugs_still_require_image(self, slug: str) -> None:
         from genblaze_runway import RunwayProvider
 
         provider = RunwayProvider(api_secret="test")
         spec = provider._models.get(slug)
-        assert spec.param_defaults.get("ratio") == "1280:720"
         assert len(spec.param_constraints) == 1  # only _check_prompt_image
 
 

--- a/libs/connectors/runway/tests/test_catalog_decoupling.py
+++ b/libs/connectors/runway/tests/test_catalog_decoupling.py
@@ -76,9 +76,16 @@ class TestRunwayGenFamily:
             assert match is None, slug
 
     def test_resolved_spec_carries_constraints(self) -> None:
-        """The family's constraints (duration ∈ {5, 10}, ratio value set,
-        input image required — #226) ride on every resolved spec. Subclasses
-        inherit Runway's validation without code duplication.
+        """The family's constraints (duration ∈ {5, 10}, ratio value set)
+        ride on every resolved spec. Subclasses inherit Runway's validation
+        without code duplication.
+
+        The image-required check is NOT one of these constraints — it's
+        endpoint routing, not a fixed property of the model, so submit()
+        calls it explicitly only when it has already decided (no image +
+        family match) that image_to_video is the only valid endpoint for
+        this model and no image was given. See test_runway_provider.py for
+        the routing behavior end-to-end.
 
         The ``ratio`` default is deliberately NOT on the spec — gen3a_turbo's
         accepted ratio set is disjoint from gen4_turbo's, so a single
@@ -91,7 +98,7 @@ class TestRunwayGenFamily:
 
         provider = RunwayProvider(api_secret="test")
         spec = provider._models.get("gen4_turbo")
-        assert len(spec.param_constraints) == 3
+        assert len(spec.param_constraints) == 2
         # The aspect_ratio → ratio alias travels with the spec_template.
         assert spec.param_aliases.get("aspect_ratio") == "ratio"
 
@@ -102,11 +109,13 @@ class TestRunwayGenFamily:
 class TestBroadenedFallbackCatalog:
     """gen4.5, veo3, veo3.1, veo3.1_fast are accepted by the pinned SDK
     (runwayml>=0.6,<5, resolving to 4.7.0) but don't match the ``*_turbo``
-    family pattern — they route through the permissive fallback. Duration/
-    ratio value ranges differ per model so aren't strictly validated there,
-    but the fallback still carries the image-required constraint that's
-    true for every model on this endpoint (the ratio default is applied in
-    submit(), not on the spec — see test_runway_provider.py)."""
+    family pattern — they route through the permissive fallback. Unlike
+    gen4_turbo/gen3a_turbo, these models are text-capable (the SDK's
+    text_to_video.create accepts them), so no image-required constraint
+    applies at the spec level — submit() routes them to text_to_video when
+    no image is given (see test_runway_provider.py for the end-to-end
+    behavior). Duration/ratio value ranges differ per model on both
+    endpoints and aren't strictly validated at the spec level either."""
 
     @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
     def test_broadened_slugs_do_not_match_turbo_family(self, slug: str) -> None:
@@ -116,12 +125,14 @@ class TestBroadenedFallbackCatalog:
         assert provider._models.match_family(slug) is None, slug
 
     @pytest.mark.parametrize("slug", ["gen4.5", "veo3", "veo3.1", "veo3.1_fast"])
-    def test_broadened_slugs_still_require_image(self, slug: str) -> None:
+    def test_broadened_slugs_carry_no_spec_level_constraints(self, slug: str) -> None:
+        """No image-required constraint at the spec level — these models
+        are text-capable, so requiring an image would be wrong."""
         from genblaze_runway import RunwayProvider
 
         provider = RunwayProvider(api_secret="test")
         spec = provider._models.get(slug)
-        assert len(spec.param_constraints) == 1  # only _check_prompt_image
+        assert spec.param_constraints == ()
 
 
 # --- validate_model end-to-end --------------------------------------------

--- a/libs/connectors/runway/tests/test_runway_provider.py
+++ b/libs/connectors/runway/tests/test_runway_provider.py
@@ -25,6 +25,7 @@ def mock_runway():
     """Patch runwayml with a mock client."""
     mock_client = MagicMock()
     mock_client.image_to_video.create.return_value = SimpleNamespace(id="task-abc")
+    mock_client.text_to_video.create.return_value = SimpleNamespace(id="ttv-task-abc")
     mock_client.tasks.retrieve.return_value = SimpleNamespace(
         id="task-abc",
         status="SUCCEEDED",
@@ -174,6 +175,86 @@ def test_submit_prompt_image_via_params_https_forwarded(mock_runway):
         params={"prompt_image": "https://example.com/reference.jpg"},
     )
     provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
+
+
+# --- text_to_video path (no image input) — #226 follow-up -----------------
+
+
+def test_submit_text_only_prompt_works_for_text_capable_model(mock_runway):
+    """Reproduces the reporter's exact scenario from #226 — a text-only
+    prompt with no input image — but on a text-capable model (veo3.1)
+    instead of the image-only gen4_turbo. This is the "severely nerfed"
+    complaint: text-only prompts on the right model should just work."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="veo3.1",
+        prompt="A timelapse of wildflowers blooming in a meadow, soft morning light, macro detail",
+    )
+    task_id = provider.submit(step)
+    assert task_id == "ttv-task-abc"
+    client.image_to_video.create.assert_not_called()
+    call_kwargs = client.text_to_video.create.call_args[1]
+    assert call_kwargs["model"] == "veo3.1"
+    assert "wildflowers" in call_kwargs["prompt_text"]
+    assert call_kwargs["ratio"] == "1280:720"
+    assert call_kwargs["duration"] == 8
+
+
+def test_submit_text_to_video_user_ratio_and_duration_override(mock_runway):
+    """Explicit ratio/duration params win over the text_to_video defaults."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="veo3.1",
+        prompt="a sunset",
+        params={"ratio": "1080:1920", "duration": 6},
+    )
+    provider.submit(step)
+    call_kwargs = client.text_to_video.create.call_args[1]
+    assert call_kwargs["ratio"] == "1080:1920"
+    assert call_kwargs["duration"] == 6
+
+
+def test_submit_text_to_video_rejects_image_only_ratio(mock_runway):
+    """A ratio value valid for image_to_video but not text_to_video (e.g.
+    "1104:832", one of gen4_turbo's image ratios) must be rejected — the
+    two endpoints have different accepted ratio sets."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="veo3.1",
+        prompt="a sunset",
+        params={"ratio": "1104:832"},
+    )
+    with pytest.raises(ProviderError, match="Invalid ratio"):
+        provider.submit(step)
+    client.text_to_video.create.assert_not_called()
+
+
+def test_submit_image_only_model_text_only_still_raises(mock_runway):
+    """gen4_turbo/gen3a_turbo never fall back to text_to_video — the pinned
+    SDK's text_to_video.create doesn't accept either as a model literal, so
+    a text-only request to one of them must still raise the actionable
+    image-required error, not silently route to the wrong endpoint."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen3a_turbo", prompt="a sunset")
+    with pytest.raises(ProviderError, match="image-to-video only"):
+        provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+    client.text_to_video.create.assert_not_called()
+
+
+def test_submit_fallback_model_with_image_still_uses_image_to_video(mock_runway):
+    """A text-capable fallback model (gen4.5) WITH an input image still
+    routes to image_to_video, not text_to_video — image presence, not
+    model capability, decides the endpoint when both are available."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen4.5", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    client.text_to_video.create.assert_not_called()
     call_kwargs = client.image_to_video.create.call_args[1]
     assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
 

--- a/libs/connectors/runway/tests/test_runway_provider.py
+++ b/libs/connectors/runway/tests/test_runway_provider.py
@@ -59,7 +59,7 @@ def test_submit_without_image_raises_actionable_error(mock_runway):
         prompt="wildflowers blooming",
         params={"duration": 10},
     )
-    with pytest.raises(ProviderError, match="require an input image"):
+    with pytest.raises(ProviderError, match="requires an input image"):
         provider.submit(step)
     client.image_to_video.create.assert_not_called()
 
@@ -142,7 +142,7 @@ def test_submit_non_image_chain_input_still_requires_image(mock_runway):
         prompt="a sunset",
         inputs=[Asset(url="https://example.com/clip.mp4", media_type="video/mp4")],
     )
-    with pytest.raises(ProviderError, match="require an input image"):
+    with pytest.raises(ProviderError, match="requires an input image"):
         provider.submit(step)
     client.image_to_video.create.assert_not_called()
 
@@ -201,6 +201,21 @@ def test_submit_text_only_prompt_works_for_text_capable_model(mock_runway):
     assert "wildflowers" in call_kwargs["prompt_text"]
     assert call_kwargs["ratio"] == "1280:720"
     assert call_kwargs["duration"] == 8
+
+
+def test_submit_unrecognized_slug_no_image_routes_to_text_to_video(mock_runway):
+    """A genuinely unrecognized/future slug (not gen*_turbo, not gen4.5/
+    veo3*) with no image still reaches text_to_video via the permissive
+    fallback — extras["image_only"] is absent for fallback-routed specs, so
+    it isn't wrongly treated as image-only. Submit-time API errors (not a
+    client-side guess) are authoritative for slugs the SDK doesn't actually
+    support."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="totally-new-model", prompt="a sunset")
+    provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+    call_kwargs = client.text_to_video.create.call_args[1]
+    assert call_kwargs["model"] == "totally-new-model"
 
 
 def test_submit_text_to_video_user_ratio_and_duration_override(mock_runway):

--- a/libs/connectors/runway/tests/test_runway_provider.py
+++ b/libs/connectors/runway/tests/test_runway_provider.py
@@ -90,6 +90,56 @@ def test_submit_user_ratio_overrides_default(mock_runway):
     assert call_kwargs["ratio"] == "832:1104"
 
 
+def test_submit_watermark_param_not_forwarded(mock_runway):
+    """The pinned SDK's image_to_video.create has no 'watermark' parameter
+    at all (keyword-only, no **kwargs) — forwarding a user-supplied
+    params={'watermark': ...} would raise an opaque TypeError wrapped as a
+    generic "Runway submit failed" error. It must be silently dropped, not
+    forwarded."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"watermark": True},
+        inputs=_IMAGE_INPUT,
+    )
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert "watermark" not in call_kwargs
+
+
+def test_submit_gen4_5_image_path_defaults_duration(mock_runway):
+    """gen4.5's image_to_video.create overload marks `duration` required
+    (no Omit) — the image path must default it, not just ratio."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen4.5", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["duration"] == 8
+
+
+def test_submit_veo3_image_path_defaults_duration(mock_runway):
+    """veo3's image_to_video.create overload pins `duration` to exactly 8
+    (Literal[8], no Omit) — the image path must default it."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="veo3", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["duration"] == 8
+
+
+def test_submit_gen4_turbo_image_path_leaves_duration_absent(mock_runway):
+    """gen4_turbo accepts an absent duration on image_to_video — unlike
+    gen4.5/veo3, it must NOT get a forced default (pre-existing behavior,
+    unaffected by the gen4.5/veo3 duration-default fix)."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert "duration" not in call_kwargs
+
+
 def test_submit_gen3a_turbo_gets_its_own_ratio_default(mock_runway):
     """gen3a_turbo's accepted ratio set ({"768:1280", "1280:768"}) is
     disjoint from gen4_turbo's — it must NOT get the generic 1280:720
@@ -148,7 +198,7 @@ def test_submit_non_image_chain_input_still_requires_image(mock_runway):
 
 
 def test_submit_prompt_image_via_params_is_url_validated(mock_runway):
-    """_check_prompt_image's error message points callers at
+    """_raise_image_required_error's message points callers at
     params={'prompt_image': url} as a fallback — that path skips the
     step.inputs SSRF check (validate_chain_input_url), so submit() must
     validate it directly before forwarding to the SDK."""
@@ -177,6 +227,56 @@ def test_submit_prompt_image_via_params_https_forwarded(mock_runway):
     provider.submit(step)
     call_kwargs = client.image_to_video.create.call_args[1]
     assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
+
+
+def test_submit_prompt_image_list_shape_is_url_validated(mock_runway):
+    """Multi-frame prompt_image (a list of {"uri": ...} dicts, e.g. for
+    veo3.1/veo3.1_fast first/last-frame arrays) must be SSRF-validated
+    per-item, not just the single-string shape."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={
+            "prompt_image": [
+                {"uri": "https://example.com/first.jpg"},
+                {"uri": "http://evil.example/last.jpg"},
+            ]
+        },
+    )
+    with pytest.raises(ProviderError, match="Unsafe asset URL"):
+        provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+
+
+def test_submit_prompt_image_data_uri_is_allowed(mock_runway):
+    """A data: URI is a local, no-network-fetch image submission — not an
+    SSRF vector — and must not be rejected by the https-only guard."""
+    provider, client = mock_runway
+    data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"prompt_image": data_uri},
+    )
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["prompt_image"] == data_uri
+
+
+def test_submit_prompt_image_list_with_data_uri_is_allowed(mock_runway):
+    """A data: URI inside the list-of-dicts shape is likewise allowed."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"prompt_image": [{"uri": "data:image/png;base64,AAAA"}]},
+    )
+    provider.submit(step)
+    client.image_to_video.create.assert_called_once()
 
 
 # --- text_to_video path (no image input) — #226 follow-up -----------------
@@ -247,6 +347,36 @@ def test_submit_text_to_video_rejects_image_only_ratio(mock_runway):
     with pytest.raises(ProviderError, match="Invalid ratio"):
         provider.submit(step)
     client.text_to_video.create.assert_not_called()
+
+
+def test_fetch_output_records_resolved_text_to_video_duration(mock_runway):
+    """submit()'s resolved text_to_video duration default (8) must be
+    reflected in fetch_output's duration metadata — not the image-oriented
+    5s fallback fetch_output falls back to when nothing was recorded
+    (duration provenance, #226 follow-up)."""
+    provider, client = mock_runway
+    client.tasks.retrieve.return_value = SimpleNamespace(
+        id="ttv-task-abc",
+        status="SUCCEEDED",
+        output=["https://runway-output.com/video.mp4"],
+    )
+    step = Step(provider="runway", model="veo3.1", prompt="a sunset")
+    provider.submit(step)
+    assert step.params["duration"] == 8
+    result = provider.fetch_output("ttv-task-abc", step)
+    assert result.assets[0].duration == 8.0
+
+
+def test_fetch_output_records_resolved_image_to_video_duration(mock_runway):
+    """Same provenance guarantee on the image_to_video path: gen4.5's
+    resolved duration default (8) must be recorded, not fetch_output's 5s
+    fallback."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen4.5", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    assert step.params["duration"] == 8
+    result = provider.fetch_output("task-abc", step)
+    assert result.assets[0].duration == 8.0
 
 
 def test_submit_image_only_model_text_only_still_raises(mock_runway):

--- a/libs/connectors/runway/tests/test_runway_provider.py
+++ b/libs/connectors/runway/tests/test_runway_provider.py
@@ -89,6 +89,95 @@ def test_submit_user_ratio_overrides_default(mock_runway):
     assert call_kwargs["ratio"] == "832:1104"
 
 
+def test_submit_gen3a_turbo_gets_its_own_ratio_default(mock_runway):
+    """gen3a_turbo's accepted ratio set ({"768:1280", "1280:768"}) is
+    disjoint from gen4_turbo's — it must NOT get the generic 1280:720
+    default, which the real API would reject for this model."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen3a_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["ratio"] == "1280:768"
+
+
+def test_submit_gen3a_turbo_accepts_its_native_ratio(mock_runway):
+    """A gen3a_turbo-native ratio value (invalid for gen4_turbo) is accepted,
+    not wrongly rejected by the cross-model _VALID_RATIOS union."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen3a_turbo",
+        prompt="a sunset",
+        params={"ratio": "768:1280"},
+        inputs=_IMAGE_INPUT,
+    )
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["ratio"] == "768:1280"
+
+
+def test_submit_broadened_fallback_model_end_to_end(mock_runway):
+    """A model outside the *_turbo family (veo3.1, accepted by the pinned
+    SDK) still gets the image-required check, the generic ratio default,
+    and image routing all the way through submit() — not just spec
+    attributes checked in isolation."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="veo3.1", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["model"] == "veo3.1"
+    assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
+    assert call_kwargs["ratio"] == "1280:720"
+
+
+def test_submit_non_image_chain_input_still_requires_image(mock_runway):
+    """Chaining a video-producing step's output (no image asset) must still
+    raise the actionable error — route_images only picks up image/* assets,
+    so a video-only chain input leaves 'prompt_image' unset."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        inputs=[Asset(url="https://example.com/clip.mp4", media_type="video/mp4")],
+    )
+    with pytest.raises(ProviderError, match="require an input image"):
+        provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+
+
+def test_submit_prompt_image_via_params_is_url_validated(mock_runway):
+    """_check_prompt_image's error message points callers at
+    params={'prompt_image': url} as a fallback — that path skips the
+    step.inputs SSRF check (validate_chain_input_url), so submit() must
+    validate it directly before forwarding to the SDK."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"prompt_image": "http://evil.example/payload.jpg"},
+    )
+    with pytest.raises(ProviderError, match="Unsafe asset URL"):
+        provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+
+
+def test_submit_prompt_image_via_params_https_forwarded(mock_runway):
+    """A valid https prompt_image supplied directly via params (no chained
+    step.inputs) is accepted and forwarded as-is."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"prompt_image": "https://example.com/reference.jpg"},
+    )
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
+
+
 def test_poll_returns_true_on_succeeded(mock_runway):
     provider, _ = mock_runway
     assert provider.poll("task-abc") is True

--- a/libs/connectors/runway/tests/test_runway_provider.py
+++ b/libs/connectors/runway/tests/test_runway_provider.py
@@ -8,11 +8,16 @@ from urllib.parse import urlparse
 
 import pytest
 from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.asset import Asset
 from genblaze_core.models.enums import StepStatus
 from genblaze_core.models.manifest import Manifest
 from genblaze_core.models.run import Run
 from genblaze_core.models.step import Step
 from genblaze_core.testing import ProviderComplianceTests
+
+# Runway's image_to_video endpoint always requires a source image (#226);
+# every submit()-exercising test below needs one chained via step.inputs.
+_IMAGE_INPUT = [Asset(url="https://example.com/reference.jpg", media_type="image/jpeg")]
 
 
 @pytest.fixture
@@ -36,10 +41,52 @@ def mock_runway():
 
 def test_submit_returns_task_id(mock_runway):
     provider, client = mock_runway
-    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset")
+    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
     task_id = provider.submit(step)
     assert task_id == "task-abc"
     client.image_to_video.create.assert_called_once()
+
+
+def test_submit_without_image_raises_actionable_error(mock_runway):
+    """Reproduces #226: gen4_turbo submitted with no input image must raise
+    a clear, actionable ProviderError — not the SDK's raw "Missing required
+    arguments" leak."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="wildflowers blooming",
+        params={"duration": 10},
+    )
+    with pytest.raises(ProviderError, match="require an input image"):
+        provider.submit(step)
+    client.image_to_video.create.assert_not_called()
+
+
+def test_submit_routes_input_image_and_defaults_ratio(mock_runway):
+    """An image chained via step.inputs is routed to 'prompt_image'; ratio
+    defaults to 1280:720 when the caller doesn't specify one."""
+    provider, client = mock_runway
+    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["prompt_image"] == "https://example.com/reference.jpg"
+    assert call_kwargs["ratio"] == "1280:720"
+
+
+def test_submit_user_ratio_overrides_default(mock_runway):
+    """An explicit ratio param wins over the default."""
+    provider, client = mock_runway
+    step = Step(
+        provider="runway",
+        model="gen4_turbo",
+        prompt="a sunset",
+        params={"ratio": "832:1104"},
+        inputs=_IMAGE_INPUT,
+    )
+    provider.submit(step)
+    call_kwargs = client.image_to_video.create.call_args[1]
+    assert call_kwargs["ratio"] == "832:1104"
 
 
 def test_poll_returns_true_on_succeeded(mock_runway):
@@ -75,7 +122,7 @@ def test_fetch_output_failed_raises(mock_runway):
 
 def test_invoke_full_lifecycle(mock_runway):
     provider, _ = mock_runway
-    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset")
+    step = Step(provider="runway", model="gen4_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
     result = provider.invoke(step)
     assert result.status == StepStatus.SUCCEEDED
     assert len(result.assets) == 1
@@ -83,7 +130,9 @@ def test_invoke_full_lifecycle(mock_runway):
 
 def test_url_only_output_manifest_does_not_verify_without_sink(mock_runway):
     provider, _ = mock_runway
-    result = provider.invoke(Step(provider="runway", model="gen4_turbo", prompt="a sunset"))
+    result = provider.invoke(
+        Step(provider="runway", model="gen4_turbo", prompt="a sunset", inputs=_IMAGE_INPUT)
+    )
 
     manifest = Manifest.from_run(Run(name="same", steps=[result]))
 
@@ -148,17 +197,19 @@ def test_cost_none_unknown_model(mock_runway):
 def test_aspect_ratio_alias(mock_runway):
     """Standard 'aspect_ratio' param is mapped to 'ratio' via normalize_params."""
     provider, client = mock_runway
-    # normalize_params maps aspect_ratio → ratio
-    params = provider.normalize_params({"aspect_ratio": "16:9"})
+    # normalize_params maps aspect_ratio → ratio. Runway's native ratio is a
+    # pixel-dimension string (e.g. "1280:720"), not a colon aspect ratio.
+    params = provider.normalize_params({"aspect_ratio": "1280:720"})
     step = Step(
         provider="runway",
         model="gen4_turbo",
         prompt="test",
         params=params,
+        inputs=_IMAGE_INPUT,
     )
     provider.submit(step)
     call_kwargs = client.image_to_video.create.call_args[1]
-    assert call_kwargs["ratio"] == "16:9"
+    assert call_kwargs["ratio"] == "1280:720"
 
 
 def test_invalid_aspect_ratio_alias_raises(mock_runway):
@@ -238,4 +289,6 @@ class TestRunwayCompliance(ProviderComplianceTests):
         return provider
 
     def make_step(self):
-        return Step(provider="runway", model="gen4_turbo", prompt="test prompt")
+        return Step(
+            provider="runway", model="gen4_turbo", prompt="test prompt", inputs=_IMAGE_INPUT
+        )


### PR DESCRIPTION
## Summary

Fixes **#226** (RunwayProvider unusable). `RunwayProvider.submit()` routes
between Runway's two SDK endpoints based on whether the step has an input
image, fixing both the crash on submit and the "severely nerfed" catalog
complaint (text-only prompts now work on text-capable models).

## Root cause

The connector previously called `client.image_to_video.create()`
unconditionally for every model. Inspecting the installed `runwayml` SDK
(pinned `runwayml>=0.6,<5`, resolving to 4.7.0) directly — its
`@required_args` decorators and per-model `Literal` overloads, not the SDK
docs — showed:

- `image_to_video.create()` **always** requires `prompt_image`; there is no
  argument combination that omits it. A step with no image (the reporter's
  exact case) hits the SDK's raw `Missing required arguments; Expected
  either (...)` error.
- Runway's `ratio` is a **pixel-dimension string** (`"1280:720"`), not a
  colon aspect ratio (`"16:9"`/`"9:16"`).
- `gen4_turbo`/`gen3a_turbo` are genuinely **image-to-video only** —
  `text_to_video.create()`'s accepted `model` literals are `gen4.5`, `veo3`,
  `veo3.1`, `veo3.1_fast`; neither turbo model is in that set. `gen3a_turbo`
  also has its own ratio set disjoint from every other model's.

## Exact kwargs sent per endpoint

`image_to_video.create(model, prompt_text, duration=<if given, or a
model-aware default for gen4.5/veo3>, ratio=<user value or a per-model
default>, seed=<if given>, prompt_image=<url or list of {"uri": ...}>)` —
**no `watermark`**, the pinned SDK has no such parameter.

`text_to_video.create(model, prompt_text, duration=<user value or 8>,
ratio=<user value or "1280:720">, seed=<if given>)`.

## Changes

`libs/connectors/runway/genblaze_runway/provider.py`

- `submit()` branches on `has_image = bool(payload.get("prompt_image"))`:
  image present → `_submit_image_to_video()`; no image + resolved model's
  `extras["image_only"]` (currently `gen4_turbo`/`gen3a_turbo`, via
  `_RUNWAY_GEN_FAMILY`) → a clear, actionable `ProviderError`; no image +
  text-capable → `_submit_text_to_video()`.
- Endpoint capability is carried as `extras["image_only"]` on the resolved
  `ModelSpec`, mirroring the Google Veo connector's `extras["has_audio"]`
  pattern — not re-derived from the family's parameter-shape regex.
- `ratio` defaults per-model (`_default_ratio_for_model`) since
  `gen3a_turbo`'s accepted set is disjoint from everyone else's.
- `duration` on the image path now also defaults per-model
  (`_default_duration_for_image_model`) — `gen4.5`/`veo3` mark it required
  on `image_to_video` too, not just `text_to_video`.
- Both submit paths persist the resolved duration onto `step.params` before
  calling the SDK, so `fetch_output`'s duration metadata (and any
  duration-keyed pricing) reflects what was actually submitted instead of
  its own image-oriented 5s fallback.
- `watermark` is no longer forwarded on the image path — the pinned SDK's
  `image_to_video.create` has no such parameter at all (keyword-only, no
  `**kwargs`); forwarding it previously raised an opaque `TypeError`
  wrapped as a generic "Runway submit failed" — exactly the error class
  #226 targeted. Removal is behavior-preserving (it never worked).
- `prompt_image` SSRF validation now covers both shapes the SDK accepts —
  a single URL/data-URI string, or a list of `{"uri": ...}` dicts
  (multi-frame first/last-frame arrays) — and no longer rejects `data:`
  URIs (a local, no-network-fetch image submission, not an SSRF vector;
  the prior https-only guard broke that legitimate path).
- Collapsed a tautological guard (only ever reached when the image check
  was already known to fail) into a direct raise.

`libs/connectors/runway/README.md`: split the quickstart into a
text-capable-model example (`veo3.1`) and a `gen4_turbo` image-to-video
example with `external_inputs`, since the original text-only `gen4_turbo`
example is now correctly rejected.

## Reviewer verdicts (triangulated, three rounds)

**Round 1** (image_to_video-only fix): Security P1 (SSRF gap on
`params`-supplied `prompt_image`) and Correctness P1 (`gen3a_turbo` ratio
handling) — both fixed.

**Round 2** (text_to_video addition): Architecture P1 (capability oracle
conflated with parameter-shape family) — fixed via `extras["image_only"]`.
Correctness/Security clean otherwise.

**Round 3** (5-reviewer panel on the full diff): applied every confirmed
finding — unsupported `watermark` param, duration provenance mismatch,
missing `gen4.5`/`veo3` duration default on the image path, SSRF gap on
list-shaped `prompt_image` plus the `data:` URI false-positive, the
tautological guard, a stale docstring, and the now-broken README
quickstart. Declined by explicit instruction: audio-param support (separate
feature), a new `_check_prompt_text` validation surface, and any change to
the permissive-fallback design.

## Test plan

- [x] `make lint` passes (ran full repo `make lint` this session, after the
  final commit)
- [x] `make test` passes (ran full repo `make test` this session, after the
  final commit — all packages, zero failures)
- [x] Docs updated — in-package docstrings plus `README.md` quickstart
  (examples/ left untouched — not in this round's scope)

`libs/connectors/runway`: 75 passed, 3 skipped (pre-existing, unrelated).
`ruff check`/`ruff format --check`/`deptry` clean.

## Related

Closes #226
