### PR TITLE
ci: skip all CI on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   lint:
+    # Policy: Dependabot PRs run no CI (skip every job). See also security.yml.
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     # Runs ruff directly rather than `make lint` (which also runs `make
     # deptry`): deptry needs the full workspace installed, so it gets its own
     # `deptry` job below. Local `make lint` therefore covers more than this
@@ -38,6 +40,7 @@ jobs:
       - run: ruff format --check libs/ cli/ examples/
 
   ts-types:
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     # Drift guard for libs/spec/ts/genblaze.d.ts. Fails if a schema changed
     # without `make ts-types` being run. See libs/spec/README.md.
     runs-on: ubuntu-latest
@@ -60,6 +63,7 @@ jobs:
         run: npx --yes -p typescript@5.4 tsc --noEmit --strict --skipLibCheck libs/spec/ts/genblaze.d.ts
 
   typecheck:
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -107,6 +111,7 @@ jobs:
           fi
 
   deptry:
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     # Dependency hygiene gate. `pip check` proves the installed set has no
     # conflicting/missing transitive deps; `make deptry` proves every package
     # declares what it imports — the replicate/httpx clean-install crash class
@@ -134,6 +139,7 @@ jobs:
         run: make deptry
 
   build:
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     # Smoke-build every published package on every PR so packaging
     # regressions (e.g. broken hatch dynamic-version sources, missing
     # README, malformed classifiers) are caught here, not at release
@@ -172,6 +178,7 @@ jobs:
           fi
 
   test:
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   zizmor:
+    # Policy: Dependabot PRs run no CI (see ci.yml). Push + schedule still run.
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     name: zizmor (GitHub Actions security audit)
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,4 @@
 - Keep diffs minimal — only change what's needed
 - Adding a new connector: use `/scaffold-provider`. Before tagging a release: run `make pre-release` and read [RELEASING.md](RELEASING.md). After publish: `make post-release VERSION=<umbrella-version>`. Auditing docs freshness: `/verify-docs`.
 - Release flow: tag name follows the CHANGELOG wave header (`v0.3.0`), not any single package's version. Workflow at `.github/workflows/release.yml` triggers on GitHub Release creation; `workflow_dispatch` runs a TestPyPI dry-run.
+- CI policy: Dependabot PRs run NO CI. Every job in `.github/workflows/ci.yml` and `security.yml` is guarded by `if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}`. When adding a job to any `pull_request`-triggered workflow, copy that same guard onto it, otherwise Dependabot PRs would start running CI again. `release.yml` has no `pull_request` trigger, so it needs no guard.


### PR DESCRIPTION
Guard every pull_request-triggered job so Dependabot PRs run no CI.