### PR TITLE
fix(gmicloud): alias prompt to text/lyrics for GMI audio models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
 
+### genblaze-gmicloud
+
+- **Fixed** every GMI Cloud audio model (TTS and music) was unreachable —
+  the `gmi-audio-tts` and `gmi-audio-music` families' `param_allowlist`
+  didn't include the API's required `text`/`lyrics` fields, so every request
+  400'd with "Required parameter is missing" before it reached GMI. `prompt`
+  now aliases to `text` for TTS and to `lyrics` for music, matching the same
+  `prompt=` idiom every other modality uses (#251).
+
 ## [0.7.0] - 2026-07-28
 
 Bug-fix wave with one new opt-in feature and one new provider. Closes a

--- a/docs/reference/model-matrix.md
+++ b/docs/reference/model-matrix.md
@@ -75,10 +75,10 @@ python tools/gen_model_matrix.py
 
 | Model | Modality | Pricing | Allowed params | Notes |
 |---|---|---|---|---|
-| `ElevenLabs-TTS-v3` | audio | $0.1000/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, voice_id | ⚠ suspected_dead |
-| `Inworld-TTS-1.5-Mini` | audio | $0.0050/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, voice_id | ⚠ suspected_dead |
-| `MiniMax-Music-2.5` | audio | $0.1500/asset | duration, duration_seconds, language, negative_prompt, output_format, prompt, reference_audio, seed, style_weight, tempo, voice_id | ⚠ suspected_dead |
-| `MiniMax-TTS-Speech-2.6-Turbo` | audio | $0.0600/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, voice_id | ⚠ suspected_dead |
+| `ElevenLabs-TTS-v3` | audio | $0.1000/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, text, voice_id | ⚠ suspected_dead |
+| `Inworld-TTS-1.5-Mini` | audio | $0.0050/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, text, voice_id | ⚠ suspected_dead |
+| `MiniMax-Music-2.5` | audio | $0.1500/asset | duration, duration_seconds, language, lyrics, negative_prompt, output_format, prompt, reference_audio, seed, style_weight, tempo, voice_id | ⚠ suspected_dead |
+| `MiniMax-TTS-Speech-2.6-Turbo` | audio | $0.0600/asset | duration, language, negative_prompt, output_format, prompt, reference_audio, seed, text, voice_id | ⚠ suspected_dead |
 | `MiniMax-Voice-Clone-Speech-2.6-HD` | audio | $0.1000/asset | duration, emotion, language, negative_prompt, output_format, pitch, prompt, reference_audio, seed, similarity, speed, stability, voice_id | ⚠ suspected_dead |
 
 ### `gmicloud-image`

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py
@@ -3,13 +3,15 @@
 Three families distinguished by upstream payload contract:
 
 * ``gmi-audio-tts`` — text-to-speech models (ElevenLabs, MiniMax-TTS,
-  Inworld). Standard audio surface with ``voice``→``voice_id`` aliasing.
+  Inworld). Standard audio surface with ``voice``→``voice_id`` and
+  ``prompt``→``text`` aliasing (GMI's TTS payload requires ``text``, #251).
 * ``gmi-audio-clone`` — voice-clone models (MiniMax-Voice-Clone). Adds
   expressive controls (pitch, emotion, speed, stability, similarity)
   and routes chain-input audio to ``reference_audio``.
 * ``gmi-audio-music`` — music generation (MiniMax-Music). Adds
-  style_weight, duration_seconds, tempo. Stereo output via
-  ``extras["is_music"]=True``.
+  style_weight, duration_seconds, tempo, plus ``prompt``→``lyrics``
+  aliasing (GMI's music payload requires ``lyrics``, #251). Stereo output
+  via ``extras["is_music"]=True``.
 
 Every audio slug currently shipped by GMI was flagged ``suspected_dead``
 in the 2026-04 reconciliation — those slugs are preserved in each
@@ -40,8 +42,19 @@ _AUDIO_BASE = ParamSurface.for_modality(Modality.AUDIO).with_aliases(voice="voic
 # Voice clone variants accept a reference audio plus expressive controls.
 _VOICE_CLONE = _AUDIO_BASE.extend("pitch", "emotion", "speed", "stability", "similarity")
 
-# Music models accept style hints + per-second duration controls.
-_MUSIC = _AUDIO_BASE.extend("style_weight", "duration_seconds", "tempo")
+# Music models accept style hints + per-second duration controls. GMI's music
+# endpoint requires the lyrics payload key as ``lyrics``, not ``prompt`` —
+# alias it so a music step takes the same ``prompt=`` every other modality
+# uses (#251).
+_MUSIC = _AUDIO_BASE.extend("style_weight", "duration_seconds", "tempo").with_aliases(
+    prompt="lyrics"
+)
+
+# TTS models follow the MiniMax/Inworld convention of a ``text`` payload key
+# rather than ``prompt`` — GMI's image/video endpoints happen to accept
+# ``prompt`` directly, but the audio endpoints don't. Alias it so a TTS step
+# takes the same ``prompt=`` every other modality uses (#251).
+_TTS = _AUDIO_BASE.with_aliases(prompt="text")
 
 
 _ENVELOPE = {"envelope_key": "payload"}
@@ -122,7 +135,7 @@ _GMI_AUDIO_TTS_FAMILY = ModelFamily(
         model_id="*",
         modality=Modality.AUDIO,
         extras={**_ENVELOPE, "is_music": False},
-        **_AUDIO_BASE.build(),
+        **_TTS.build(),
     ),
     description="GMICloud text-to-speech (ElevenLabs, MiniMax-TTS, Inworld families).",
     example_slugs=(

--- a/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
+++ b/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
@@ -77,6 +77,17 @@ class TestAudioFamilyResolution:
         assert match.spec.extras.get("is_music") is True
         assert match.spec.model_id == "minimax-music-2.5"
 
+    def test_music_family_allowlists_lyrics_aliased_from_prompt(self) -> None:
+        """#251: GMI's music endpoint requires ``lyrics``, not ``prompt`` —
+        the allowlist must carry it and ``prompt`` must alias onto it, or
+        every music request 400s with "lyrics (Required parameter is
+        missing)" before it ever reaches GMI's servers."""
+        provider = GMICloudAudioProvider(api_key="test")
+        match = provider._models.match_family("MiniMax-Music-2.5")
+        assert match is not None
+        assert "lyrics" in (match.spec.param_allowlist or set())
+        assert match.spec.param_aliases.get("prompt") == "lyrics"
+
     def test_tts_routes_to_tts_family(self) -> None:
         provider = GMICloudAudioProvider(api_key="test")
         # Mix PascalCase + lowercase to prove both casings match.
@@ -89,6 +100,17 @@ class TestAudioFamilyResolution:
             assert match is not None, slug
             assert match.family.name == "gmi-audio-tts", slug
             assert match.spec.model_id == expected_wire, slug
+
+    def test_tts_family_allowlists_text_aliased_from_prompt(self) -> None:
+        """#251: GMI's TTS endpoint requires ``text``, not ``prompt`` —
+        the allowlist must carry it and ``prompt`` must alias onto it, or
+        every TTS request 400s with "text (Required parameter is missing)"
+        before it ever reaches GMI's servers."""
+        provider = GMICloudAudioProvider(api_key="test")
+        match = provider._models.match_family("minimax-tts-speech-2.6-turbo")
+        assert match is not None
+        assert "text" in (match.spec.param_allowlist or set())
+        assert match.spec.param_aliases.get("prompt") == "text"
 
 
 class TestImageFamilyResolution:

--- a/libs/connectors/gmicloud/tests/test_gmicloud_audio_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_audio_provider.py
@@ -237,6 +237,61 @@ def test_voice_aliased_to_voice_id(provider):
     assert "voice" not in result
 
 
+def test_tts_prompt_aliased_to_text(provider):
+    """#251: TTS models need ``text``, not ``prompt`` — GMI 400s with
+    "text (Required parameter is missing)" otherwise. ``prompt`` is the
+    idiom every other modality uses, so it must alias through."""
+    step = Step(
+        provider="gmicloud-audio",
+        model="minimax-tts-speech-2.6-turbo",
+        prompt="Handmade ceramic mug, thrown and glazed by hand.",
+    )
+    result = provider.prepare_payload(step)
+    assert result["text"] == "Handmade ceramic mug, thrown and glazed by hand."
+    assert "prompt" not in result
+
+
+def test_music_prompt_aliased_to_lyrics(provider):
+    """#251: music models need ``lyrics``, not ``prompt`` — GMI 400s with
+    "lyrics (Required parameter is missing)" otherwise."""
+    step = Step(
+        provider="gmicloud-audio",
+        model="MiniMax-Music-2.5",
+        prompt="Verse one, about summer nights.",
+    )
+    result = provider.prepare_payload(step)
+    assert result["lyrics"] == "Verse one, about summer nights."
+    assert "prompt" not in result
+
+
+def test_tts_submit_forwards_text_in_payload(provider):
+    """End-to-end: the aliased ``text`` key (not ``prompt``) reaches the
+    outgoing HTTP request body for a TTS model."""
+    step = Step(
+        provider="gmicloud-audio",
+        model="minimax-tts-speech-2.6-turbo",
+        prompt="Hello world",
+    )
+    provider.submit(step)
+    body = provider._http_client.post.call_args.kwargs.get("json")
+    assert body["payload"]["text"] == "Hello world"
+    assert "prompt" not in body["payload"]
+
+
+def test_music_submit_forwards_lyrics_in_payload(provider):
+    """End-to-end: the aliased ``lyrics`` key (not ``prompt``) reaches the
+    outgoing HTTP request body for a music model."""
+    step = Step(
+        provider="gmicloud-audio",
+        model="MiniMax-Music-2.5",
+        prompt="Verse one, about summer nights.",
+    )
+    provider.submit(step)
+    body = provider._http_client.post.call_args.kwargs.get("json")
+    assert body["payload"]["lyrics"] == "Verse one, about summer nights."
+    assert "prompt" not in body["payload"]
+
+
 def test_prepare_payload_is_idempotent_for_normalized_params(provider):
     step = Step(
         provider="gmicloud-audio",


### PR DESCRIPTION
## Summary

Every GMI Cloud audio model (TTS and music) via `genblaze-gmicloud`'s `GMICloudAudioProvider` was unreachable — every request 400'd with "Required parameter is missing" because the SDK's own param allowlist stripped the API's required `text` (TTS) / `lyrics` (music) fields before the request went out, and there was no alias from the canonical `prompt` param (the one every other modality uses) onto them.

## Changes

- `libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py`: added a `_TTS` `ParamSurface` (`_AUDIO_BASE.with_aliases(prompt="text")`) used by the `gmi-audio-tts` family, and chained `.with_aliases(prompt="lyrics")` onto `_MUSIC` for the `gmi-audio-music` family. `with_aliases()` auto-adds the alias target to the allowlist, so `text`/`lyrics` are no longer stripped. Updated the module docstring to match.
- `libs/connectors/gmicloud/tests/test_catalog_decoupling.py`: registry-level regression tests confirming `text`/`lyrics` are allow-listed and aliased from `prompt` for the TTS/music families.
- `libs/connectors/gmicloud/tests/test_gmicloud_audio_provider.py`: end-to-end regression tests confirming `prompt=` reaches `prepare_payload()` and the outgoing HTTP body as `text` (TTS) / `lyrics` (music), with `prompt` itself absent from the final payload.
- `docs/reference/model-matrix.md`: updated the affected rows' "Allowed params" column (this file is generator-owned by `tools/gen_model_matrix.py`; hand-patched here to match exactly what the generator would emit, since this sandbox lacks the API-key env vars the generator needs to enumerate every connector without wiping unrelated sections).
- `CHANGELOG.md`: `[Unreleased]` entry under `### genblaze-gmicloud`.

**Deliberately out of scope:** the `gmi-audio-clone` (MiniMax Voice-Clone) family was left untouched. The issue's own root-cause analysis and suggested fix are scoped to `gmi-audio-tts`/`gmi-audio-music` only (its title literally says "the TTS/music param allowlists"); voice-clone was mentioned in the issue's affected-models table without a reproduced failure. Rather than guess at an unconfirmed payload contract, I filed a scoped follow-up: backblaze-labs/genblaze#257.

## Test plan

- [x] `make test` passes (verified this session — full suite, 19 packages, 0 failures)
- [x] `make lint` passes for the touched connector (`ruff check`/`ruff format --check libs/connectors/gmicloud/`)
- [x] Docs updated in this PR (CHANGELOG + model-matrix.md)
- [ ] `make typecheck` — not run this session (scoped to `libs/core`, unaffected by this change; connector typecheck is optional per the release-check gate)

New regression tests (`test_catalog_decoupling.py`, `test_gmicloud_audio_provider.py`) were confirmed to fail against the pre-fix code (`KeyError: 'text'`/`'lyrics'`) and pass after the fix, per TDD.

This PR went through a triangulated 3-lens review (correctness/tests, security/invariants, architecture/DRY) against the committed diff before push:
- **Correctness**: no P0s. One P1 — flagged that `gmi-audio-clone` may share the same defect but wasn't in the issue's confirmed reproduction; resolved by filing #257 rather than shipping an unverified alias.
- **Security**: no blocking issues. Two informational P2s (pre-existing shared alias-collision logging behavior in `model_registry.py`, and the same clone-family scoping note) — not regressions from this diff.
- **Architecture/DRY**: no blocking issues. Confirmed the `ParamSurface.with_aliases()` per-family composition here matches the existing `video.py` convention (e.g. `_VIDEO_BASE`/`_PIXVERSE`), adds zero per-request overhead, and is appropriately minimal.

## Related

Refs #251 (intentionally not using a closing keyword — see the "Deliberately out of scope" note above; leaving the issue's closure to a maintainer's judgment call given the voice-clone open question)
Refs #257 (follow-up: confirm whether `gmi-audio-clone` needs the same aliasing)