### PR TITLE
ci: harden npm supply-chain security for @genblaze/spec build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,12 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: libs/spec/package-lock.json
       - name: Regenerate TS types
+        # generate-types.sh installs the pinned toolchain via `npm ci
+        # --ignore-scripts` from the committed lockfile — no unpinned `npx`,
+        # no lifecycle scripts. See #270.
         run: make ts-types
       - name: Verify no drift
         run: |
@@ -60,7 +65,9 @@ jobs:
             exit 1
           fi
       - name: Type-check generated .d.ts
-        run: npx --yes -p typescript@5.4 tsc --noEmit --strict --skipLibCheck libs/spec/ts/genblaze.d.ts
+        # Uses the pinned local tsc installed by generate-types.sh above,
+        # not an unpinned `npx --yes` fetch.
+        run: libs/spec/node_modules/.bin/tsc --noEmit --strict --skipLibCheck libs/spec/ts/genblaze.d.ts
 
   typecheck:
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,16 +369,67 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # npm publish (TypeScript types). Runs in parallel with the PyPI graph
   # because @genblaze/spec has no dependency on any Python package.
+  #
+  # Split in two (see #270): build-npm-types does the npm install +
+  # code-generation in a low-privilege job (no id-token), and publish-npm
+  # — which holds `id-token: write` for npm provenance — only downloads the
+  # already-verified artifact and calls `npm publish`. No npm install or
+  # execution of third-party code happens in the privileged job, so a
+  # compromised transitive dependency of the type generator can never reach
+  # the OIDC token or NPM_TOKEN.
   # ─────────────────────────────────────────────────────────────────────
+
+  build-npm-types:
+    # Low-privilege build: regenerate libs/spec/ts/genblaze.d.ts from the
+    # JSON Schemas and fail if it doesn't match what's committed (someone
+    # changed a schema without re-running `make ts-types`). This job never
+    # touches npm publish credentials — default permissions are read-only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [validate-version]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # zizmor: ignore[cache-poisoning] (this job's output artifact feeds the id-token publish job — no cache: input, nothing to poison); v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Regenerate TS types from JSON Schemas
+        # Defensive — CI already runs ts-types-check on every push, but a
+        # release shouldn't trust that the committed types are still
+        # current. Regenerate, then refuse to publish if the working tree
+        # is dirty. generate-types.sh installs the pinned toolchain via
+        # `npm ci --ignore-scripts` from the committed lockfile — no
+        # unpinned `npx`, no lifecycle scripts.
+        run: make ts-types
+      - name: Verify generated types match committed
+        run: |
+          if ! git diff --exit-code libs/spec/ts/; then
+            echo "::error::libs/spec/ts/ is stale. Run 'make ts-types' locally and commit before tagging a release."
+            exit 1
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: genblaze-spec-types
+          path: libs/spec/ts/genblaze.d.ts
+          retention-days: 1
 
   publish-npm:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [validate-version, changelog-gate, pin-parity]
+    needs: [build-npm-types, validate-version, changelog-gate, pin-parity]
     environment: ${{ needs.validate-version.outputs.dry_run == 'true' && 'npm-dryrun' || 'npm' }}
     permissions:
       contents: read
       id-token: write   # npm provenance — signed attestation that this tarball was built from this commit by this workflow.
+    env:
+      # Belt-and-suspenders (see #270): this job never installs a dependency
+      # tree, but `npm publish` itself can run package lifecycle hooks
+      # (prepublishOnly/prepack/prepare/postpublish) if @genblaze/spec's
+      # package.json ever defines one. Job-wide so no future step in this
+      # privileged job can accidentally skip it.
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -388,18 +439,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
-      - name: Regenerate TS types from JSON Schemas
-        # Defensive — CI already runs ts-types-check on every push, but a
-        # release shouldn't trust that the committed types are still
-        # current. Regenerate, then refuse to publish if the working tree
-        # is dirty (someone changed a schema without re-running ts-types).
-        run: make ts-types
-      - name: Verify generated types match committed
-        run: |
-          if ! git diff --exit-code libs/spec/ts/; then
-            echo "::error::libs/spec/ts/ is stale. Run 'make ts-types' locally and commit before tagging a release."
-            exit 1
-          fi
+      - name: Download verified TS types
+        # No npm install and no code generation happens in this job — the
+        # types were already regenerated and drift-checked by
+        # build-npm-types, which holds no publish credentials.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: genblaze-spec-types
+          path: libs/spec/ts/
       - name: Check if @genblaze/spec version is already published
         # Idempotent guard: npm publish hard-fails on duplicate versions
         # (no skip-existing equivalent). Pre-check via `npm view` so a

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ CLAUDE.local.md
 *.tmp
 *.bak
 *.log
+
+# Node (libs/spec type-generation toolchain)
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
 
+### Internal
+
+- **Security** hardened the `@genblaze/spec` TypeScript type-generation
+  toolchain against npm supply-chain attacks (#270): `generate-types.sh` now
+  installs `json-schema-to-typescript`/`typescript` via `npm ci
+  --ignore-scripts` from a new committed `libs/spec/package-lock.json`
+  instead of an unpinned `npx --yes` fetch, and the release workflow's
+  `publish-npm` job (which holds `id-token: write`) no longer installs or
+  executes any npm package — type generation moved to a new low-privilege
+  `build-npm-types` job whose verified output is handed to `publish-npm` as
+  a build artifact, and now sets `NPM_CONFIG_IGNORE_SCRIPTS=true` for the
+  whole job. No change to the generated `genblaze.d.ts` or to the tarball's
+  published file contents (`ts/genblaze.d.ts`, `schemas/**/*.json`,
+  `README.md`); `package.json` itself gains the new `devDependencies`/
+  `scripts` fields used for local regeneration.
+
 ## [0.7.0] - 2026-07-28
 
 Bug-fix wave with one new opt-in feature and one new provider. Closes a

--- a/docs/exec-plans/completed/issue-270-harden-npm-supply-chain-build.md
+++ b/docs/exec-plans/completed/issue-270-harden-npm-supply-chain-build.md
@@ -1,0 +1,240 @@
+<!-- completed: 2026-09-03 -->
+# Issue 270: Harden the Node build toolchain against npm supply-chain attacks (ignore-scripts, lockfile, split publish job)
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/270
+Labels: `ci-release`, `P2`, `security`
+
+Preventive hardening prompted by the Aug 2026 keyv/cacheable npm supply-chain
+campaign, where malware stole GitHub Actions OIDC and npm tokens via a
+`preinstall` hook and self-propagated through npm Trusted Publishing.
+
+**genblaze was NOT exposed.** The published `@genblaze/spec` has zero npm
+dependencies, and the `json-schema-to-typescript@15.0.4` tree (15 packages)
+contains none of the compromised keyv/cacheable/flat-cache/file-entry-cache/
+cacheable-request/cache-manager packages. This closes the *structural* gap so
+a future transitive compromise cannot reach a privileged context — it was not
+a response to an active exploit.
+
+The gap: `libs/spec/scripts/generate-types.sh` ran
+`npx --yes json-schema-to-typescript@15.0.4` (three times) with no committed
+lockfile, so the generator's transitive dependencies were resolved **fresh at
+run time** from `^`-range specifiers. Verified live before the fix:
+
+    $ npm view json-schema-to-typescript@15.0.4 dependencies
+    { lodash: '^4.17.21', 'is-glob': '^4.0.3', 'js-yaml': '^4.1.0',
+      minimist: '^1.2.8', prettier: '^3.2.5', tinyglobby: '^0.2.9',
+      '@types/lodash': '^4.17.7', '@types/json-schema': '^7.0.15',
+      '@apidevtools/json-schema-ref-parser': '^11.5.5' }
+
+Every `^` means "resolve the newest matching version now" — so a future
+compromise of any of these (or their own transitive `^` deps) would have been
+pulled automatically on the next run. That live, script-enabled `npx` ran in
+two contexts:
+
+- CI `ts-types` job (`.github/workflows/ci.yml`) — low privilege. Also ran a
+  second unpinned `npx --yes -p typescript@5.4 tsc`.
+- Release `publish-npm` job (`.github/workflows/release.yml`) — holds
+  **`id-token: write`** for npm provenance and carries `secrets.NPM_TOKEN`;
+  ran `make ts-types` → `generate-types.sh` in that same privileged context.
+
+An unpinned, script-enabled `npx` inside `publish-npm` was exactly the
+context where a future transitive compromise would do the most damage: two
+stealable secrets (the long-lived `NPM_TOKEN` and the OIDC token) were in
+reach of any install-time hook — the keyv/cacheable malware's exact playbook.
+
+Stale-comment note: `generate-types.sh`'s header said "no package.json in the
+repo", but `libs/spec/package.json` already existed (publishing metadata, 0
+runtime deps). The comment predated it and was corrected.
+
+## Fix
+
+CI/release hardening. **No change to the published `@genblaze/spec` contents
+and no change to the generated `libs/spec/ts/genblaze.d.ts`** — verified
+byte-for-byte identical. Three changes, highest-security-value first.
+
+1. **Split build from publish (`.github/workflows/release.yml`)** — the
+   structural fix. Added a low-privilege `build-npm-types` job (default
+   read-only permissions) that runs `make ts-types`, verifies no drift, and
+   uploads `libs/spec/ts/genblaze.d.ts` as an artifact. `publish-npm` now
+   `needs:` it, downloads the artifact, and no longer regenerates or verifies
+   types itself. Result: **no npm install or execution happens in the job
+   holding `id-token: write`** — it only downloads a pre-built,
+   drift-verified file and calls `npm publish`.
+
+2. **Disabled install scripts** on every type-gen npm invocation
+   (`--ignore-scripts`) in `generate-types.sh` and the `ci.yml` `ts-types`
+   job (both the generator install and the `tsc` type-check). Neutralizes the
+   entire `preinstall`/`postinstall` hook class at zero cost — neither tool
+   needs lifecycle scripts to run.
+
+3. **Pinned the toolchain via a committed lockfile.** Added
+   `json-schema-to-typescript@15.0.4` and `typescript@5.4.5` as
+   `devDependencies` in `libs/spec/package.json`; generated and committed
+   `libs/spec/package-lock.json` (16 packages, all exact versions, none from
+   the compromised list). Rewrote `generate-types.sh` to
+   `npm ci --ignore-scripts --prefix libs/spec` then call the
+   locally-installed `json2ts` binary instead of `npx --yes`. Fixed the
+   stale header comment. `devDependencies` are not published, so the
+   tarball is unaffected.
+
+4. **Updated CI to use the lockfile (`.github/workflows/ci.yml`).** The
+   `ts-types` job now caches on `libs/spec/package-lock.json` and calls the
+   pinned local `tsc` (`libs/spec/node_modules/.bin/tsc`) — no unpinned `npx`
+   remains anywhere in the type-generation path.
+
+5. **Docs.** Updated `libs/spec/README.md`'s regeneration section to describe
+   the lockfile-based install and how to bump pinned versions; added a
+   `.gitignore` entry for `node_modules/` (the repo had none — it was purely
+   Python before); added a `**Security**` bullet to `CHANGELOG.md` under
+   `[Unreleased]` → `### Internal`.
+
+### Regression / guard
+
+The drift guard (`git diff --exit-code libs/spec/ts/`) is preserved and now
+runs in the low-privilege `build-npm-types` job instead of `publish-npm`.
+`npm ci` adds a second, independent reproducibility guard: it hard-fails on
+any lockfile/manifest mismatch instead of silently re-resolving versions.
+
+No version bump — package versions bump per release wave, not per fix
+(RELEASING.md). `@genblaze/spec` `version` is untouched.
+
+## Risk
+
+Low. All CI/release plumbing; no runtime/API surface change and no change to
+shipped artifacts.
+
+- **Release workflow topology changed** — `publish-npm` now depends on a new
+  `build-npm-types` job via an artifact hand-off. Not yet exercised end-to-end
+  against real GitHub Actions (no `workflow_dispatch` dry-run was triggered as
+  part of this change); both workflow YAML files were validated for correct
+  structure and job dependencies, and `zizmor` (the repo's GH Actions security
+  auditor) reports no findings against either modified file.
+- **Lockfile bootstrapping** — the lockfile was generated fresh against the
+  pinned `devDependencies` and committed together; `npm ci` confirmed to
+  install cleanly from it.
+- **Dependabot** — `devDependencies` are now Dependabot-visible; existing
+  `ci.yml`/`security.yml` Dependabot guards already skip CI on those PRs, so
+  no new CI exposure.
+
+Out of scope: the PyPI publish graph in `release.yml` (separate ecosystem);
+`genblaze-*` PyPI packages (Python, unaffected by an npm-ecosystem attack);
+the published `@genblaze/spec` contents (0 runtime deps, unchanged).
+
+## Files Modified
+
+| File | Change | Notes |
+|---|---|---|
+| `.github/workflows/release.yml` | modified | new low-priv `build-npm-types` job builds + drift-checks + uploads `genblaze.d.ts` artifact; `publish-npm` downloads it instead of regenerating — no npm install/exec in the `id-token: write` job |
+| `.github/workflows/ci.yml` | modified | `ts-types` job caches on the lockfile; `tsc` type-check uses the pinned local binary instead of unpinned `npx` |
+| `libs/spec/scripts/generate-types.sh` | modified | installs from the lockfile with `npm ci --ignore-scripts` instead of `npx --yes`; fixed stale "no package.json" comment |
+| `libs/spec/package.json` | modified | added `devDependencies` (`json-schema-to-typescript@15.0.4`, `typescript@5.4.5`) and `generate`/`typecheck` scripts |
+| `libs/spec/package-lock.json` | created | committed lockfile pinning the full 16-package transitive tree |
+| `.gitignore` | modified | added `node_modules/` (repo had no Node ignore rules before) |
+| `libs/spec/README.md` | modified | regeneration section describes the lockfile-based install and version-bump procedure |
+| `CHANGELOG.md` | modified | `**Security**` bullet under `[Unreleased]` → `### Internal` |
+| `docs/exec-plans/completed/issue-270-harden-npm-supply-chain-build.md` | created | this file |
+
+## Acceptance criteria (from the issue)
+
+- [x] `generate-types.sh` and the `ci.yml` / `release.yml` jobs that call it
+      run npm with install scripts disabled.
+- [x] The type-generator dependency set is version-pinned and reproducible
+      from a committed lockfile.
+- [x] No npm install or execution happens in any job that holds
+      `id-token: write`.
+
+Additional invariants preserved:
+
+- [x] `make ts-types` still produces a byte-for-byte identical
+      `libs/spec/ts/genblaze.d.ts` (drift guard passes).
+- [x] The published `@genblaze/spec` tarball is unchanged (devDependencies
+      excluded from the `files` allowlist).
+
+## Verification
+
+Confirmed the generated output is unaffected by the hardening — same file,
+safer production. Before the fix, from `main`:
+
+    $ npx --yes json-schema-to-typescript@15.0.4 ...   # (three unpinned calls)
+    Generated /.../libs/spec/ts/genblaze.d.ts
+
+After the fix, same command surface (`make ts-types`), now installing from
+the lockfile with scripts disabled:
+
+    $ libs/spec/scripts/generate-types.sh
+
+    added 16 packages, and audited 17 packages in 554ms
+
+    6 packages are looking for funding
+      run `npm fund` for details
+
+    found 0 vulnerabilities
+    Generated /Users/ffumero/Desktop/dev/genblaze/libs/spec/ts/genblaze.d.ts
+
+Drift check against the pre-change committed file — confirms byte-identical
+output:
+
+    $ git diff --exit-code libs/spec/ts/
+    NO DRIFT — output unchanged from committed main
+
+Lockfile install (`npm ci`, the stricter CI-faithful install) from a clean
+`node_modules/`:
+
+    $ rm -rf libs/spec/node_modules && cd libs/spec && npm ci --ignore-scripts
+    added 16 packages, and audited 17 packages in 531ms
+    found 0 vulnerabilities
+
+Pinned local `tsc` type-check (replacing the old unpinned
+`npx --yes -p typescript@5.4 tsc`):
+
+    $ libs/spec/node_modules/.bin/tsc --noEmit --strict --skipLibCheck libs/spec/ts/genblaze.d.ts
+    TSC OK  (no output — exit 0)
+
+Resolved lockfile packages (16 total) — confirmed none match the
+keyv/cacheable/flat-cache/file-entry-cache/cacheable-request/cache-manager
+compromise list:
+
+    @apidevtools/json-schema-ref-parser, @jsdevtools/ono, @types/json-schema,
+    @types/lodash, argparse, fdir, is-extglob, is-glob, js-yaml,
+    json-schema-to-typescript, lodash, minimist, picomatch, prettier,
+    tinyglobby, typescript
+
+GitHub Actions workflow validation — both modified YAML files parse
+correctly with the expected job graph:
+
+    release.yml jobs: [..., publish-meta, build-npm-types, publish-npm, install-verify]
+    build-npm-types.needs: ['validate-version']
+    publish-npm.needs: ['build-npm-types', 'validate-version', 'changelog-gate', 'pin-parity']
+    ci.yml jobs: [lint, ts-types, typecheck, deptry, build, test]
+
+`zizmor` (the repo's GitHub Actions security auditor, run locally at v1.30.0
+against both modified workflow files):
+
+    $ zizmor .github/workflows/release.yml .github/workflows/ci.yml
+    No findings to report. Good job! (2 ignored, 22 suppressed)
+
+(One `cache-poisoning` finding was raised and fixed during implementation: an
+initial `cache: "npm"` on the new `build-npm-types` job's `setup-node` step
+was flagged because that job's output feeds the `id-token: write` publish
+job via artifact — removed, matching the no-cache pattern already used in
+`publish-npm` itself.)
+
+Lint (no Python files touched by this change; run for completeness):
+
+    $ ruff check libs/ cli/ examples/
+    All checks passed!
+
+    $ ruff format --check libs/ cli/ examples/
+    400 files already formatted
+
+`make test` was not run: this change touches only `.github/workflows/`,
+`libs/spec/` (types tooling, not Python code), `.gitignore`, `CHANGELOG.md`,
+and docs — no Python source or test file changed.
+
+**Not yet done:** an actual `workflow_dispatch` dry-run (`dry_run=true`)
+against real GitHub Actions, to exercise the `build-npm-types` →
+`publish-npm` artifact hand-off and confirm `npm publish --dry-run
+--provenance` still succeeds end-to-end. Recommended before the next release
+tag.

--- a/libs/spec/README.md
+++ b/libs/spec/README.md
@@ -88,10 +88,14 @@ function handle(ev: StreamEvent) {
 make ts-types
 ```
 
-This runs `libs/spec/scripts/generate-types.sh`, which invokes a pinned
-`json-schema-to-typescript` via `npx` and writes `ts/genblaze.d.ts`.
+This runs `libs/spec/scripts/generate-types.sh`, which installs the pinned
+`json-schema-to-typescript` and `typescript` toolchain from the committed
+`libs/spec/package-lock.json` (`npm ci --ignore-scripts` — no unpinned `npx`
+fetch, no install-time lifecycle scripts) and writes `ts/genblaze.d.ts`.
 The script is deterministic — rerunning with no schema changes produces
-a byte-identical file.
+a byte-identical file. Bumping either tool's version means updating
+`libs/spec/package.json` and regenerating `package-lock.json`
+(`cd libs/spec && npm install --package-lock-only --ignore-scripts`).
 
 ## Drift prevention
 

--- a/libs/spec/package-lock.json
+++ b/libs/spec/package-lock.json
@@ -1,0 +1,228 @@
+{
+  "name": "@genblaze/spec",
+  "version": "0.4.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@genblaze/spec",
+      "version": "0.4.0",
+      "license": "MIT",
+      "devDependencies": {
+        "json-schema-to-typescript": "15.0.4",
+        "typescript": "5.4.5"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/libs/spec/package.json
+++ b/libs/spec/package.json
@@ -29,5 +29,13 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate": "scripts/generate-types.sh",
+    "typecheck": "tsc --noEmit --strict --skipLibCheck ts/genblaze.d.ts"
+  },
+  "devDependencies": {
+    "json-schema-to-typescript": "15.0.4",
+    "typescript": "5.4.5"
   }
 }

--- a/libs/spec/scripts/generate-types.sh
+++ b/libs/spec/scripts/generate-types.sh
@@ -5,18 +5,29 @@
 # a byte-identical file. CI uses `make ts-types-check` (see Makefile) to
 # fail PRs that change schemas without regenerating.
 #
-# Phase 1a: no package.json in the repo; npx fetches a pinned version.
+# Supply-chain hardening (see #270): the generator is installed from the
+# committed libs/spec/package-lock.json via `npm ci`, not fetched live via
+# `npx --yes`, so the transitive dependency tree is pinned and reproducible.
+# --ignore-scripts disables preinstall/postinstall lifecycle hooks — the
+# generator needs none to run — closing off the hook-based attack class used
+# by the Aug 2026 keyv/cacheable npm supply-chain campaign.
 set -euo pipefail
 
-JSTT_VERSION="15.0.4"
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
-MANIFEST_SCHEMA_DIR="$REPO_ROOT/libs/spec/schemas/manifest/v1"
-EVENT_SCHEMA_DIR="$REPO_ROOT/libs/spec/schemas/events/v1"
-OUT_FILE="$REPO_ROOT/libs/spec/ts/genblaze.d.ts"
+SPEC_DIR="$REPO_ROOT/libs/spec"
+MANIFEST_SCHEMA_DIR="$SPEC_DIR/schemas/manifest/v1"
+EVENT_SCHEMA_DIR="$SPEC_DIR/schemas/events/v1"
+OUT_FILE="$SPEC_DIR/ts/genblaze.d.ts"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 mkdir -p "$(dirname "$OUT_FILE")"
+
+# Install the pinned toolchain from the lockfile. `npm ci` fails on any
+# lockfile/manifest drift instead of silently re-resolving versions.
+npm ci --ignore-scripts --prefix "$SPEC_DIR"
+
+JSTT_BIN="$SPEC_DIR/node_modules/.bin/json2ts"
 
 # Shared CLI flags: --declareExternallyReferenced walks $refs so a single
 # input file emits the full connected tree. --unknownAny prefers `unknown`
@@ -34,20 +45,20 @@ EVENT_FLAGS=(
 )
 
 # Manifest pulls Run → Step → Asset via $ref. Emits the full tree.
-npx --yes "json-schema-to-typescript@$JSTT_VERSION" \
+"$JSTT_BIN" \
   -i "$MANIFEST_SCHEMA_DIR/manifest.schema.json" \
   "${MANIFEST_FLAGS[@]}" \
   > "$TMP_DIR/manifest.ts"
 
 # EmbedPolicy is standalone (not referenced by Manifest).
-npx --yes "json-schema-to-typescript@$JSTT_VERSION" \
+"$JSTT_BIN" \
   -i "$MANIFEST_SCHEMA_DIR/policy.schema.json" \
   "${MANIFEST_FLAGS[@]}" \
   > "$TMP_DIR/policy.ts"
 
 # StreamEvent is the discriminated-union root — pulls every variant via
 # oneOf/$ref. One invocation emits the full event tree.
-npx --yes "json-schema-to-typescript@$JSTT_VERSION" \
+"$JSTT_BIN" \
   -i "$EVENT_SCHEMA_DIR/stream-event.schema.json" \
   "${EVENT_FLAGS[@]}" \
   > "$TMP_DIR/events.ts"


### PR DESCRIPTION
`libs/spec/scripts/generate-types.sh` fetched `json-schema-to-typescript` fresh via `npx --yes` on every run, with no lockfile — so its 15 transitive dependencies resolved to whatever was newest on npm at run time, with install scripts allowed to execute. That same unpinned, script-enabled fetch ran inside the release workflow's `publish-npm` job, which holds `id-token: write` and `NPM_TOKEN` — exactly the kind of privileged context the Aug 2026 keyv/cacheable npm campaign exploited via a `preinstall` hook. genblaze was never actually compromised (the pinned tree contains none of the affected packages), but the structural gap was real.

Fixes [#270](https://github.com/backblaze-labs/genblaze/issues/270)

## Summary

Three changes, in order of security value: moved type generation out of the `id-token: write` job entirely (a low-privilege `build-npm-types` job now generates and drift-checks the types, handing the verified file to `publish-npm` as an artifact); disabled install scripts on every remaining npm invocation in the type-generation path; and pinned the full toolchain to a committed lockfile so versions no longer float. The generated `libs/spec/ts/genblaze.d.ts` is unchanged — verified byte-for-byte identical (matching SHA-256) throughout.

## Changes

* `.github/workflows/release.yml` — new low-privilege `build-npm-types` job builds, drift-checks, and uploads `genblaze.d.ts` as an artifact; `publish-npm` downloads it instead of regenerating, and its `npm view`/`npm publish` steps now run with `NPM_CONFIG_IGNORE_SCRIPTS=true` so no npm install or lifecycle-hook execution happens in the `id-token: write` job.
* `.github/workflows/ci.yml` — `ts-types` job caches on the lockfile and its `tsc` type-check now uses the pinned local binary instead of an unpinned `npx --yes` fetch.
* `libs/spec/scripts/generate-types.sh` — installs from the lockfile via `npm ci --ignore-scripts` instead of `npx --yes`; fixed a stale "no package.json in the repo" comment.
* `libs/spec/package.json` — added `devDependencies` (`json-schema-to-typescript@15.0.4`, `typescript@5.4.5`) and `generate`/`typecheck` convenience scripts.
* `libs/spec/package-lock.json` — new, committed; pins the full 16-package transitive tree to exact versions (none matching the compromised keyv/cacheable/flat-cache/file-entry-cache/cacheable-request/cache-manager list).
* `.gitignore` — added `node_modules/` (the repo had no Node ignore rule before this).
* `libs/spec/README.md` — regeneration section documents the lockfile-based install and how to bump pinned versions.
* `CHANGELOG.md` — one `**Security**` bullet under `[Unreleased]` → `### Internal`.
* `docs/exec-plans/completed/issue-270-harden-npm-supply-chain-build.md` — plan doc with problem, fix rationale, files modified, and verification output.

## Test plan

* `bash libs/spec/scripts/generate-types.sh` → installs from lockfile, generates cleanly; `git diff --exit-code libs/spec/ts/` clean (byte-identical to `main`)
* `cd libs/spec && npm ci --ignore-scripts` → succeeds from the committed lockfile
* `libs/spec/node_modules/.bin/tsc --noEmit --strict --skipLibCheck libs/spec/ts/genblaze.d.ts` → passes
* `ruff check` / `ruff format --check` — clean (no Python files touched by this change)
* `zizmor .github/workflows/release.yml .github/workflows/ci.yml` (v1.30.0) — 0 findings
* Full `pre-pr-check` run (Claude + Codex, standard/security/adversarial) — 2 blocking findings caught and fixed (lockfile wasn't staged; `npm publish` was missing `--ignore-scripts`), re-verified clean
* **Not yet exercised:** an actual `workflow_dispatch` dry-run against real GitHub Actions to confirm the `build-npm-types` → `publish-npm` artifact hand-off end-to-end — recommended before the next release tag

## Related

* Fixes [#270](https://github.com/backblaze-labs/genblaze/issues/270)
* Plan: `docs/exec-plans/completed/issue-270-harden-npm-supply-chain-build.md`