### PR TITLE
fix(core): expose lazy imports to introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### genblaze-core
+
+- **Fixed** lazy top-level exports now appear in `dir(genblaze_core)` before
+  first access, and `RunnableConfig` is available directly from
+  `genblaze_core` (#55).
+
 ## [0.7.0] - 2026-07-28
 
 Bug-fix wave with one new opt-in feature and one new provider. Closes a

--- a/docs/exec-plans/completed/issue-55-core-import-discovery.md
+++ b/docs/exec-plans/completed/issue-55-core-import-discovery.md
@@ -1,0 +1,27 @@
+# Issue 55: core import discovery
+
+## Context
+
+`genblaze_core` exposes its public API through `__all__` and a lazy `__getattr__` table. Lazy names are absent from the module dictionary before first access, so the default `dir()` cannot discover them. `RunnableConfig` is also used throughout provider and runnable signatures but is missing from the top-level export surface. The `genblaze` umbrella already implements `__dir__()` by combining `__all__` with module globals.
+
+## Scope
+
+- Add `RunnableConfig` to the core lazy import table.
+- Add a core `__dir__()` matching the umbrella behavior.
+- Test discovery before first access and top-level import identity.
+- Document the public import behavior and add an unreleased changelog entry.
+
+Provider behavior, wire models, canonical hashing, connector packages, and runtime configuration semantics are out of scope.
+
+## Validation
+
+1. Run the two new tests before the implementation and confirm both fail.
+2. Run the target core import tests after the implementation.
+3. Run the core and meta suites, then the repository `make test` gate.
+4. Run `make lint` and verify the changed public imports in a fresh interpreter.
+
+## Outcome
+
+The core package now exposes `RunnableConfig` lazily and reports all names in
+`__all__` through `dir()`. Regression tests cover both behaviors. No wire model,
+provider, or canonical serialization code changed.

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-04-22 -->
+<!-- last_verified: 2026-07-29 -->
 # genblaze-core
 
 **Python SDK for building generative AI pipelines across video, image, and audio — with built-in SHA-256 provenance.**
@@ -44,6 +44,19 @@ Optional extras:
 pip install "genblaze-core[parquet]"   # ParquetSink for analytics
 pip install "genblaze-core[audio]"     # Audio metadata embedding (mutagen)
 ```
+
+## Public imports
+
+The supported top-level API is available directly from `genblaze_core`, including
+runnable configuration types:
+
+```python
+from genblaze_core import Pipeline, RunnableConfig
+```
+
+Imports are resolved lazily. `dir(genblaze_core)` still lists the full public
+surface, so REPL completion and introspection work before individual modules are
+loaded.
 
 Add provider adapters separately:
 

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -7,6 +7,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "Pipeline": ("genblaze_core.pipeline.pipeline", "Pipeline"),
     "PipelineResult": ("genblaze_core.pipeline.result", "PipelineResult"),
     "StepCompleteEvent": ("genblaze_core.pipeline.result", "StepCompleteEvent"),
+    # runnable configuration
+    "RunnableConfig": ("genblaze_core.runnable.config", "RunnableConfig"),
     # pipeline cache
     "StepCache": ("genblaze_core.pipeline.cache", "StepCache"),
     # pipeline templates
@@ -132,6 +134,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 }
 
 __all__ = [*_LAZY_IMPORTS.keys(), "__version__"]
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(globals().keys()))
 
 
 def __getattr__(name: str):

--- a/libs/core/tests/unit/test_all_public_names_importable.py
+++ b/libs/core/tests/unit/test_all_public_names_importable.py
@@ -19,6 +19,30 @@ import sys
 import genblaze_core
 
 
+def test_dir_surfaces_lazy_names_before_first_access() -> None:
+    """Lazy public names must be discoverable without importing their modules."""
+    script = (
+        "import genblaze_core;"
+        "assert 'Pipeline' not in genblaze_core.__dict__;"
+        "assert 'Pipeline' in dir(genblaze_core)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_runnable_config_is_a_top_level_export() -> None:
+    """RunnableConfig is part of the public runnable API."""
+    from genblaze_core import RunnableConfig
+    from genblaze_core.runnable.config import RunnableConfig as NestedRunnableConfig
+
+    assert RunnableConfig is NestedRunnableConfig
+
+
 def test_all_public_names_resolve() -> None:
     """Every name in __all__ must be retrievable without AttributeError."""
     failures = []


### PR DESCRIPTION
## Summary

Make the lazy `genblaze_core` public surface discoverable through `dir()` and export `RunnableConfig` from the top-level package.

## Changes

- add `RunnableConfig` to the core lazy import table
- implement `genblaze_core.__dir__()` using the umbrella package pattern
- cover pre-access discovery and top-level import identity
- document the import surface and add an unreleased changelog entry

## Test plan

- [x] `make test`
- [x] `ruff check libs/ cli/ examples/`
- [x] `ruff format --check` for the changed Python files
- [x] `make deptry`
- [ ] `make lint` (the format step reports the same 17 pre-existing README code-block formatting issues on clean `ec81e81` with ruff 0.16.0)
- [x] Docs updated

## Related

Closes #55