### PR TITLE
fix(chat): panel-review follow-ups to #221 rate-limit backoff

### DIFF
--- a/docs/features/llm-calls.md
+++ b/docs/features/llm-calls.md
@@ -84,21 +84,30 @@ the attempt cap or backoff timing (passing `retry_policy=` alone, without
 only *narrow* retry here — e.g. `RetryPolicy.disabled()` turns retry off
 entirely — it cannot broaden retry to other error codes; this loop only ever
 acts on `RATE_LIMIT`, by design, regardless of what `retryable_codes` contains.
-`achat()` accepts the same kwargs — the retry wait happens inside the worker
-thread `achat` already runs in, so it never blocks the event loop.
+
+When `chat()` creates its own client (no `client=` passed) and retry is
+opted in, the OpenAI/Gemini SDK's own internal retry is disabled
+(`max_retries=0` / a single-attempt `HttpRetryOptions`) so `RetryPolicy.max_attempts`
+is the only retry budget in effect — otherwise the SDK would retry underneath
+this loop and multiply the effective attempt count. If you pass your own
+`client=`, its retry configuration is untouched; configure it yourself to match.
 
 **Known limits of this opt-in loop:**
 
-- **Bounded but not tiny — and only at this layer.** Worst case here is
-  `(max_attempts - 1) * MAX_RETRY_AFTER_SEC` — with the default policy (6
-  attempts, 120s cap), that's up to ~10 minutes if a misbehaving upstream
-  returns the maximum `Retry-After` hint on every attempt. For
-  `genblaze_openai`, the OpenAI SDK client also retries transient errors on
-  its own (`max_retries=2` by default) *underneath* this loop, so the actual
-  worst case is higher than the bound above; pass `client=openai.OpenAI(max_retries=0)`
-  if you want this loop's bound to be exact. Pass a tighter
-  `retry_policy=RetryPolicy(max_attempts=2)` if the documented bound is
-  already unacceptable for your call site.
+- **Bounded but not tiny.** Worst case here is `(max_attempts - 1) *
+  MAX_RETRY_AFTER_SEC`, *plus* each attempt's own HTTP `timeout=` — with the
+  default policy (6 attempts, 120s cap) that's up to ~10 minutes from backoff
+  alone, and higher still if attempts themselves stall close to `timeout=`
+  before failing. Pass a tighter `retry_policy=RetryPolicy(max_attempts=2)`
+  and/or a smaller `timeout=` if that ceiling is unacceptable for your call site.
+- **`achat()` occupies a thread-pool worker for the whole wait.** `asyncio.to_thread`
+  runs on Python's shared default `ThreadPoolExecutor` (capped around
+  `min(32, os.cpu_count() + 4)` workers, process-wide). A retrying
+  `achat(retry_on_rate_limit=True)` call holds its worker — sleeping, not just
+  computing — for as long as the loop above, so a burst of concurrent retrying
+  calls can exhaust that pool and stall unrelated `to_thread` work elsewhere in
+  the process. Bound how many `achat()` calls run concurrently (e.g. an
+  `asyncio.Semaphore`) rather than firing an unbounded number at once.
 - **Not a rate limiter.** This is a per-call retry wrapper, not a shared
   token-bucket / queue-level limiter. Many concurrent callers hitting the same
   TPM ceiling all see the same server `Retry-After` hint and wake in lockstep,

--- a/libs/connectors/google/genblaze_google/chat.py
+++ b/libs/connectors/google/genblaze_google/chat.py
@@ -236,10 +236,11 @@ def chat(
         project: GCP project for Vertex AI auth (mutually exclusive with api_key).
         location: GCP region for Vertex AI.
         client: Pre-built `google.genai.Client` — escape hatch for tests.
-        retry_on_rate_limit: When ``True``, a 429 wait-and-retry using the
-            server's ``Retry-After`` hint (falling back to exponential backoff)
-            instead of raising immediately. Off by default — existing callers
-            see no behavior change. See ``docs/features/llm-calls.md``.
+        retry_on_rate_limit: When ``True``, waits and retries on a 429 using
+            the server's ``Retry-After`` hint (falling back to exponential
+            backoff) instead of raising immediately. Off by default —
+            existing callers see no behavior change. See
+            ``docs/features/llm-calls.md``.
         retry_policy: Optional ``RetryPolicy`` controlling attempt cap / backoff
             when ``retry_on_rate_limit=True`` (or passed on its own to opt in
             implicitly). Defaults to ``RetryPolicy()`` (6 attempts).
@@ -249,6 +250,10 @@ def chat(
         ProviderError: With a classified `error_code` for any SDK exception.
             Re-raised once retries (if enabled) are exhausted.
     """
+    # retry_policy alone (without the bool flag) also opts in — see the
+    # retry_policy docstring above.
+    retry_managed = retry_on_rate_limit or retry_policy is not None
+
     own_client = client is None
     if own_client:
         try:
@@ -257,10 +262,22 @@ def chat(
             raise ProviderError(
                 "google-genai package not installed. Run: pip install google-genai"
             ) from exc
+        ckwargs: dict[str, Any] = {}
+        if retry_managed:
+            # We already retry via call_with_rate_limit_retry below; disable
+            # the SDK's own internal retry (default up to 5 attempts) so
+            # RetryPolicy.max_attempts stays authoritative instead of being
+            # multiplied by a second, invisible retry layer underneath it.
+            # `genai.types` (not a fresh `from google.genai import types`) so
+            # this works off the already-imported `genai` module — matters for
+            # tests that stub `sys.modules["google"]` without a real
+            # `google.genai` submodule to resolve independently.
+            ckwargs["http_options"] = genai.types.HttpOptions(
+                retry_options=genai.types.HttpRetryOptions(attempts=1)
+            )
         if project:
-            client = genai.Client(vertexai=True, project=project, location=location)
+            client = genai.Client(vertexai=True, project=project, location=location, **ckwargs)
         else:
-            ckwargs: dict[str, Any] = {}
             if api_key:
                 ckwargs["api_key"] = api_key
             client = genai.Client(**ckwargs)
@@ -295,7 +312,8 @@ def chat(
             ) from exc
 
     try:
-        if retry_on_rate_limit or retry_policy is not None:
+        # retry_policy= alone opts in implicitly, even without retry_on_rate_limit=True.
+        if retry_managed:
             raw = call_with_rate_limit_retry(_invoke, policy=retry_policy)
         else:
             raw = _invoke()

--- a/libs/connectors/google/tests/test_chat.py
+++ b/libs/connectors/google/tests/test_chat.py
@@ -345,6 +345,53 @@ def test_internally_created_client_closed_once_across_retries(monkeypatch):
     created_clients[0].close.assert_called_once()
 
 
+def test_own_client_disables_sdk_retry_when_genblaze_manages_it(monkeypatch):
+    """When genblaze creates its own client AND retry is genblaze-managed, the
+    SDK's internal retry must be disabled (a single-attempt `HttpRetryOptions`)
+    — otherwise the SDK would retry underneath `call_with_rate_limit_retry` and
+    `RetryPolicy.max_attempts` wouldn't be authoritative, multiplying
+    rate-limited traffic (#221 panel review)."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    fake_google = MagicMock()
+    created_clients: list[MagicMock] = []
+
+    def _client_factory(**_kwargs):
+        c = MagicMock()
+        c.models.generate_content.side_effect = ProviderError(
+            "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+        )
+        created_clients.append(c)
+        return c
+
+    fake_google.genai.Client.side_effect = _client_factory
+    monkeypatch.setitem(__import__("sys").modules, "google", fake_google)
+
+    with pytest.raises(ProviderError):
+        chat(
+            "gemini-2.5-flash",
+            prompt="hi",
+            api_key="test-key",
+            retry_policy=RetryPolicy.disabled(),
+        )
+
+    assert "http_options" in fake_google.genai.Client.call_args.kwargs
+    # RetryPolicy.disabled() -> genblaze doesn't retry either -> exactly one SDK call.
+    assert created_clients[0].models.generate_content.call_count == 1
+
+
+def test_own_client_keeps_default_sdk_retry_when_retry_not_opted_in(monkeypatch):
+    """Default (opt-out) path must not set `http_options` — no behavior change
+    for existing callers who rely on the SDK's own retry behavior."""
+    fake_google = MagicMock()
+    fake_google.genai.Client.return_value.models.generate_content.return_value = _mock_response()
+    monkeypatch.setitem(__import__("sys").modules, "google", fake_google)
+
+    chat("gemini-2.5-flash", prompt="hi", api_key="test-key")
+
+    assert "http_options" not in fake_google.genai.Client.call_args.kwargs
+
+
 # --- Opt-in rate-limit backoff (#221) ---
 #
 # `chat()`/`achat()` already parse a 429's `Retry-After` hint onto

--- a/libs/connectors/openai/genblaze_openai/chat.py
+++ b/libs/connectors/openai/genblaze_openai/chat.py
@@ -145,10 +145,11 @@ def chat(
         client: Pre-built `openai.OpenAI` instance — escape hatch for tests
             and custom clients. When supplied, its lifecycle is the caller's
             (we won't close it).
-        retry_on_rate_limit: When ``True``, a 429 wait-and-retry using the
-            server's ``Retry-After`` hint (falling back to exponential backoff)
-            instead of raising immediately. Off by default — existing callers
-            see no behavior change. See ``docs/features/llm-calls.md``.
+        retry_on_rate_limit: When ``True``, waits and retries on a 429 using
+            the server's ``Retry-After`` hint (falling back to exponential
+            backoff) instead of raising immediately. Off by default —
+            existing callers see no behavior change. See
+            ``docs/features/llm-calls.md``.
         retry_policy: Optional ``RetryPolicy`` controlling attempt cap / backoff
             when ``retry_on_rate_limit=True`` (or passed on its own to opt in
             implicitly). Defaults to ``RetryPolicy()`` (6 attempts).
@@ -164,6 +165,10 @@ def chat(
         Internally-created clients are closed after each call to avoid
         resource leaks.
     """
+    # retry_policy alone (without the bool flag) also opts in — see the
+    # retry_policy docstring above.
+    retry_managed = retry_on_rate_limit or retry_policy is not None
+
     own_client = client is None
     if own_client:
         try:
@@ -175,6 +180,12 @@ def chat(
             ckwargs["api_key"] = api_key
         if base_url:
             ckwargs["base_url"] = base_url
+        if retry_managed:
+            # We already retry via call_with_rate_limit_retry below; disable
+            # the SDK's own internal retry (default 2) so RetryPolicy.max_attempts
+            # stays authoritative instead of being multiplied by a second,
+            # invisible retry layer underneath it.
+            ckwargs["max_retries"] = 0
         client = openai.OpenAI(**ckwargs)
 
     payload: dict[str, Any] = {
@@ -204,7 +215,8 @@ def chat(
             ) from exc
 
     try:
-        if retry_on_rate_limit or retry_policy is not None:
+        # retry_policy= alone opts in implicitly, even without retry_on_rate_limit=True.
+        if retry_managed:
             raw = call_with_rate_limit_retry(_invoke, policy=retry_policy)
         else:
             raw = _invoke()

--- a/libs/connectors/openai/tests/test_chat.py
+++ b/libs/connectors/openai/tests/test_chat.py
@@ -265,6 +265,47 @@ def test_internally_created_client_closed_once_across_retries(monkeypatch):
     created_clients[0].close.assert_called_once()
 
 
+def test_own_client_disables_sdk_retry_when_genblaze_manages_it(monkeypatch):
+    """When genblaze creates its own client AND retry is genblaze-managed, the
+    SDK's internal retry must be disabled (`max_retries=0`) — otherwise the SDK
+    would retry underneath `call_with_rate_limit_retry` and `RetryPolicy.max_attempts`
+    wouldn't be authoritative, multiplying rate-limited traffic (#221 panel review)."""
+    from genblaze_core.providers.retry import RetryPolicy
+
+    fake_openai = MagicMock()
+    created_clients: list[MagicMock] = []
+
+    def _client_factory(**_kwargs):
+        c = MagicMock()
+        c.chat.completions.create.side_effect = ProviderError(
+            "rate limited", error_code=ProviderErrorCode.RATE_LIMIT, retry_after=0.1
+        )
+        created_clients.append(c)
+        return c
+
+    fake_openai.OpenAI.side_effect = _client_factory
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+
+    with pytest.raises(ProviderError):
+        chat("gpt-4o", prompt="hi", api_key="sk-test", retry_policy=RetryPolicy.disabled())
+
+    assert fake_openai.OpenAI.call_args.kwargs["max_retries"] == 0
+    # RetryPolicy.disabled() -> genblaze doesn't retry either -> exactly one SDK call.
+    assert created_clients[0].chat.completions.create.call_count == 1
+
+
+def test_own_client_keeps_default_sdk_retry_when_retry_not_opted_in(monkeypatch):
+    """Default (opt-out) path must not touch `max_retries` — no behavior change
+    for existing callers who rely on the SDK's own retry behavior."""
+    fake_openai = MagicMock()
+    fake_openai.OpenAI.return_value.chat.completions.create.return_value = _mock_completion()
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+
+    chat("gpt-4o", prompt="hi", api_key="sk-test")
+
+    assert "max_retries" not in fake_openai.OpenAI.call_args.kwargs
+
+
 def test_base_url_forwarded_to_sdk(monkeypatch):
     fake_openai = MagicMock()
     fake_openai.OpenAI.return_value.chat.completions.create.return_value = _mock_completion()


### PR DESCRIPTION
## Summary

Follow-up to the merged `#229` (opt-in `retry_on_rate_limit`/`retry_policy` backoff for `chat()`/`achat()`, closing `#221`). A parallel panel review of that PR surfaced additional findings; this PR lands the remaining fixes that hadn't landed in the squash-merge to `main`.

## Changes

- `libs/connectors/openai/genblaze_openai/chat.py`, `libs/connectors/google/genblaze_google/chat.py` — when `chat()` creates its own client (no `client=` passed) **and** retry is genblaze-managed (`retry_on_rate_limit=True` or `retry_policy=` set), disable the SDK's own internal retry so `RetryPolicy.max_attempts` is the only retry budget in effect:
  - OpenAI: `openai.OpenAI(max_retries=0, ...)`.
  - Gemini: `genai.Client(http_options=genai.types.HttpOptions(retry_options=genai.types.HttpRetryOptions(attempts=1)), ...)`.
  Without this, the SDK's own default retry (OpenAI `max_retries=2`; Gemini's tenacity-based retry when enabled) runs *underneath* `call_with_rate_limit_retry`, so the documented attempt cap isn't authoritative and rate-limited traffic can multiply. Caller-supplied `client=` instances are untouched — configure their retry yourself.
  - Fixed a `retry_on_rate_limit` docstring sentence fragment (missing main verb) in both connectors.
  - Added an inline comment at the retry-decision branch noting `retry_policy=` alone opts in implicitly, even without `retry_on_rate_limit=True`.
- `docs/features/llm-calls.md` — updated the existing "Rate limits" section (added by the merged `#229`):
  - Documents the new automatic SDK-retry-disable behavior above (replacing the old "pass `client=openai.OpenAI(max_retries=0)` yourself" workaround note, which is no longer necessary for genblaze-owned clients).
  - Notes the worst-case wall-clock bound (`(max_attempts - 1) * MAX_RETRY_AFTER_SEC`) also compounds with each attempt's own HTTP `timeout=`, so it's higher than the bound alone suggests.
  - Notes `achat(retry_on_rate_limit=True)` holds a worker on Python's shared default `ThreadPoolExecutor` (via `asyncio.to_thread`) for the entire wait, not just the HTTP call — a burst of concurrent retrying calls can exhaust that pool; recommends bounding concurrency (e.g. `asyncio.Semaphore`).
- Tests: added to both connectors' `test_chat.py` — `RetryPolicy.disabled()` + genblaze-managed retry results in exactly one SDK client construction and exactly one SDK call, with the SDK-retry-disabling kwarg present; and a companion test proving the default (opt-out) path never sets that kwarg (no behavior change for existing callers).

No package versions or `CHANGELOG.md` entries were touched.

## Test plan

- [x] `make test` (targeted) — ran the three affected packages directly (this PR only touches `openai`, `google`, and docs; `core` is unmodified but re-verified for regressions): **core 1847 passed / 22 skipped** (2 failures are pre-existing/unrelated — they only appear when `genblaze-s3` isn't installed in this scratch venv, present on `origin/main` too), **openai 163 passed / 7 skipped**, **google 139 passed / 10 skipped**. Did not run the full 16-package `make test` — CI is the authoritative full-suite gate.
- [ ] `make lint` — ran `ruff check`/`ruff format --check` on every file this PR touches: **all checks passed / already formatted**. Left the literal `make lint` box unchecked since I didn't re-run the full repo-wide `ruff format --check libs/ cli/ examples/` this session (a prior audit found pre-existing, unrelated `README.md` formatting drift on `main`; this PR doesn't touch any of those files).
- [x] Docs updated — `docs/features/llm-calls.md` updated in this PR.

Also ran `mypy libs/core/genblaze_core/ --ignore-missing-imports`: no issues found.

## Related

Follows up `#229` (which closed `#221`). Not itself closing an issue.

### Flags for the release gate / a separate fix (not addressed here, per scope)

1. **Core/connector version floors need bumping before publish.** The merged `#229` added the `call_with_rate_limit_retry` symbol to `genblaze-core` (and the `genblaze-openai`/`genblaze-google` connectors now import it). The connector `pyproject.toml` core-dependency floors are still `genblaze-core>=0.3.7,<0.4` — a version of `genblaze-core` at that floor predates this symbol, so a connector-only upgrade against an old, unbumped core would crash on import. The release gate must bump `genblaze-core`'s version for this change and raise both connectors' core floors to match before the next publish.
2. **Pre-existing bug flagged for a separate targeted fix (not touched here):** `libs/connectors/google/genblaze_google/_errors.py`'s `map_google_error` used to match bare `"rate"` in the error message, colliding with `"generate"`/`"generateContent"`. This was already fixed on `main` as part of the `#229` squash-merge (narrowed to `"rate limit"`/`"rate_limit"`) — flagging here only so the release notes/tracker reflect it's resolved, not outstanding.