### PR TITLE
feat(signing): Mode 2 Ed25519 manifest signer (optional extra)

### DIFF
--- a/docs/features/trust-modes.md
+++ b/docs/features/trust-modes.md
@@ -47,15 +47,28 @@ assert manifest.verify_hash()
 # $ genblaze verify video.mp4
 ```
 
-### Mode 2 — Authenticated integrity (roadmap)
+### Mode 2 — Authenticated integrity (experimental — `feat/mode2-ed25519-signer`)
 
-**What it would prove:** Mode 1 + only the holder of a specific signing key could have produced the manifest.
+**What it proves:** Mode 1 + only the holder of a specific signing key could have produced the manifest.
 
-**Mechanism (planned):** Pluggable `Signer` / `Verifier` interface; ship Ed25519 default. Bring-your-own-key, no PKI. The `signature` and `encryption_scheme` fields on `Manifest` are reserved (excluded from the canonical hash) for forward compatibility — adding signing in a future schema version is non-breaking.
+**Mechanism:** Optional `genblaze_core.signing` module with `Ed25519Signer` (requires `pip install 'genblaze-core[signing]'`). Signs canonical manifest JSON (excluding `signature`, `manifest_uri`, `encryption_scheme`). Store the JSON bundle in `Manifest.signature`.
 
-**When you'd want it:** Multi-tenant SaaS attribution, brand publishing, internal compliance.
+**When you'd want it:** Multi-tenant SaaS attribution, brand publishing, EU AI Act Article 50 compliance pipelines (see [ATTEST](https://github.com/backblaze-labs/genblaze/discussions)).
 
-**Status:** Not yet implemented. Open an issue if your use case needs it.
+**Status:** Implemented behind optional extra in ATTEST upstream PR. API surface:
+
+```python
+from datetime import datetime, timezone
+from genblaze_core import Manifest
+from genblaze_core.signing import Ed25519Signer, verify_signature_bundle
+
+signer = Ed25519Signer.from_env("GENBLAZE_SIGNING_KEY_HEX")
+manifest = Manifest.from_run(run)
+payload = manifest.model_dump(mode="python")
+bundle = signer.sign_manifest(payload, signed_at=datetime.now(timezone.utc).isoformat())
+manifest.signature = bundle.to_json()
+assert verify_signature_bundle(payload, bundle)
+```
 
 ### Mode 3 — Standards-verifiable (roadmap, opt-in)
 

--- a/libs/core/genblaze_core/__init__.py
+++ b/libs/core/genblaze_core/__init__.py
@@ -128,6 +128,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "WebhookConfig": ("genblaze_core.webhooks.notifier", "WebhookConfig"),
     "WebhookEvent": ("genblaze_core.webhooks.notifier", "WebhookEvent"),
     "WebhookSink": ("genblaze_core.webhooks.sink", "WebhookSink"),
+    # signing (Mode 2 — optional extra)
+    "Ed25519Signer": ("genblaze_core.signing.ed25519", "Ed25519Signer"),
+    "SignatureBundle": ("genblaze_core.signing.base", "SignatureBundle"),
+    "verify_signature_bundle": ("genblaze_core.signing.ed25519", "verify_signature_bundle"),
 }
 
 __all__ = [*_LAZY_IMPORTS.keys(), "__version__"]

--- a/libs/core/genblaze_core/signing/__init__.py
+++ b/libs/core/genblaze_core/signing/__init__.py
@@ -1,0 +1,11 @@
+"""Pluggable manifest signing (Genblaze Mode 2)."""
+
+from genblaze_core.signing.base import SignatureBundle, Signer
+from genblaze_core.signing.ed25519 import Ed25519Signer, verify_signature_bundle
+
+__all__ = [
+    "Ed25519Signer",
+    "SignatureBundle",
+    "Signer",
+    "verify_signature_bundle",
+]

--- a/libs/core/genblaze_core/signing/base.py
+++ b/libs/core/genblaze_core/signing/base.py
@@ -1,0 +1,52 @@
+"""Signer protocol for Mode 2 authenticated integrity."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class SignatureBundle:
+    algorithm: str
+    public_key_hex: str
+    signature_b64: str
+    signed_at: str
+    manifest_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "algorithm": self.algorithm,
+            "public_key_hex": self.public_key_hex,
+            "signature_b64": self.signature_b64,
+            "signed_at": self.signed_at,
+            "manifest_sha256": self.manifest_sha256,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, raw: str) -> SignatureBundle:
+        data = json.loads(raw)
+        return cls(
+            algorithm=data["algorithm"],
+            public_key_hex=data["public_key_hex"],
+            signature_b64=data["signature_b64"],
+            signed_at=data["signed_at"],
+            manifest_sha256=data["manifest_sha256"],
+        )
+
+
+class Signer(Protocol):
+    """Sign a manifest payload dict (without signature field)."""
+
+    def sign_manifest(self, manifest: dict[str, Any], signed_at: str) -> SignatureBundle: ...
+
+
+class ManifestSigner(ABC):
+    @abstractmethod
+    def sign_manifest(self, manifest: dict[str, Any], signed_at: str) -> SignatureBundle:
+        raise NotImplementedError

--- a/libs/core/genblaze_core/signing/ed25519.py
+++ b/libs/core/genblaze_core/signing/ed25519.py
@@ -1,0 +1,101 @@
+"""Ed25519 implementation of Mode 2 manifest signing."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from typing import Any
+
+from genblaze_core.signing.base import ManifestSigner, SignatureBundle
+
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+except ImportError as exc:  # pragma: no cover - guarded by optional extra
+    Ed25519PrivateKey = None  # type: ignore[misc, assignment]
+    Ed25519PublicKey = None  # type: ignore[misc, assignment]
+    _CRYPTO_IMPORT_ERROR = exc
+else:
+    _CRYPTO_IMPORT_ERROR = None
+
+
+def _require_crypto() -> None:
+    if _CRYPTO_IMPORT_ERROR is not None:
+        raise ImportError(
+            "Ed25519 signing requires cryptography. Install with: pip install 'genblaze-core[signing]'"
+        ) from _CRYPTO_IMPORT_ERROR
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    """Canonical JSON for signing — excludes transport fields like signature."""
+    payload = {k: v for k, v in manifest.items() if k not in ("signature", "manifest_uri", "encryption_scheme")}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+class Ed25519Signer(ManifestSigner):
+    def __init__(self, private_key: Ed25519PrivateKey) -> None:
+        _require_crypto()
+        self._private_key = private_key
+        self._public_key = private_key.public_key()
+
+    @classmethod
+    def generate(cls) -> Ed25519Signer:
+        _require_crypto()
+        return cls(Ed25519PrivateKey.generate())
+
+    @classmethod
+    def from_hex_seed(cls, seed_hex: str) -> Ed25519Signer:
+        _require_crypto()
+        seed = bytes.fromhex(seed_hex)
+        if len(seed) != 32:
+            raise ValueError("Ed25519 seed must be 32 bytes (64 hex chars)")
+        return cls(Ed25519PrivateKey.from_private_bytes(seed))
+
+    @classmethod
+    def from_env(cls, env_var: str = "GENBLAZE_SIGNING_KEY_HEX") -> Ed25519Signer:
+        seed = os.environ.get(env_var, "").strip()
+        if not seed:
+            raise ValueError(f"Environment variable {env_var} is not set")
+        return cls.from_hex_seed(seed)
+
+    @property
+    def public_key_hex(self) -> str:
+        raw = self._public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        return raw.hex()
+
+    def sign_manifest(self, manifest: dict[str, Any], signed_at: str) -> SignatureBundle:
+        digest = manifest_sha256(manifest)
+        signature = self._private_key.sign(digest.encode("utf-8"))
+        return SignatureBundle(
+            algorithm="ed25519",
+            public_key_hex=self.public_key_hex,
+            signature_b64=base64.b64encode(signature).decode("ascii"),
+            signed_at=signed_at,
+            manifest_sha256=digest,
+        )
+
+
+def verify_signature_bundle(manifest: dict[str, Any], bundle: SignatureBundle) -> bool:
+    _require_crypto()
+    if bundle.algorithm != "ed25519":
+        return False
+    if bundle.manifest_sha256 != manifest_sha256(manifest):
+        return False
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(bundle.public_key_hex))
+        public_key.verify(
+            base64.b64decode(bundle.signature_b64),
+            bundle.manifest_sha256.encode("utf-8"),
+        )
+        return True
+    except Exception:
+        return False

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -62,6 +62,7 @@ otel = ["opentelemetry-api>=1.20"]
 # langsmith README). It imports pytest at module load, so it's only usable with
 # this extra installed: `pip install "genblaze-core[testing]"`.
 testing = ["pytest>=7.0"]
+signing = ["cryptography>=42.0"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/libs/core/tests/unit/test_ed25519_signing.py
+++ b/libs/core/tests/unit/test_ed25519_signing.py
@@ -1,0 +1,37 @@
+"""Tests for Mode 2 Ed25519 manifest signing."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from genblaze_core.signing import Ed25519Signer, verify_signature_bundle
+from genblaze_core.signing.ed25519 import manifest_sha256
+
+
+def test_sign_and_verify_manifest():
+    signer = Ed25519Signer.generate()
+    manifest = {
+        "schema_version": "1.5",
+        "run": {"run_id": "abc", "steps": []},
+        "canonical_hash": "deadbeef",
+    }
+    bundle = signer.sign_manifest(manifest, signed_at="2026-06-29T00:00:00Z")
+    assert verify_signature_bundle(manifest, bundle)
+    assert bundle.manifest_sha256 == manifest_sha256(manifest)
+
+
+def test_tampered_manifest_fails_verify():
+    signer = Ed25519Signer.generate()
+    manifest = {"schema_version": "1.5", "run": {"run_id": "abc", "steps": []}}
+    bundle = signer.sign_manifest(manifest, signed_at="2026-06-29T00:00:00Z")
+    manifest["canonical_hash"] = "changed"
+    assert not verify_signature_bundle(manifest, bundle)
+
+
+def test_from_hex_seed_deterministic():
+    seed = "ab" * 32
+    a = Ed25519Signer.from_hex_seed(seed)
+    b = Ed25519Signer.from_hex_seed(seed)
+    assert a.public_key_hex == b.public_key_hex


### PR DESCRIPTION
## Summary

Implements **Trust Mode 2 — authenticated integrity** from `docs/features/trust-modes.md`.

Mode 1 proves an asset's bytes are intact; it doesn't prove *who* produced it. This PR adds optional Ed25519 manifest signing to `genblaze_core.signing`, so a pipeline can prove a manifest was produced by a trusted key. It complements v0.6.0's `verify --fetch` (bytes unchanged) with an authorship guarantee — together they close the full provenance chain that EU AI Act Article 50 transparency calls for.

Shipped behind an optional `[signing]` extra, so core stays dependency-light and existing behavior is unchanged.

## Changes

- `libs/core/genblaze_core/signing/base.py` — `SignatureBundle` + verification interface
- `libs/core/genblaze_core/signing/ed25519.py` — `Ed25519Signer`, canonical-JSON signing, `verify_signature_bundle`
- `libs/core/genblaze_core/signing/__init__.py` — lazy exports
- `libs/core/genblaze_core/__init__.py` — surface the signing module
- `libs/core/pyproject.toml` — optional `[signing]` extra (`cryptography`)
- `libs/core/tests/unit/test_ed25519_signing.py` — sign/verify + tamper-detection tests
- `docs/features/trust-modes.md` — document Mode 2

## Test plan

- [x] `make test` passes (unit tests for sign/verify + tamper detection added)
- [x] `make lint` passes
- [x] Docs updated — `trust-modes.md` describes Mode 2

## Related

Reference consumer: [ATTEST](https://github.com/Demiladepy/attest), an EU AI Act Article 50 compliance gateway built on Genblaze + Backblaze B2 (Backblaze Generative Media Hackathon). Signs every generated asset's manifest with Ed25519 and exposes a public verifier.