### PR TITLE
docs(release): clarify wave tag vs. PyPI version confusion

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -54,7 +54,11 @@ and prose):
 
 1. Cut `CHANGELOG.md`'s `[Unreleased]` section to `## [X.Y.Z] - <today>`, pasting in
    the `### Released package versions` list the script just emitted. Fold in any
-   entries that were mis-sectioned under the wrong package heading.
+   entries that were mis-sectioned under the wrong package heading. Carry forward
+   the "wave vs. package version" paragraph from the most recent prior wave (see
+   the current `## [0.7.0]` entry) — the GitHub Release body is generated verbatim
+   from this section, so a dropped paragraph here silently disappears from the
+   published release notes too.
 2. Leave `[Unreleased]` empty — `changelog-gate` in `release.yml` fails the release
    otherwise.
 3. **The tag name is `v` + that heading, exactly** (e.g. heading `## [0.5.0]` → tag
@@ -125,7 +129,15 @@ not run them for you:
 ```bash
 git tag -a v<wave> -m "Release <wave>"
 git push origin v<wave>
-gh release create v<wave> --title "<wave>" --notes-from-tag
+# --notes-from-tag would just repeat the tag message ("Release <wave>") as the
+# body. Paste the actual CHANGELOG slice per RELEASING.md instead — extract it
+# and pass it via --notes-file:
+awk '/^## \[<wave>\]/{p=1} p&&/^## \[/&&!/^## \[<wave>\]/{exit} p' CHANGELOG.md > /tmp/release-notes-<wave>.md
+if test -s /tmp/release-notes-<wave>.md; then
+  gh release create v<wave> --title "<wave>" --notes-file /tmp/release-notes-<wave>.md
+else
+  echo "empty slice — check the wave heading; release NOT created" >&2
+fi
 # after the Release workflow finishes publishing:
 make post-release VERSION=<umbrella-version>
 ```

--- a/.claude/skills/release-check/SKILL.md
+++ b/.claude/skills/release-check/SKILL.md
@@ -51,7 +51,13 @@ A pass/fail table, then the exact next commands:
 git add <path>/pyproject.toml CHANGELOG.md
 git commit -m "release: <package> v<new-version>"
 git push
-gh release create <package>-v<new-version> --title "<package> v<new-version>" --notes-from-tag
 ```
 
-Do NOT create the tag or release yourself — leave it for the user to review and trigger.
+This gate gets one package release-ready within a wave — it does not tag or
+publish. The actual tag/release/publish flow is wave-level, not per-package
+(the workflow's `validate-version` job requires the tag to be `v<wave>`, the
+CHANGELOG's most recent version heading — see RELEASING.md's versioning
+policy); a tag shaped `<package>-v<new-version>` will not trigger it
+correctly. Once every package in the wave is ready, cut the release with
+`/prepare-release`, which also fixes the `--notes-from-tag` bare-body trap
+this skill previously suggested here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,5 +27,6 @@ What actually happened. Include error messages or tracebacks.
 ## Environment
 
 - Python version:
+- genblaze version (`pip show genblaze`, if installed via the umbrella):
 - genblaze-core version:
 - OS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ and closes a `verify --fetch` SSRF gap.
 
 This heading is the release **wave** name and the git tag (`v0.7.0`);
 individual PyPI package versions move independently and are listed below (the
-umbrella `genblaze` package is `0.4.5`).
+umbrella `genblaze` package is `0.4.5`). Wave tags and the umbrella's PyPI
+versions are separate sequences that happen to look alike — don't pin
+`genblaze==0.7.0`. A pin on a wave tag either fails outright or, worse,
+resolves silently to an unrelated umbrella build from a different wave (e.g.
+`genblaze==0.4.0` on PyPI predates the `v0.4.0` wave). Pin the exact umbrella
+version above, or a lockfile for full reproducibility (the umbrella pins
+ranges, not exact versions, for its own dependencies).
 
 ### Released package versions
 
@@ -195,7 +201,13 @@ verification of output assets against the manifest's committed digests.
 
 This heading is the release **wave** name and the git tag (`v0.6.0`); individual
 PyPI package versions move independently and are listed below (the umbrella
-`genblaze` package is `0.4.4`).
+`genblaze` package is `0.4.4`). Wave tags and the umbrella's PyPI versions are
+separate sequences that happen to look alike — don't pin `genblaze==0.6.0`. A
+pin on a wave tag either fails outright or, worse, resolves silently to an
+unrelated umbrella build from a different wave (e.g. `genblaze==0.4.0` on
+PyPI predates the `v0.4.0` wave). Pin the exact umbrella version above, or a
+lockfile for full reproducibility (the umbrella pins ranges, not exact
+versions, for its own dependencies).
 
 ### Released package versions
 
@@ -495,6 +507,16 @@ on the openai SDK 2.x, Google Veo on Vertex AI). Highlights: the ReDoS guard's
 heuristic now always runs, manifests load tolerantly while `verify()` stays the
 enforcement boundary, `ParquetSink` writes are index-backed and resink-correct,
 stream emitters are per-instance, and a batch of connector patch-republishes.
+
+This heading is the release **wave** name and the git tag (`v0.5.0`); individual
+PyPI package versions move independently and are listed below (the umbrella
+`genblaze` package is `0.4.3`). Wave tags and the umbrella's PyPI versions are
+separate sequences that happen to look alike — don't pin `genblaze==0.5.0`. A
+pin on a wave tag either fails outright or, worse, resolves silently to an
+unrelated umbrella build from a different wave (e.g. `genblaze==0.4.0` on
+PyPI predates the `v0.4.0` wave). Pin the exact umbrella version above, or a
+lockfile for full reproducibility (the umbrella pins ranges, not exact
+versions, for its own dependencies).
 
 ### Released package versions
 
@@ -912,6 +934,17 @@ stream emitters are per-instance, and a batch of connector patch-republishes.
 Security hardening (SSRF, URL-only asset verification), two new providers
 (Hume Octave TTS, AssemblyAI STT), and a batch of connector patch-republishes
 to update the `genblaze-core>=0.3.4` floor.
+
+This heading is the release **wave** name and the git tag (`v0.4.0`); individual
+PyPI package versions move independently and are listed below (the umbrella
+`genblaze` package is `0.4.1`, after the patch republish noted below). Wave
+tags and the umbrella's PyPI versions are separate sequences that happen to
+look alike — don't pin `genblaze==0.4.0`. That version *is* real and installs
+without error, which is the dangerous case: it's this wave's original wheel,
+published before the `0.4.1` patch republish fixed the connector floors, so
+it silently ships with the older, unfixed pins. Pin `genblaze==0.4.1` (this
+wave's actual umbrella), or a lockfile for full reproducibility (the umbrella
+pins ranges, not exact versions, for its own dependencies).
 
 ### Released package versions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-21 -->
+<!-- last_verified: 2026-08-01 -->
 <h1 align="center" style="border-bottom: none">
     Genblaze
 </h1>
@@ -46,6 +46,20 @@ pip install "genblaze[all]"           # + every provider
 ```
 
 The umbrella pulls in `genblaze-core` (pipeline + models) and `genblaze-s3` (Backblaze B2 / S3 storage) so you have a working provenance pipeline out of the box. Provider adapters are opt-in extras.
+
+> **A GitHub Release tag (e.g. `v0.7.0`) is not a `genblaze` version — don't pin `genblaze==<wave tag>`.**
+> The tag names a CHANGELOG *wave*; every package in that wave versions independently, so
+> wave tags and the umbrella's PyPI versions are separate sequences that happen to look
+> alike (see [RELEASING.md](RELEASING.md#versioning-policy)). A pin on a wave tag either:
+> - **fails outright** (no such version was published), or
+> - **resolves silently to an unrelated umbrella build from a different wave** — no
+>   error, just stale code (e.g. `genblaze==0.4.0` on PyPI predates the `v0.4.0` wave).
+>
+> Pin the exact umbrella version instead (from that wave's "Released package versions"
+> list in its [release notes](https://github.com/backblaze-labs/genblaze/releases)) — but
+> note the umbrella pins ranges (e.g. `genblaze-core>=0.3.8,<0.4`), not exact versions, so
+> even that isn't fully reproducible on its own. For a locked install, generate a lockfile
+> (`pip freeze`, `uv lock`, or a constraints file) once your stack works.
 
 Install packages individually if you prefer:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,7 +80,12 @@ Before cutting a release, verify on `main`:
 2. **CHANGELOG is cut.** The `[Unreleased]` section is empty; a new
    `## [X.Y.Z] - YYYY-MM-DD` section lists every package version change
    under "Released package versions" (the exact text `prepare_release.py`
-   emits).
+   emits). The section's intro must include the "wave vs. package version"
+   paragraph (see the `## [0.7.0]` entry for the current wording) — the
+   GitHub Release body is generated verbatim from this slice (see below), so
+   this is the only place that warning needs to be written for *release
+   notes*; the root `README.md` and `libs/meta/README.md` carry their own
+   copies for readers who never open a release page.
 3. **TS types are current.** `make ts-types` produces no diff. (CI's
    `ts-types-check` job already enforces this on every push, but the
    release workflow re-runs it as a defense in depth.)
@@ -116,7 +121,20 @@ Triggered two ways:
    git push origin v0.3.0
    ```
 2. Create a GitHub Release on that tag. Paste the CHANGELOG slice for
-   this version as the body.
+   this version as the body — **do not** use `gh release create --notes-from-tag`;
+   it repeats the annotated tag's one-line message (`Release 0.3.0`) instead of
+   the CHANGELOG content, which is how v0.5.0 and v0.6.0 originally shipped
+   with just the tag message as their entire body (#250). Extract the slice
+   and pass it via `--notes-file`:
+   ```bash
+   awk '/^## \[0.3.0\]/{p=1} p&&/^## \[/&&!/^## \[0.3.0\]/{exit} p' CHANGELOG.md \
+     > /tmp/release-notes-0.3.0.md
+   if test -s /tmp/release-notes-0.3.0.md; then
+     gh release create v0.3.0 --title "0.3.0" --notes-file /tmp/release-notes-0.3.0.md
+   else
+     echo "empty slice — check the wave heading; release NOT created" >&2
+   fi
+   ```
 3. Publishing the Release fires the `Release` workflow.
 
 The workflow then runs:

--- a/docs/exec-plans/active/onboarding-feedback-response.md
+++ b/docs/exec-plans/active/onboarding-feedback-response.md
@@ -103,7 +103,7 @@ findings, ranked by how broken they are:
   nonexistent umbrella extra); `genblaze-cli[index]`/`[parquet]` above is
   still open, tracked separately.
 
-### A3 — Version compatibility table (feedback item 1, no GitHub tracking issue yet)
+### A3 — Version compatibility table (feedback item 1, tracked in #254)
 
 - Current state: umbrella `genblaze==0.4.0` ships with `genblaze-core==0.3.2`
   and `genblaze-s3==0.3.2`. Agents installing `genblaze==0.3.2` from public
@@ -139,13 +139,13 @@ findings, ranked by how broken they are:
   fix into `RELEASING.md`; added a `genblaze` (umbrella) version field to the
   bug report issue template. Republishing the v0.5.0/v0.6.0/v0.7.0 GitHub
   Release bodies from the corrected CHANGELOG slices (with a dated edit
-  marker, since these are already-published artifacts) is drafted but not yet
-  applied — pending review; `v0.4.0`'s live release already carries an
-  ad-hoc, pre-existing note covering this and was not re-touched. This is
+  marker, since these are already-published artifacts) is applied; `v0.4.0`'s
+  live release already carried an ad-hoc, pre-existing note covering this and
+  was not re-touched. #244 is closed; #250 is closed with the remaining
+  compatibility-table work split into #254. This item (#244/#250 fix) is
   docs-only and scoped to the umbrella/wave-tag confusion — the full "Version
   compatibility" table mapping umbrella → core → s3 → every connector floor,
-  and Gate 1's clean-venv verification, are still open and have no dedicated
-  tracking issue yet.
+  and Gate 1's clean-venv verification, remain open in #254.
 
 ### A4 — Python 3.11+ install preamble (#9)
 

--- a/docs/exec-plans/active/onboarding-feedback-response.md
+++ b/docs/exec-plans/active/onboarding-feedback-response.md
@@ -103,7 +103,7 @@ findings, ranked by how broken they are:
   nonexistent umbrella extra); `genblaze-cli[index]`/`[parquet]` above is
   still open, tracked separately.
 
-### A3 — Version compatibility table (#1)
+### A3 — Version compatibility table (feedback item 1, no GitHub tracking issue yet)
 
 - Current state: umbrella `genblaze==0.4.0` ships with `genblaze-core==0.3.2`
   and `genblaze-s3==0.3.2`. Agents installing `genblaze==0.3.2` from public
@@ -124,6 +124,28 @@ findings, ranked by how broken they are:
     is a single-line ≤512-char summary and won't render Markdown. Verify
     rendering by running `twine check dist/*` against a locally built wheel
     before publish.
+- **Partially addressed (2026-08-01, #244/#250):** added a "don't pin
+  `genblaze==<wave tag>`" callout to root `README.md` and to
+  `libs/meta/README.md` (the PyPI long_description); added the same warning
+  (in tense-independent wording, so it doesn't decay into a false claim as the
+  umbrella version advances) to the `## [0.4.0]`, `## [0.5.0]`, `## [0.6.0]`,
+  and `## [0.7.0]` `CHANGELOG.md` wave headers — `0.4.0` because
+  `genblaze==0.4.0` is the one wave tag that actually resolves silently to a
+  stale pre-republish wheel, which three independent reviewers flagged as the
+  gap in the first draft of this fix. `CHANGELOG.md` is the single source the
+  GitHub Release bodies are now generated from (see next item). Fixed
+  `prepare-release`'s and `release-check`'s `--notes-from-tag` (root cause of
+  v0.5.0/v0.6.0 shipping bodies with just the tag message) and mirrored the
+  fix into `RELEASING.md`; added a `genblaze` (umbrella) version field to the
+  bug report issue template. Republishing the v0.5.0/v0.6.0/v0.7.0 GitHub
+  Release bodies from the corrected CHANGELOG slices (with a dated edit
+  marker, since these are already-published artifacts) is drafted but not yet
+  applied — pending review; `v0.4.0`'s live release already carries an
+  ad-hoc, pre-existing note covering this and was not re-touched. This is
+  docs-only and scoped to the umbrella/wave-tag confusion — the full "Version
+  compatibility" table mapping umbrella → core → s3 → every connector floor,
+  and Gate 1's clean-venv verification, are still open and have no dedicated
+  tracking issue yet.
 
 ### A4 — Python 3.11+ install preamble (#9)
 

--- a/libs/meta/README.md
+++ b/libs/meta/README.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-28 -->
+<!-- last_verified: 2026-08-01 -->
 # genblaze
 
 Umbrella metapackage for genblaze — a provider-agnostic SDK for AI media generation with built-in provenance (manifests, SHA-256 hashing, B2/S3 durable storage).
@@ -26,6 +26,20 @@ pip install "genblaze[all]"
 # Optional: Parquet-backed manifest sink (ParquetSink)
 pip install "genblaze[parquet]"
 ```
+
+> **A GitHub Release tag (e.g. `v0.7.0`) is not a `genblaze` version — don't pin `genblaze==<wave tag>`.**
+> The tag names a CHANGELOG *wave*; every package in that wave versions independently, so
+> wave tags and the umbrella's PyPI versions are separate sequences that happen to look
+> alike. A pin on a wave tag either:
+> - **fails outright** (no such version was published), or
+> - **resolves silently to an unrelated umbrella build from a different wave** — no
+>   error, just stale code (e.g. `genblaze==0.4.0` on PyPI predates the `v0.4.0` wave).
+>
+> Pin the exact umbrella version instead (from that wave's "Released package versions"
+> list in its [release notes](https://github.com/backblaze-labs/genblaze/releases)) — but
+> note the umbrella pins ranges (e.g. `genblaze-core>=0.3.8,<0.4`), not exact versions, so
+> even that isn't fully reproducible on its own. For a locked install, generate a lockfile
+> (`pip freeze`, `uv lock`, or a constraints file) once your stack works.
 
 ## Import
 


### PR DESCRIPTION
## Summary
- GitHub release tags name a CHANGELOG "wave", not the umbrella `genblaze` package's PyPI version. Some old wave tags (e.g. `v0.4.0`) resolve on PyPI to an unrelated, older umbrella build with no error — worse than tags that just fail. Adds a callout to both READMEs and a durable, tense-independent warning to the affected CHANGELOG wave headers (`0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`).
- Fixes the actual root cause: `prepare-release` and `release-check` both instructed `gh release create --notes-from-tag`, which is why v0.5.0/v0.6.0 shipped with only their tag message as the body. Switched to `--notes-file` extraction from the CHANGELOG slice, guarded against an empty body.
- Adds a `genblaze` (umbrella) version field to the bug report template.
- Records final disposition in `docs/exec-plans/active/onboarding-feedback-response.md`: #244 and #250 closed, remaining "version compatibility table" work tracked in #254.

Went through three independent panel reviews (5 reviewers each: EM/OSS/DX Claude lenses + 2 Codex passes) before landing — round 2 caught a factual bug in the first draft of the README callout, round 3 verified the fix and caught a few more accuracy/disclosure gaps, all incorporated here.

## Already done outside this PR
- v0.5.0/v0.6.0/v0.7.0 GitHub release notes republished from the corrected CHANGELOG slices, each with a dated edit marker disclosing the retroactive change.
- #244 and #250 closed with substantive comments; #254 filed for the remaining compatibility-table work.

## Test plan
- [ ] Docs-only change — no code paths affected. Confirmed the CHANGELOG's wave-tag parsing used by `.github/workflows/release.yml` and `tools/prepare_release.py` is unaffected by the added prose (verified during review).