### PR TITLE
fix(openai): image edits reject remote https sources due to wrong temp-file suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
 
+### genblaze-openai
+
+- **Fixed** `DalleProvider` image edits from an `https://` reference image
+  (e.g. a presigned object-storage URL) always failed upstream with
+  `unsupported mimetype`. The download's temp file was named with a fixed
+  `.img` suffix, so the OpenAI client inferred `Content-Type:
+  application/octet-stream` instead of the source's real type. The suffix
+  is now derived from the input `Asset.media_type` (falling back to `.png`)
+  (#253).
+
 ## [0.7.0] - 2026-07-28
 
 Bug-fix wave with one new opt-in feature and one new provider. Closes a

--- a/libs/connectors/openai/genblaze_openai/dalle.py
+++ b/libs/connectors/openai/genblaze_openai/dalle.py
@@ -318,10 +318,10 @@ def _resolve_local_file(url: str, extra_root: Path | None) -> Path:
     return resolved
 
 
+# Derived from _FORMAT_TO_MEDIA/_FORMAT_TO_EXT above so the png/jpeg/webp
+# triple has one source of truth instead of a third parallel copy.
 _MEDIA_TYPE_TO_EXT: dict[str, str] = {
-    "image/png": ".png",
-    "image/jpeg": ".jpg",
-    "image/webp": ".webp",
+    media_type: _FORMAT_TO_EXT[fmt] for fmt, media_type in _FORMAT_TO_MEDIA.items()
 }
 
 

--- a/libs/connectors/openai/genblaze_openai/dalle.py
+++ b/libs/connectors/openai/genblaze_openai/dalle.py
@@ -318,7 +318,26 @@ def _resolve_local_file(url: str, extra_root: Path | None) -> Path:
     return resolved
 
 
-def _download_https_to_temp(url: str, timeout: float) -> Path:
+_MEDIA_TYPE_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+
+def _suffix_for_media_type(media_type: str | None) -> str:
+    """Map a declared MIME type to the temp-file suffix ``_download_https_to_temp``
+    should use.
+
+    The OpenAI client's multipart upload infers ``Content-Type`` from the temp
+    filename, not the actual bytes. An unrecognized/missing media type falls
+    back to ``.png`` (an OpenAI-accepted type) rather than a made-up extension
+    that would 400 upstream as ``application/octet-stream`` (#253).
+    """
+    return _MEDIA_TYPE_TO_EXT.get((media_type or "").lower(), ".png")
+
+
+def _download_https_to_temp(url: str, timeout: float, suffix: str = ".png") -> Path:
     """Download an https:// URL to a temp file. SSRF-checked with DNS pinning.
 
     Uses ``open_pinned_https_connection`` which connects to the validated pinned
@@ -329,6 +348,14 @@ def _download_https_to_temp(url: str, timeout: float) -> Path:
     Note: outbound connections bypass HTTP(S)_PROXY / NO_PROXY env vars by
     design — see ``open_pinned_https_connection`` for rationale.
 
+    ``suffix`` should reflect the source's declared media type (see
+    ``_suffix_for_media_type``) — the OpenAI client infers the upload's
+    Content-Type from this filename, so a wrong/unrecognized suffix (the
+    previous hardcoded ``.img``) makes ``/v1/images/edits`` reject the
+    request as ``application/octet-stream`` (#253). Callers that don't
+    upload the result back to OpenAI (e.g. fetching our own generated-image
+    CDN URL) can rely on the ``.png`` default.
+
     Caller is responsible for unlinking the returned temp file.
     """
     parsed = urlparse(url)
@@ -337,7 +364,7 @@ def _download_https_to_temp(url: str, timeout: float) -> Path:
         path = f"{path}?{parsed.query}"
     host = parsed.hostname or ""
 
-    fd, tmp = tempfile.mkstemp(suffix=".img")
+    fd, tmp = tempfile.mkstemp(suffix=suffix)
     os.close(fd)
     tmp_path = Path(tmp)
     conn = None
@@ -566,7 +593,8 @@ class DalleProvider(SyncProvider):
             if parsed.scheme == "file":
                 local.append(_resolve_local_file(asset.url, self._output_dir))
             else:
-                tmp = _download_https_to_temp(asset.url, self._http_timeout)
+                suffix = _suffix_for_media_type(asset.media_type)
+                tmp = _download_https_to_temp(asset.url, self._http_timeout, suffix=suffix)
                 temps.append(tmp)
                 local.append(tmp)
         return local, temps

--- a/libs/connectors/openai/tests/test_dalle_provider.py
+++ b/libs/connectors/openai/tests/test_dalle_provider.py
@@ -410,6 +410,24 @@ def test_output_format_jpeg_sets_jpg_suffix(mock_b64_dalle):
     assert result.assets[0].url.endswith(".jpg")
 
 
+def test_persist_image_bytes_uses_local_file_url_helper(mock_b64_dalle):
+    """Regression guard for #252: output asset URLs must be built via the
+    shared ``local_file_url`` (``Path.as_uri()``) helper, not a hand-rolled
+    ``f"file://{quote(...)}"`` — the latter mis-parses on Windows because the
+    drive letter's colon lands in the URL's netloc instead of the path. This
+    pins the *call site*, not just the helper (already covered in
+    libs/core/tests/unit/test_utils.py), so a future revert to inline string
+    building is caught here too."""
+    provider, _, _ = mock_b64_dalle
+    with patch(
+        "genblaze_openai.dalle.local_file_url", return_value="file:///sentinel.png"
+    ) as mock_helper:
+        step = Step(provider="openai-dalle", model="gpt-image-1", prompt="x")
+        result = provider.generate(step)
+    mock_helper.assert_called_once()
+    assert result.assets[0].url == "file:///sentinel.png"
+
+
 def test_output_compression_out_of_range_rejected(mock_b64_dalle):
     provider, _, _ = mock_b64_dalle
     step = Step(
@@ -730,6 +748,82 @@ class TestDownloadHttpsToTemp:
                 _download_https_to_temp("https://oai.example.com/img.png", timeout=5.0)
 
         conn.close.assert_called()
+
+    def test_default_suffix_is_a_recognized_image_extension(self):
+        """Regression for #253: the old hardcoded '.img' suffix made the OpenAI
+        client infer Content-Type: application/octet-stream on upload, which
+        /v1/images/edits rejects. The default must be an extension OpenAI's
+        multipart Content-Type sniffing recognizes."""
+        conn = _make_dalle_conn(status=200, body=b"imagedata")
+        with patch(_DALLE_CONN_PATCH, return_value=conn):
+            from genblaze_openai.dalle import _download_https_to_temp
+
+            result = _download_https_to_temp("https://oai.example.com/img.png", timeout=5.0)
+        try:
+            assert result.suffix != ".img"
+            assert result.suffix == ".png"
+        finally:
+            result.unlink(missing_ok=True)
+
+    @pytest.mark.parametrize("suffix", [".png", ".jpg", ".webp"])
+    def test_explicit_suffix_is_honored(self, suffix):
+        """Callers that know the declared media type can request the matching
+        suffix so the temp filename's extension truthfully reflects the bytes."""
+        conn = _make_dalle_conn(status=200, body=b"imagedata")
+        with patch(_DALLE_CONN_PATCH, return_value=conn):
+            from genblaze_openai.dalle import _download_https_to_temp
+
+            result = _download_https_to_temp(
+                "https://oai.example.com/img", timeout=5.0, suffix=suffix
+            )
+        try:
+            assert result.suffix == suffix
+        finally:
+            result.unlink(missing_ok=True)
+
+
+# --- media_type -> temp-file suffix mapping (#253) ---
+
+
+@pytest.mark.parametrize(
+    ("media_type", "expected_suffix"),
+    [
+        ("image/png", ".png"),
+        ("image/jpeg", ".jpg"),
+        ("image/webp", ".webp"),
+        ("image/PNG", ".png"),  # case-insensitive
+        ("image/gif", ".png"),  # unrecognized -> safe fallback
+        (None, ".png"),  # absent -> safe fallback
+        ("", ".png"),
+    ],
+)
+def test_suffix_for_media_type(media_type, expected_suffix):
+    from genblaze_openai.dalle import _suffix_for_media_type
+
+    assert _suffix_for_media_type(media_type) == expected_suffix
+
+
+def test_edit_https_input_downloaded_with_media_type_suffix(mock_b64_dalle):
+    """End-to-end regression for #253: an https:// edit input's declared
+    Asset.media_type must drive the downloaded temp file's suffix, so the
+    OpenAI client's multipart upload infers a real Content-Type instead of
+    application/octet-stream."""
+    provider, client, _ = mock_b64_dalle
+    from genblaze_core.models.asset import Asset as _Asset
+
+    conn = _make_dalle_conn(status=200, body=b"remote-jpeg-bytes")
+    step = Step(
+        provider="openai-dalle",
+        model="gpt-image-2",
+        prompt="edit remote source",
+        inputs=[_Asset(url="https://cdn.example.com/product.jpg", media_type="image/jpeg")],
+    )
+    with patch(_DALLE_CONN_PATCH, return_value=conn):
+        provider.generate(step)
+
+    kwargs = client.images.edit.call_args.kwargs
+    uploaded = kwargs["image"]
+    assert uploaded.name.endswith(".jpg")
 
 
 # --- Compliance harness ---

--- a/libs/connectors/openai/tests/test_sora_provider.py
+++ b/libs/connectors/openai/tests/test_sora_provider.py
@@ -100,6 +100,24 @@ def test_fetch_output_attaches_asset(mock_openai):
     assert result.assets[0].url.startswith("file://")
 
 
+def test_fetch_output_uses_local_file_url_helper(mock_openai):
+    """Regression guard for #252: the Sora video output URL must be built via
+    the shared ``local_file_url`` (``Path.as_uri()``) helper, not a hand-rolled
+    ``f"file://{quote(...)}"`` — the latter mis-parses on Windows because the
+    drive letter's colon lands in the URL's netloc instead of the path. This
+    pins the *call site*, not just the helper (already covered in
+    libs/core/tests/unit/test_utils.py), so a future revert to inline string
+    building is caught here too."""
+    provider, _ = mock_openai
+    step = Step(provider="openai-sora", model="sora-2", prompt="a sunset")
+    with patch(
+        "genblaze_openai.provider.local_file_url", return_value="file:///sentinel.mp4"
+    ) as mock_helper:
+        result = provider.fetch_output("vid-abc123", step)
+    mock_helper.assert_called_once()
+    assert result.assets[0].url == "file:///sentinel.mp4"
+
+
 def test_fetch_output_uses_download_content(mock_openai):
     """Download must go through videos.download_content, not the removed
     videos.content, and keep passing variant='video' (#127)."""


### PR DESCRIPTION
## Summary

Fixes #253: `DalleProvider` image edits from an `https://` reference image (e.g. a presigned object-storage URL) always failed with `unsupported mimetype`. `_download_https_to_temp` wrote the download to a temp file with a hardcoded `.img` suffix; the OpenAI client's multipart upload infers `Content-Type` from that filename, so the request went out as `application/octet-stream` and `/v1/images/edits` rejected it.

Also investigated #252 (file:// URLs invalid on Windows) since it was filed against the same file with the same stated root cause. It is **already fixed** — a prior merged commit (4801ce6, PR #180) routed `dalle.py`'s `_persist_image_bytes` and `provider.py`'s Sora output path through the shared `genblaze_core._utils.local_file_url()` helper (`Path.as_uri()`), which is exactly the fix #252 requests. No production change was needed for #252 in this PR; two regression tests were added to pin those call sites against a future revert to hand-rolled `f"file://{quote(...)}"` construction. #252 will be closed separately with a comment pointing to the prior fix.

## Changes

- `libs/connectors/openai/genblaze_openai/dalle.py`: new `_suffix_for_media_type()` helper (derived from the existing `_FORMAT_TO_MEDIA`/`_FORMAT_TO_EXT` dicts) maps an input `Asset.media_type` to a temp-file suffix (`.png`/`.jpg`/`.webp`, falling back to `.png`). `_download_https_to_temp()` gains a `suffix` parameter (default `.png`, replacing the old hardcoded `.img`); `_materialize_inputs()` threads the edit-input asset's declared media type into it.
- `libs/connectors/openai/tests/test_dalle_provider.py`: regression tests for `_suffix_for_media_type` (png/jpeg/webp/case-insensitive/unrecognized/missing), `_download_https_to_temp`'s new `suffix` param, an end-to-end test asserting the file handle passed to `client.images.edit()` has the correct extension, and a call-site regression test pinning `_persist_image_bytes` to the `local_file_url` helper (#252).
- `libs/connectors/openai/tests/test_sora_provider.py`: call-site regression test pinning the Sora output path to `local_file_url` (#252).
- `CHANGELOG.md`: `[Unreleased]` entry under `genblaze-openai`.

## Test plan

- [x] `make test` passes (full suite, ran this session)
- [x] `make lint` passes (ran this session)
- [x] `libs/connectors/openai` suite: 190 passed, 7 skipped (ran this session)
- [ ] `make typecheck` — not run as a full-repo gate this session; `mypy` on the changed file directly reported no issues
- [x] Docs updated — CHANGELOG only; no user-facing API/doc changes

### Panel review (triangulated, 3 lenses on the committed diff)

- **Correctness & tests**: no P0/P1. Confirmed the fix resolves #253 end-to-end (traced `_materialize_inputs` → `_download_https_to_temp` → the uploaded file handle's `.name`). Noted the mask-download path (`_resolve_mask`) also benefits from the `.png` default (masks must be PNG per OpenAI's API) — a low-risk side improvement, out of stated scope.
- **Security & invariants**: no P0/P1. Suffix is always drawn from a fixed 4-way dict/fallback — no adversarial `media_type` string can escape into the filesystem path. SSRF guard, DNS pinning, and the 50MB download cap are unchanged.
- **Architecture & DRY**: no P0/P1 blocking; flagged the new `_MEDIA_TYPE_TO_EXT` dict as a third parallel copy of the png/jpeg/webp triple — addressed by deriving it from the existing `_FORMAT_TO_MEDIA`/`_FORMAT_TO_EXT` dicts (second commit on this branch).

## Related

Closes #253
Refs #252 (root cause already fixed by #180; will close with a comment)