### PR TITLE
chore(release): prepare v0.7.0 wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,25 +44,28 @@ umbrella `genblaze` package is `0.4.5`).
   a quantified alternation with overlapping branches whose textual prefixes
   differ, and adjacent unbounded-quantified groups whose reachable character
   sets actually overlap despite looking disjoint by source text alone (#196,
-  #200). Both are now rejected by `assert_safe()`. Fixing #200's
-  charset-overlap gate introduced two further bugs, both closed in this same
-  release before it shipped: (1) an unescaped `.` was resolved to the literal
-  character `'.'` instead of "matches anything", so `(.+)([a-z]+)$`-shaped
-  patterns were wrongly accepted as safe — a real ReDoS bypass, reopening the
-  exact class #196/#200 closed for other atom shapes; and (2) a `(?:...)`/
-  `(?P<name>...)` group's marker prefix was analyzed as literal match text
-  instead of being stripped first, so two charset-disjoint non-capturing
-  groups like `(?:[a-z]+)(?:[0-9]+)` were wrongly *rejected* as unsafe. Both
-  are covered by new regression tests; lookaround groups (`(?=...)`, `(?!...)`)
-  are intentionally left out of scope for the second fix and keep their
-  existing conservative (reject) behavior.
+  #200). Both are now rejected by `assert_safe()`. That charset-overlap gate
+  itself had two bugs, also closed here: an unescaped `.` no longer resolves
+  to the literal character `'.'` (it now correctly means "matches anything"),
+  so a pattern like `(.+)([a-z]+)$` is rejected as it should be; and a
+  `(?:...)`/`(?P<name>...)` group's marker prefix is now stripped before
+  charset analysis, so a genuinely safe pattern like `(?:[a-z]+)(?:[0-9]+)$`
+  is no longer wrongly rejected. **Upgrade impact:** the shipped connector
+  catalog contains no pattern of either shape, so this only affects
+  third-party or future connectors — a `ModelFamily` pattern with two or
+  more adjacent unbounded groups where one uses `.` will now be rejected at
+  import time (fix: separate the groups with a mandatory, non-nullable
+  delimiter, or narrow `.` to an explicit character class); a pattern using
+  `(?:...)`/`(?P<name>...)` that was previously (incorrectly) rejected will
+  now import successfully. Lookaround groups (`(?=...)`, `(?!...)`) keep
+  their existing, unchanged handling.
 - **Fixed** `Mp4Handler.embed()` raised on a `str` path instead of accepting
   one like every other media handler, and `Pipeline.step()` accepted any
   object as a provider instead of validating it's a `BaseProvider` — a
   non-provider value previously surfaced a confusing failure deep inside
   `run()` instead of immediately at the call site (#224, #225).
 
-### genblaze-openai / genblaze-google (chat helpers)
+### genblaze-openai
 
 - **Added** opt-in rate-limit backoff for `chat()`/`achat()` and the vision
   helpers via `retry_on_rate_limit=`/`retry_policy=` kwargs, wrapping calls in
@@ -71,34 +74,37 @@ umbrella `genblaze` package is `0.4.5`).
   genblaze already manages backoff on an internally-created client, closing a
   double-retry (multiplicative wait) bug the initial opt-in introduced; a
   caller-supplied `client=` keeps its own retry configuration untouched
-  (#221, #235). Currently wired into `openai`/`google` only — see
+  (#221, #235). The identical feature and fix landed in `genblaze-google`
+  (see below); currently wired into `openai`/`google` only — see
   `docs/features/llm-calls.md`.
-- **Fixed** (`genblaze-openai`) confirmed `estimate_cost()` already computed
-  per-model pricing correctly; the reported gap was a documentation error in
+- **Docs** confirmed `estimate_cost()` already computed per-model pricing
+  correctly; the reported gap was a documentation error in
   `docs/reference/pricing-recipes.md`, now corrected, plus added test
   coverage pinning the existing (correct) behavior (#222, #223). No
   production code changed.
 
 ### genblaze-google
 
+- **Added** the same opt-in rate-limit backoff described under
+  `genblaze-openai` above (#221, #235).
 - **Added** `GeminiImageProvider`, a native Gemini image-generation provider
   (`google-gemini-image` entry point) alongside the existing Imagen provider,
   sharing client construction via a new `GoogleClientMixin` (#205).
-- **Fixed** the Imagen entitlement probe re-grades a probe-confirmed-`LIVE`
-  but known-gated slug to `OK_PROVISIONAL` instead of a misleading
-  authoritative `OK`, mirroring the same gmicloud fix below (#206).
+- **Fixed** a probe-confirmed-`LIVE` but known-gated Imagen slug reported a
+  misleading authoritative `OK` instead of `OK_PROVISIONAL`, mirroring the
+  same gmicloud fix below (#206).
 - **Fixed** `chat()`/vision calls sent an `ImageURLContent` input as an
   unsupported field instead of translating it to Gemini's
   `inline_data`/`file_data` wire format (#217).
 
 ### genblaze-gmicloud
 
-- **Fixed** preflight validation now distinguishes a known-catalog slug from
-  one confirmed callable with the caller's API key, re-grading a
-  probe-confirmed slug that isn't confirmed-callable to `OK_PROVISIONAL`
-  instead of a misleading authoritative `OK` (#193). Added a guard against a
-  misconfigured `base_url`/`GMI_BASE_URL` pointed at the wrong endpoint shape
-  (a silent-404 footgun), and an edit-mode fallback path.
+- **Fixed** preflight validation didn't distinguish a known-catalog slug from
+  one confirmed callable with the caller's API key, reporting a misleading
+  authoritative `OK` for a probe-confirmed slug that isn't confirmed-callable
+  instead of `OK_PROVISIONAL` (#193). Added a guard against a misconfigured
+  `base_url`/`GMI_BASE_URL` pointed at the wrong endpoint shape (a
+  silent-404 footgun), and an edit-mode fallback path.
 
 ### genblaze-runway
 
@@ -124,9 +130,9 @@ umbrella `genblaze` package is `0.4.5`).
 
 ### genblaze (umbrella)
 
-- **Fixed** `OptionalDependencyError`'s `__getattr__` propagation preserved
-  the original install hint instead of losing it to a generic message
-  (#213).
+- **Fixed** the umbrella's lazy `__getattr__` lost the original install hint
+  to a generic message when propagating `OptionalDependencyError` instead of
+  preserving it (#213).
 - **Added** a `parquet` extra re-exposing `genblaze-core[parquet]`, so
   `pip install "genblaze[parquet]"` — the exact incantation
   `OptionalDependencyError` prints for `ParquetSink` — resolves instead of
@@ -141,6 +147,13 @@ umbrella `genblaze` package is `0.4.5`).
   version wasn't bumped alongside it (#209) — a `pypi-pin-parity` trap that
   would have blocked (not silently shipped) this release. Closed here by
   bumping all nine to a new patch version.
+- **Fixed** `genblaze-openai` and `genblaze-google` import
+  `call_with_rate_limit_retry`, new in `genblaze-core` 0.3.8 this release,
+  but still declared a `genblaze-core>=0.3.7` floor — the same class of gap
+  as the item above, catchable only because it's caught here rather than by
+  any automated gate (`tools/prepare_release.py` doesn't check connector→core
+  floors against the symbols a connector actually imports). Both floors are
+  now `genblaze-core>=0.3.8,<0.4`.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,141 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-28
+
+Bug-fix wave with one new opt-in feature and one new provider. Closes a
+regression in the ReDoS pattern-safety heuristic (both the shape #196/#200
+fixed and two further false-positive/false-negative bugs those same fixes
+introduced), adds an opt-in rate-limit backoff for `chat()`/vision helpers,
+ships a native Gemini image provider, fixes Runway's image-to-video routing,
+and closes a `verify --fetch` SSRF gap.
+
+This heading is the release **wave** name and the git tag (`v0.7.0`);
+individual PyPI package versions move independently and are listed below (the
+umbrella `genblaze` package is `0.4.5`).
+
+### Released package versions
+
+- `genblaze` (umbrella) 0.4.4 → **0.4.5**
+- `genblaze-core` 0.3.7 → **0.3.8**
+- `genblaze-cli` 0.3.5 → **0.3.6**
+- `genblaze-assemblyai` 0.3.1 → **0.3.2**
+- `genblaze-decart` 0.3.2 → **0.3.3**
+- `genblaze-elevenlabs` 0.3.2 → **0.3.3**
+- `genblaze-gmicloud` 0.3.4 → **0.3.5**
+- `genblaze-google` 0.3.3 → **0.3.4**
+- `genblaze-hume` 0.3.2 → **0.3.3**
+- `genblaze-lmnt` 0.3.2 → **0.3.3**
+- `genblaze-nvidia` 0.3.2 → **0.3.3**
+- `genblaze-openai` 0.3.3 → **0.3.4**
+- `genblaze-runway` 0.3.2 → **0.3.3**
+- `genblaze-stability-audio` 0.3.2 → **0.3.3**
+
+### genblaze-core
+
+- **Security** the ReDoS pattern-safety heuristic (`pattern_safety.py`) missed
+  two more catastrophic-backtracking shapes on top of #157 (fixed in 0.6.0):
+  a quantified alternation with overlapping branches whose textual prefixes
+  differ, and adjacent unbounded-quantified groups whose reachable character
+  sets actually overlap despite looking disjoint by source text alone (#196,
+  #200). Both are now rejected by `assert_safe()`. Fixing #200's
+  charset-overlap gate introduced two further bugs, both closed in this same
+  release before it shipped: (1) an unescaped `.` was resolved to the literal
+  character `'.'` instead of "matches anything", so `(.+)([a-z]+)$`-shaped
+  patterns were wrongly accepted as safe — a real ReDoS bypass, reopening the
+  exact class #196/#200 closed for other atom shapes; and (2) a `(?:...)`/
+  `(?P<name>...)` group's marker prefix was analyzed as literal match text
+  instead of being stripped first, so two charset-disjoint non-capturing
+  groups like `(?:[a-z]+)(?:[0-9]+)` were wrongly *rejected* as unsafe. Both
+  are covered by new regression tests; lookaround groups (`(?=...)`, `(?!...)`)
+  are intentionally left out of scope for the second fix and keep their
+  existing conservative (reject) behavior.
+- **Fixed** `Mp4Handler.embed()` raised on a `str` path instead of accepting
+  one like every other media handler, and `Pipeline.step()` accepted any
+  object as a provider instead of validating it's a `BaseProvider` — a
+  non-provider value previously surfaced a confusing failure deep inside
+  `run()` instead of immediately at the call site (#224, #225).
+
+### genblaze-openai / genblaze-google (chat helpers)
+
+- **Added** opt-in rate-limit backoff for `chat()`/`achat()` and the vision
+  helpers via `retry_on_rate_limit=`/`retry_policy=` kwargs, wrapping calls in
+  `genblaze_core.providers.retry.call_with_rate_limit_retry` (#221). A
+  follow-up in this same release disables the SDK's own internal retry when
+  genblaze already manages backoff on an internally-created client, closing a
+  double-retry (multiplicative wait) bug the initial opt-in introduced; a
+  caller-supplied `client=` keeps its own retry configuration untouched
+  (#221, #235). Currently wired into `openai`/`google` only — see
+  `docs/features/llm-calls.md`.
+- **Fixed** (`genblaze-openai`) confirmed `estimate_cost()` already computed
+  per-model pricing correctly; the reported gap was a documentation error in
+  `docs/reference/pricing-recipes.md`, now corrected, plus added test
+  coverage pinning the existing (correct) behavior (#222, #223). No
+  production code changed.
+
+### genblaze-google
+
+- **Added** `GeminiImageProvider`, a native Gemini image-generation provider
+  (`google-gemini-image` entry point) alongside the existing Imagen provider,
+  sharing client construction via a new `GoogleClientMixin` (#205).
+- **Fixed** the Imagen entitlement probe re-grades a probe-confirmed-`LIVE`
+  but known-gated slug to `OK_PROVISIONAL` instead of a misleading
+  authoritative `OK`, mirroring the same gmicloud fix below (#206).
+- **Fixed** `chat()`/vision calls sent an `ImageURLContent` input as an
+  unsupported field instead of translating it to Gemini's
+  `inline_data`/`file_data` wire format (#217).
+
+### genblaze-gmicloud
+
+- **Fixed** preflight validation now distinguishes a known-catalog slug from
+  one confirmed callable with the caller's API key, re-grading a
+  probe-confirmed slug that isn't confirmed-callable to `OK_PROVISIONAL`
+  instead of a misleading authoritative `OK` (#193). Added a guard against a
+  misconfigured `base_url`/`GMI_BASE_URL` pointed at the wrong endpoint shape
+  (a silent-404 footgun), and an edit-mode fallback path.
+
+### genblaze-runway
+
+- **Fixed** `image_to_video` on models that require an input image (e.g.
+  `gen4_turbo`, `gen3a_turbo`) now raises a clear, actionable error instead of
+  silently failing when no image is supplied; corrected the model catalog's
+  ratio literals, which were wrong pixel-dimension strings for several models
+  (#226).
+
+### genblaze-lmnt
+
+- **Fixed** an unsupported `seed` parameter was silently forwarded to
+  `generate_detailed` instead of being dropped; it's now dropped with a
+  one-time warning so callers know to stop passing it (#207).
+
+### genblaze-cli
+
+- **Fixed** `verify --fetch` accepted a `file://` URL with a remote authority
+  (e.g. `file://evil-host/path`) instead of rejecting it, and could leak
+  presigned-URL userinfo/credentials into output; both are now blocked/
+  redacted. Also dedupes redundant stream-hash computation on the same asset
+  (#214).
+
+### genblaze (umbrella)
+
+- **Fixed** `OptionalDependencyError`'s `__getattr__` propagation preserved
+  the original install hint instead of losing it to a generic message
+  (#213).
+- **Added** a `parquet` extra re-exposing `genblaze-core[parquet]`, so
+  `pip install "genblaze[parquet]"` — the exact incantation
+  `OptionalDependencyError` prints for `ParquetSink` — resolves instead of
+  failing with an unknown-extra error.
+
+### Packaging
+
+- **Fixed** nine connectors' (`genblaze-assemblyai`, `-decart`,
+  `-elevenlabs`, `-google`, `-hume`, `-lmnt`, `-nvidia`, `-openai`,
+  `-stability-audio`) `genblaze-core` dependency floor was raised to
+  `>=0.3.7` for `local_file_url()` users, but each package's own published
+  version wasn't bumped alongside it (#209) — a `pypi-pin-parity` trap that
+  would have blocked (not silently shipped) this release. Closed here by
+  bumping all nine to a new patch version.
+
 ### Internal
 
 - **Fixed** `install-verify`'s "Wait for PyPI to index the umbrella" pre-check
@@ -20,6 +155,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   truly missing/unresolvable package still fails the job after retries are
   exhausted. The umbrella pre-check and the import-smoke invocation are
   unchanged. Release tooling only — no packaged code changed.
+- **Fixed** the lint job's `ruff` version could drift from what contributors
+  run locally, producing false-red CI on a clean local run; pinned to
+  `0.14.0` (#212).
+- **Fixed** Dependabot could propose a major-version bump on a runtime
+  dependency, which this repo's pinning policy caps below the next major by
+  hand; Dependabot config now excludes major-version updates for runtime
+  deps (#216).
+- **Fixed** `tools/batch_cluster.py` could drop an in-flight dependency
+  blocker between clustering passes (#210).
+- **Chore** bumped the GitHub Actions dependency group (#191).
 
 ## [0.6.0] - 2026-07-22
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-cli"
-version = "0.3.5"
+version = "0.3.6"
 description = "CLI for genblaze manifest operations"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "cli", "command-line"]
 
 dependencies = [
-    "genblaze-core>=0.3.7,<0.4",
+    "genblaze-core>=0.3.8,<0.4",
     # <9: bounded-major convention (#61) — caps below the next major so a
     # future click release can't silently break the CLI at resolve time.
     "click>=8.0,<9",

--- a/docs/exec-plans/active/onboarding-feedback-response.md
+++ b/docs/exec-plans/active/onboarding-feedback-response.md
@@ -95,9 +95,13 @@ findings, ranked by how broken they are:
   confirm `python -c "import pyarrow"` succeeds for both. Paste output in PR.
 - **CHANGELOG:** add a `New extras` note that users pinning
   `genblaze-cli[parquet]` will now pull `pyarrow>=14.0` on upgrade.
-- Decision deferred: whether to *also* add `genblaze[parquet]` on the umbrella
-  for symmetry. Default to **no** — keeps the umbrella focused on the SDK
-  surface and avoids dragging pyarrow into pure-SDK installs.
+- **Resolved (v0.7.0, #236):** `genblaze[parquet]` now exists on the
+  umbrella, re-exposing `genblaze-core[parquet]` — the earlier "default to
+  no" call above didn't hold up: it's an opt-in extra like every other one
+  here, so it doesn't drag pyarrow into a plain `pip install genblaze`. This
+  closes the specific complaint in issue #6 (the error message pointing at a
+  nonexistent umbrella extra); `genblaze-cli[index]`/`[parquet]` above is
+  still open, tracked separately.
 
 ### A3 — Version compatibility table (#1)
 

--- a/libs/connectors/assemblyai/pyproject.toml
+++ b/libs/connectors/assemblyai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-assemblyai"
-version = "0.3.1"
+version = "0.3.2"
 description = "AssemblyAI (speech-to-text / transcription) provider adapter for genblaze"
 authors = [{name = "Eduardo Pavez", email = "epavez@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/decart/pyproject.toml
+++ b/libs/connectors/decart/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-decart"
-version = "0.3.2"
+version = "0.3.3"
 description = "Decart Lucy video/image provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/elevenlabs/pyproject.toml
+++ b/libs/connectors/elevenlabs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-elevenlabs"
-version = "0.3.2"
+version = "0.3.3"
 description = "ElevenLabs TTS and sound effects provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/gmicloud/pyproject.toml
+++ b/libs/connectors/gmicloud/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-gmicloud"
-version = "0.3.4"
+version = "0.3.5"
 description = "GMICloud media provider adapters for genblaze (video, image, audio)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/google/pyproject.toml
+++ b/libs/connectors/google/pyproject.toml
@@ -22,7 +22,11 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "google", "veo", "imagen", "gemini"]
 
 dependencies = [
-    "genblaze-core>=0.3.7,<0.4",
+    # >=0.3.8: this connector imports call_with_rate_limit_retry, added to
+    # genblaze-core in 0.3.8 -- a >=0.3.7 floor would let pip resolve this
+    # package against the still-published 0.3.7 core and fail with
+    # ImportError at `import genblaze_google`.
+    "genblaze-core>=0.3.8,<0.4",
     # <2: bounded-major convention (#61) — caps below the next major so a
     # future google-genai release can't silently break this connector at
     # resolve time.

--- a/libs/connectors/google/pyproject.toml
+++ b/libs/connectors/google/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-google"
-version = "0.3.3"
+version = "0.3.4"
 description = "Google provider adapters for genblaze (Veo video, Imagen + Gemini image)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/hume/pyproject.toml
+++ b/libs/connectors/hume/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-hume"
-version = "0.3.2"
+version = "0.3.3"
 description = "Hume AI (Octave TTS) provider adapter for genblaze"
 authors = [{name = "Kamren Mahaney", email = "kmahaney@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/lmnt/pyproject.toml
+++ b/libs/connectors/lmnt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-lmnt"
-version = "0.3.2"
+version = "0.3.3"
 description = "LMNT text-to-speech provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/nvidia/pyproject.toml
+++ b/libs/connectors/nvidia/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-nvidia"
-version = "0.3.2"
+version = "0.3.3"
 description = "NVIDIA NIM / build.nvidia.com media provider adapters for genblaze (video, image, audio, chat)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/openai/pyproject.toml
+++ b/libs/connectors/openai/pyproject.toml
@@ -22,7 +22,11 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "openai", "sora", "dall-e", "tts", "whisper"]
 
 dependencies = [
-    "genblaze-core>=0.3.7,<0.4",
+    # >=0.3.8: this connector imports call_with_rate_limit_retry, added to
+    # genblaze-core in 0.3.8 -- a >=0.3.7 floor would let pip resolve this
+    # package against the still-published 0.3.7 core and fail with
+    # ImportError at `import genblaze_openai`.
+    "genblaze-core>=0.3.8,<0.4",
     # <3: bounded-major convention (#61). The documented floor (1.0) predates
     # the SDK's current major line — openai resolves to 2.x today, so
     # capping at the next major after 1.0 (<2) would reject the version this

--- a/libs/connectors/openai/pyproject.toml
+++ b/libs/connectors/openai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-openai"
-version = "0.3.3"
+version = "0.3.4"
 description = "OpenAI provider adapters for genblaze (Sora, DALL-E, TTS)"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/runway/pyproject.toml
+++ b/libs/connectors/runway/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-runway"
-version = "0.3.2"
+version = "0.3.3"
 description = "Runway Gen video provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/connectors/stability-audio/pyproject.toml
+++ b/libs/connectors/stability-audio/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-stability-audio"
-version = "0.3.2"
+version = "0.3.3"
 description = "Stability AI Stable Audio provider adapter for genblaze"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -86,6 +86,27 @@ Known residual gaps (not detected):
   as a documented gap per this module's stated scope rather than chased
   (confirmed in review of the #196 fix — not a regression, since the
   pre-#196 heuristic missed these shapes too).
+* An escape sequence whose real match set differs from its own source
+  characters, other than the bare ``.`` wildcard (which ``_branch_charset``
+  does resolve to unknown/full) — e.g. a 3-digit octal escape resolves to
+  its four literal source characters instead of the single character it
+  actually matches, so two groups built from an octal escape and its
+  literal-character equivalent can look charset-disjoint when they aren't.
+  Same false-negative class the ``.`` fix closes, left open for this
+  narrower, rarely-used escape family rather than chased exhaustively.
+* A ``?``-prefixed group construct ``_GROUP_MARKER`` doesn't recognize —
+  scoped inline flags (``(?i:...)``), atomic groups (``(?>...)``), and
+  lookarounds (``(?=...)``, ``(?!...)``, ``(?<=...)``, ``(?<!...)``) — is
+  intentionally left with its marker characters unstripped before charset
+  analysis (see ``_has_adjacent_unbounded_groups``), so those characters
+  can spuriously collide with a sibling group's charset and cause
+  over-rejection (e.g. ``(?i:[0-9]+)(?:[a-z]+)$`` is rejected because the
+  ``i`` in ``?i:`` collides with ``[a-z]``). Recognizing every one of these
+  prefixes correctly would also require deciding what each construct means
+  for adjacency (a lookaround, unlike ``?:``/``?P<name>``, is zero-width
+  and can never actually overlap a neighbor — see the fix below), so this
+  is left as a documented gap rather than generalized past the two marker
+  shapes reported.
 
 These are all true ReDoS shapes — the same exponential class this module
 detects elsewhere, differing only in that *detecting* them requires
@@ -214,9 +235,13 @@ def _has_nested_unbounded_quantifier(src: str) -> bool:
 
 
 def _is_nullable_separator(fragment: str) -> bool:
-    """True if ``fragment`` — the raw text sitting between two top-level
-    groups — can itself match the empty string, e.g. ``-?``, ``\\s*``,
-    ``(?:foo)?``, or the empty string itself.
+    """True if ``fragment`` can itself match the empty string, e.g. ``-?``,
+    ``\\s*``, ``(?:foo)?``, or the empty string itself.
+
+    ``fragment`` is usually the raw text sitting between two top-level
+    groups, but ``_has_adjacent_unbounded_groups`` also passes a group's own
+    (marker-stripped) body here, to ask the same question about the group
+    itself: can its content match zero repetitions (e.g. ``b*`` vs. ``b+``)?
 
     A separator that can vanish doesn't break adjacency: on the adversarial
     input that makes the two flanking groups ambiguous, the regex engine
@@ -353,10 +378,13 @@ def _has_adjacent_unbounded_groups(src: str, flags: int = 0) -> bool:
         # and `:` to the group's charset as if they were real matchable
         # characters, so two disjoint non-capturing groups like
         # `(?:[a-z]+)(?:[0-9]+)` spuriously "overlap" via those marker
-        # characters and get rejected (a confirmed false positive). An
-        # unrecognized `?`-prefixed body (a lookaround) is intentionally
-        # left unstripped -- its existing conservative handling is
-        # unrelated to this fix and out of scope here.
+        # characters and get rejected (a confirmed false positive). A
+        # `?`-prefixed body _GROUP_MARKER doesn't recognize (a lookaround,
+        # a scoped inline flag) is intentionally left unstripped: unlike
+        # `?:`/`?P<name>`, those constructs' semantics vary (a lookaround is
+        # zero-width and can't overlap a neighbor at all), so folding them
+        # into the same charset analysis needs its own reasoning per
+        # construct -- see the "Known residual gaps" note above.
         marker = _GROUP_MARKER.match(body)
         if marker:
             body = body[marker.end() :]

--- a/libs/core/genblaze_core/providers/pattern_safety.py
+++ b/libs/core/genblaze_core/providers/pattern_safety.py
@@ -346,6 +346,20 @@ def _has_adjacent_unbounded_groups(src: str, flags: int = 0) -> bool:
     carried: frozenset[str] | None = None
     for start, end in top_level:
         body = src[start + 1 : end]
+        # Strip a recognized non-capturing/named-group marker before any of
+        # the reads below, mirroring _has_ambiguous_quantified_alternation
+        # (see its own marker handling). Without this, `(?:[a-z]+)`'s body
+        # is the literal text `?:[a-z]+` -- `_branch_charset` then adds `?`
+        # and `:` to the group's charset as if they were real matchable
+        # characters, so two disjoint non-capturing groups like
+        # `(?:[a-z]+)(?:[0-9]+)` spuriously "overlap" via those marker
+        # characters and get rejected (a confirmed false positive). An
+        # unrecognized `?`-prefixed body (a lookaround) is intentionally
+        # left unstripped -- its existing conservative handling is
+        # unrelated to this fix and out of scope here.
+        marker = _GROUP_MARKER.match(body)
+        if marker:
+            body = body[marker.end() :]
         unbounded = bool(re.search(_UNBOUNDED_QUANT, body))
         resolved = (
             _resolved_charset(*_branch_charset(body, allow_unbounded=True, flags=flags))
@@ -625,6 +639,17 @@ def _branch_charset(
                 return False, None
             atom_charset = _bracket_charset(branch[i + 1 : close])
             i = close + 1
+        elif ch == ".":
+            # An unescaped `.` matches any character (except a newline,
+            # absent re.DOTALL) -- not the literal character '.'. Treating
+            # it as {'.'} let two adjacent groups built from e.g. `.+` look
+            # charset-disjoint from a sibling `[a-z]+` when they can
+            # actually both match the same input, reopening the exact
+            # ReDoS bypass class #200 closed for other atom shapes (a
+            # confirmed regression: `(.+)([a-z]+)$` is flagged safe without
+            # this branch).
+            atom_charset = None
+            i += 1
         else:
             atom_charset = frozenset(ch)
             i += 1

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze-core"
-version = "0.3.7"
+version = "0.3.8"
 description = "Core SDK for genblaze media generation orchestration"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -294,6 +294,66 @@ class TestIgnoreCaseAwareCharsetOverlap:
             assert_safe(re.compile("(İ+)(i+)(İ+)(i+)(İ+)(i+)$", re.IGNORECASE))
 
 
+class TestWildcardAdjacentGroupsOverlap:
+    """Regression tests for a release-readiness-panel finding: `.` was
+    treated as the literal character '.' by `_branch_charset` instead of
+    "matches anything", so two adjacent unbounded groups built from `.+`
+    looked charset-disjoint from an `[a-z]+` sibling even though they can
+    match the same input at runtime -- reopening the exact ReDoS bypass
+    class #200 closed for other atom shapes. Confirmed regression: before
+    this fix, `_heuristic_unsafe(r"(.+)([a-z]+)$")` returned `False`."""
+
+    def test_wildcard_adjacent_to_charset_group_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(.+)([a-z]+)$"))
+
+    def test_wildcard_adjacent_groups_reported_adversarial_shape_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(.+)([a-z]+)(.+)([a-z]+)(.+)([a-z]+)$"))
+
+    def test_wildcard_adjacent_to_wildcard_still_rejected(self) -> None:
+        # Sanity check: two `.+` groups were already correctly rejected
+        # before this fix (both resolve to the same literal '.' charset by
+        # accident) -- must stay rejected afterward too, now for the
+        # correct reason (both are unknown/full, which always overlaps).
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"(.+)(.+)$"))
+
+
+class TestNonCapturingGroupCharsetOverlap:
+    """Regression tests for a release-readiness-panel finding:
+    `_has_adjacent_unbounded_groups` analyzed a group's RAW body -- including
+    a leading `?:`/`?P<name>` marker -- instead of stripping it first (unlike
+    the sibling `_has_ambiguous_quantified_alternation`, which already does).
+    `?` and `:` were added to the group's charset as if they were real
+    matchable characters, so two charset-disjoint non-capturing groups
+    spuriously "overlapped" via those marker characters and were rejected.
+    Confirmed regression: before this fix,
+    `_heuristic_unsafe(r"^(?:[a-z]+)(?:[0-9]+)$")` returned `True` even
+    though this is a safe, linear-time pattern."""
+
+    def test_non_capturing_disjoint_groups_allowed(self) -> None:
+        assert_safe(re.compile(r"^(?:[a-z]+)(?:[0-9]+)$"))
+
+    def test_non_capturing_overlapping_groups_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="catastrophic backtracking"):
+            assert_safe(re.compile(r"^(?:[a-z]+)(?:[a-z]+)$"))
+
+    def test_named_group_disjoint_from_non_capturing_allowed(self) -> None:
+        assert_safe(re.compile(r"^(?P<letters>[a-z]+)(?:[0-9]+)$"))
+
+    def test_lookahead_adjacent_to_unbounded_group_still_rejected(self) -> None:
+        # A lookaround marker (`?=`, `?!`, ...) is intentionally left
+        # unstripped by this fix -- it's a distinct, out-of-scope construct
+        # (zero-width, not a capturing/non-capturing group) whose existing
+        # conservative handling must not regress as a side effect of the
+        # `?:`/`?P<name>` fix above. Tested against the static heuristic
+        # directly, not `assert_safe()`: when `google-re2` is installed it
+        # rejects this pattern first anyway (lookarounds are an unsupported
+        # re2 construct), which would mask a heuristic regression here.
+        assert _heuristic_unsafe(r"(a+)(?=[0-9]+)(a+)$") is True
+
+
 class TestHeuristicUnsafe:
     """Direct tests of the heuristic detector, independent of whether
     ``re2`` happens to be installed in the environment. Installing

--- a/libs/core/tests/unit/test_pattern_safety.py
+++ b/libs/core/tests/unit/test_pattern_safety.py
@@ -295,7 +295,7 @@ class TestIgnoreCaseAwareCharsetOverlap:
 
 
 class TestWildcardAdjacentGroupsOverlap:
-    """Regression tests for a release-readiness-panel finding: `.` was
+    """Regression tests for a bug in the #200 charset-overlap gate: `.` was
     treated as the literal character '.' by `_branch_charset` instead of
     "matches anything", so two adjacent unbounded groups built from `.+`
     looked charset-disjoint from an `[a-z]+` sibling even though they can
@@ -321,7 +321,7 @@ class TestWildcardAdjacentGroupsOverlap:
 
 
 class TestNonCapturingGroupCharsetOverlap:
-    """Regression tests for a release-readiness-panel finding:
+    """Regression tests for a bug in the #200 charset-overlap gate:
     `_has_adjacent_unbounded_groups` analyzed a group's RAW body -- including
     a leading `?:`/`?P<name>` marker -- instead of stripping it first (unlike
     the sibling `_has_ambiguous_quantified_alternation`, which already does).
@@ -342,16 +342,27 @@ class TestNonCapturingGroupCharsetOverlap:
     def test_named_group_disjoint_from_non_capturing_allowed(self) -> None:
         assert_safe(re.compile(r"^(?P<letters>[a-z]+)(?:[0-9]+)$"))
 
-    def test_lookahead_adjacent_to_unbounded_group_still_rejected(self) -> None:
+    def test_lookahead_between_overlapping_unbounded_groups_still_rejected(self) -> None:
         # A lookaround marker (`?=`, `?!`, ...) is intentionally left
         # unstripped by this fix -- it's a distinct, out-of-scope construct
         # (zero-width, not a capturing/non-capturing group) whose existing
         # conservative handling must not regress as a side effect of the
-        # `?:`/`?P<name>` fix above. Tested against the static heuristic
-        # directly, not `assert_safe()`: when `google-re2` is installed it
-        # rejects this pattern first anyway (lookarounds are an unsupported
-        # re2 construct), which would mask a heuristic regression here.
+        # `?:`/`?P<name>` fix above. This case is rejected via the carried-
+        # charset union reaching back to the first `(a+)`, not because the
+        # lookahead itself is treated as unsafe -- see the next test.
+        # Tested against the static heuristic directly, not `assert_safe()`:
+        # when `google-re2` is installed it rejects this pattern first
+        # anyway (lookarounds are an unsupported re2 construct), which would
+        # mask a heuristic regression here.
         assert _heuristic_unsafe(r"(a+)(?=[0-9]+)(a+)$") is True
+
+    def test_lookahead_between_disjoint_unbounded_groups_allowed(self) -> None:
+        # The case that actually discriminates "leave lookarounds
+        # unstripped" from "resolve them to unknown/full charset": a
+        # zero-width lookahead can never itself overlap a neighboring
+        # group, so forcing it to unknown/full (the naive alternative fix)
+        # would wrongly reject this genuinely disjoint, linear-time pattern.
+        assert _heuristic_unsafe(r"(a+)(?=[0-9]+)(b+)$") is False
 
 
 class TestHeuristicUnsafe:

--- a/libs/meta/README.md
+++ b/libs/meta/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-23 -->
+<!-- last_verified: 2026-07-28 -->
 # genblaze
 
 Umbrella metapackage for genblaze — a provider-agnostic SDK for AI media generation with built-in provenance (manifests, SHA-256 hashing, B2/S3 durable storage).
@@ -22,6 +22,9 @@ pip install "genblaze[audio]"     # ElevenLabs + LMNT + Stability Audio + GMIClo
 
 # Everything
 pip install "genblaze[all]"
+
+# Optional: Parquet-backed manifest sink (ParquetSink)
+pip install "genblaze[parquet]"
 ```
 
 ## Import

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genblaze"
-version = "0.4.4"
+version = "0.4.5"
 description = "Umbrella package for genblaze — installs genblaze-core + genblaze-s3 and re-exports the core API; use extras for provider bundles"
 authors = [{name = "Jeronimo De Leon", email = "jdeleon@backblaze.com"}]
 readme = "README.md"
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ["genblaze", "ai", "media", "manifest", "provenance", "c2pa-ready", "genai", "pipeline", "umbrella"]
 
 dependencies = [
-    "genblaze-core>=0.3.7,<0.4",
+    "genblaze-core>=0.3.8,<0.4",
     "genblaze-s3>=0.3.6,<0.4",
 ]
 
@@ -35,59 +35,65 @@ Issues = "https://github.com/backblaze-labs/genblaze/issues"
 
 [project.optional-dependencies]
 # Individual connectors
-gmicloud = ["genblaze-gmicloud>=0.3.4,<0.4"]
-openai = ["genblaze-openai>=0.3.3,<0.4"]
-google = ["genblaze-google>=0.3.3,<0.4"]
+gmicloud = ["genblaze-gmicloud>=0.3.5,<0.4"]
+openai = ["genblaze-openai>=0.3.4,<0.4"]
+google = ["genblaze-google>=0.3.4,<0.4"]
 replicate = ["genblaze-replicate>=0.3.4,<0.4"]
-runway = ["genblaze-runway>=0.3.2,<0.4"]
+runway = ["genblaze-runway>=0.3.3,<0.4"]
 luma = ["genblaze-luma>=0.3.2,<0.4"]
-decart = ["genblaze-decart>=0.3.2,<0.4"]
-elevenlabs = ["genblaze-elevenlabs>=0.3.2,<0.4"]
-stability-audio = ["genblaze-stability-audio>=0.3.2,<0.4"]
-lmnt = ["genblaze-lmnt>=0.3.2,<0.4"]
-hume = ["genblaze-hume>=0.3.2,<0.4"]
-assemblyai = ["genblaze-assemblyai>=0.3.1,<0.4"]
+decart = ["genblaze-decart>=0.3.3,<0.4"]
+elevenlabs = ["genblaze-elevenlabs>=0.3.3,<0.4"]
+stability-audio = ["genblaze-stability-audio>=0.3.3,<0.4"]
+lmnt = ["genblaze-lmnt>=0.3.3,<0.4"]
+hume = ["genblaze-hume>=0.3.3,<0.4"]
+assemblyai = ["genblaze-assemblyai>=0.3.2,<0.4"]
 langsmith = ["genblaze-langsmith>=0.3.2,<0.4"]
-nvidia = ["genblaze-nvidia>=0.3.2,<0.4"]
+nvidia = ["genblaze-nvidia>=0.3.3,<0.4"]
+
+# Re-exposes genblaze-core's own `parquet` extra (ParquetSink) so
+# `pip install "genblaze[parquet]"` -- the exact incantation
+# OptionalDependencyError prints, see genblaze_core._optional -- actually
+# resolves instead of failing with an unknown-extra error.
+parquet = ["genblaze-core[parquet]>=0.3.8,<0.4"]
 
 # Curated bundles
 video = [
-    "genblaze-gmicloud>=0.3.4,<0.4",
-    "genblaze-google>=0.3.3,<0.4",
-    "genblaze-runway>=0.3.2,<0.4",
+    "genblaze-gmicloud>=0.3.5,<0.4",
+    "genblaze-google>=0.3.4,<0.4",
+    "genblaze-runway>=0.3.3,<0.4",
     "genblaze-luma>=0.3.2,<0.4",
-    "genblaze-decart>=0.3.2,<0.4",
-    "genblaze-nvidia>=0.3.2,<0.4",
+    "genblaze-decart>=0.3.3,<0.4",
+    "genblaze-nvidia>=0.3.3,<0.4",
 ]
 image = [
-    "genblaze-gmicloud>=0.3.4,<0.4",
-    "genblaze-openai>=0.3.3,<0.4",
-    "genblaze-google>=0.3.3,<0.4",
-    "genblaze-nvidia>=0.3.2,<0.4",
+    "genblaze-gmicloud>=0.3.5,<0.4",
+    "genblaze-openai>=0.3.4,<0.4",
+    "genblaze-google>=0.3.4,<0.4",
+    "genblaze-nvidia>=0.3.3,<0.4",
 ]
 audio = [
-    "genblaze-elevenlabs>=0.3.2,<0.4",
-    "genblaze-lmnt>=0.3.2,<0.4",
-    "genblaze-hume>=0.3.2,<0.4",
-    "genblaze-stability-audio>=0.3.2,<0.4",
-    "genblaze-gmicloud>=0.3.4,<0.4",
-    "genblaze-nvidia>=0.3.2,<0.4",
+    "genblaze-elevenlabs>=0.3.3,<0.4",
+    "genblaze-lmnt>=0.3.3,<0.4",
+    "genblaze-hume>=0.3.3,<0.4",
+    "genblaze-stability-audio>=0.3.3,<0.4",
+    "genblaze-gmicloud>=0.3.5,<0.4",
+    "genblaze-nvidia>=0.3.3,<0.4",
 ]
 all = [
-    "genblaze-gmicloud>=0.3.4,<0.4",
-    "genblaze-openai>=0.3.3,<0.4",
-    "genblaze-google>=0.3.3,<0.4",
+    "genblaze-gmicloud>=0.3.5,<0.4",
+    "genblaze-openai>=0.3.4,<0.4",
+    "genblaze-google>=0.3.4,<0.4",
     "genblaze-replicate>=0.3.4,<0.4",
-    "genblaze-runway>=0.3.2,<0.4",
+    "genblaze-runway>=0.3.3,<0.4",
     "genblaze-luma>=0.3.2,<0.4",
-    "genblaze-decart>=0.3.2,<0.4",
-    "genblaze-elevenlabs>=0.3.2,<0.4",
-    "genblaze-stability-audio>=0.3.2,<0.4",
-    "genblaze-lmnt>=0.3.2,<0.4",
-    "genblaze-hume>=0.3.2,<0.4",
-    "genblaze-assemblyai>=0.3.1,<0.4",
+    "genblaze-decart>=0.3.3,<0.4",
+    "genblaze-elevenlabs>=0.3.3,<0.4",
+    "genblaze-stability-audio>=0.3.3,<0.4",
+    "genblaze-lmnt>=0.3.3,<0.4",
+    "genblaze-hume>=0.3.3,<0.4",
+    "genblaze-assemblyai>=0.3.2,<0.4",
     "genblaze-langsmith>=0.3.2,<0.4",
-    "genblaze-nvidia>=0.3.2,<0.4",
+    "genblaze-nvidia>=0.3.3,<0.4",
 ]
 dev = ["pytest>=7.0"]
 

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -54,6 +54,11 @@ nvidia = ["genblaze-nvidia>=0.3.3,<0.4"]
 # `pip install "genblaze[parquet]"` -- the exact incantation
 # OptionalDependencyError prints, see genblaze_core._optional -- actually
 # resolves instead of failing with an unknown-extra error.
+# NOTE: tools/prepare_release.py's rewrite_floors() only matches
+# `name>=floor`, not a `name[extra]>=floor` pin -- this floor is NOT synced
+# automatically when core's version bumps in a future wave. Bump it by hand
+# alongside `genblaze-core`'s own floor above until the tool supports this
+# shape.
 parquet = ["genblaze-core[parquet]>=0.3.8,<0.4"]
 
 # Curated bundles


### PR DESCRIPTION
## Summary

Release-readiness fixes for the v0.7.0 wave (everything merged to `main` since the `v0.6.0` tag, #190-#235), found by a 5-perspective review panel plus independent verification and cross-checked against a separately-reported feedback list.

- **Fix two ReDoS-heuristic regressions in `pattern_safety.py`** introduced by the #196/#200 charset-overlap fix:
  - An unescaped `.` resolved to the literal character `'.'` instead of "matches anything," so `(.+)([a-z]+)$`-shaped catastrophic-backtracking patterns were wrongly accepted as safe — a real ReDoS bypass, reopening the exact class #196/#200 closed for other atom shapes.
  - A `(?:...)`/`(?P<name>...)` group's marker prefix was analyzed as literal match text instead of being stripped first (unlike the sibling function that already does this), so charset-disjoint non-capturing groups like `(?:[a-z]+)(?:[0-9]+)` were wrongly *rejected* as unsafe.
  - Added regression tests for both, plus a lookaround-group case guarding against a related false-positive an earlier draft of the second fix would have introduced.
- **Bump 9 connector package versions** (`assemblyai`, `decart`, `elevenlabs`, `hume`, `lmnt`, `nvidia`, `stability-audio`, `openai`, `google`) plus `genblaze-core`, `genblaze-cli`, and the umbrella package via `tools/prepare_release.py --apply`. These 9 had their `genblaze-core` floor raised (#209) without a version bump, which would have failed the `pypi-pin-parity` release gate.
- **Cut `CHANGELOG.md`** — `[Unreleased]` only documented 1 of ~19 merged PRs; backfilled a `## [0.7.0]` section covering all of them, including the two `pattern_safety.py` fixes above.
- **Add a `parquet` extra to the umbrella package** (`libs/meta/pyproject.toml`) — core advertises `parquet` and `OptionalDependencyError` tells users to `pip install "genblaze[parquet]"`, but the umbrella package never exposed that extra, so the printed instruction failed.

## Test plan

- [x] New regression tests for both `pattern_safety.py` fixes, including a lookahead-adjacency case (146/146 tests pass in that module)
- [x] Full `genblaze-core` suite passes (2128 passed, 3 skipped)
- [x] `openai`/`google`/`gmicloud`/`runway`/`lmnt` connector suites pass unchanged
- [x] `python tools/prepare_release.py --check` reports no further prep needed (idempotent)
- [x] `python tools/check_pin_parity.py` reports `0 drift`
- [x] Changelog-gate logic simulated locally: `[Unreleased]` is empty
- [x] `make pre-release` passes end-to-end (lint, typecheck, ts-types-check, pypi-metadata-check, pypi-pin-parity, full test suite, release-smoke building+installing+importing every wheel from a fresh venv)

Not in scope for this PR (deferred, lower severity): `HttpRetryOptions` version-floor gap in the google connector, stale Google connector docs/model-matrix, `Pipeline.step()`'s duck-typing break, docstring process-narrative cleanup, entitlement-regrade code duplication between gmicloud/google, `GeminiImageProvider` dropping unsupported inputs/params, ruff pin drift across 3 config files, media-handler path-coercion duplication.