### PR TITLE
fix(gmicloud): bound the video poll loop so wedged requests fail instead of hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
 
+### genblaze-gmicloud
+
+- **Fixed** the video poll loop is now bounded by a `max_poll_seconds`
+  ceiling. A request stuck reporting `dispatched` previously polled forever,
+  wedging the pipeline with no way to recover; it now fails the step with a
+  timeout once the ceiling is passed. The ceiling is tracked per prediction
+  id and cleared on a terminal status, and can be disabled by passing
+  `None` (#262).
+
 ## [0.7.0] - 2026-07-28
 
 Bug-fix wave with one new opt-in feature and one new provider. Closes a

--- a/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
+++ b/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
@@ -1,7 +1,7 @@
 <!-- last_verified: 2026-09-03 -->
 # Issue 262: Seedance 2.0 requests in agent pipeline intermittently get infinitely stalled while returning "dispatched" status
 
-> **Status: IMPLEMENTED.** Branch `issue/262-gmicloud-poll-stall-timeout` (commit `6ee33b3`). gmicloud suite green (265 passed, 8 pre-existing skips); full-repo `make test` not yet re-run cleanly on this branch.
+> **Status: IMPLEMENTED & VERIFIED.** Branch `issue/262-gmicloud-poll-stall-timeout`. gmicloud suite green (265 passed, 8 pre-existing skips) and the full-repo `make test` gate passes (exit 0, every package green — core 2144 passed, all connectors/cli/meta/tools passing; the 7 new stall/ceiling tests among them).
 
 ## Problem
 
@@ -101,4 +101,6 @@ ruff format --check libs/connectors/gmicloud/
 make test
 ```
 
-Manual sanity: temporarily set `max_poll_seconds` small and confirm a stubbed always-`processing` request produces a terminal `FAILED` step with `error_code=timeout` and an actionable message, rather than hanging.
+**Result:** the 7 new tests fail against unmodified production code (red) and pass after the fix (green); `pytest tests/ -q -rs` in gmicloud → `265 passed, 8 skipped`; `ruff check` / `ruff format --check` on the touched Python files → clean; the full-repo `make test` gate → **exit 0, all packages passing** (core `2144 passed`, gmicloud `265 passed`, every other connector / cli / meta / tools green).
+
+Manual sanity: temporarily set `max_poll_seconds` small and confirm a stubbed always-`processing` request produces a terminal `FAILED` step with `error_code=timeout` and an actionable message, rather than hanging — verified end-to-end (a `timeout=3600` caller config that previously polled forever now fails at the ceiling).

--- a/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
+++ b/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
@@ -1,0 +1,103 @@
+<!-- last_verified: 2026-09-03 -->
+# Issue 262: Seedance 2.0 requests in agent pipeline intermittently get infinitely stalled while returning "dispatched" status
+
+> **Status: PLAN (not yet implemented).** Placed here at the user's request. Branch `issue/262-gmicloud-poll-stall-timeout`.
+
+## Problem
+
+GitHub issue: [#262](https://github.com/backblaze-labs/genblaze/issues/262)
+
+A user integrating genblaze + gmiCloud into [Samsar](https://github.com/samsarone/samsar) runs multi-layer text→video jobs (Seedance 2.0). In a 10-layer fan-out, ~7 layers finish and ~3 hang indefinitely (60+ minutes) in a non-terminal state — Samsar labels this "dispatched"; on the genblaze side the step is stuck in `StepStatus.PROCESSING`. A hung step can neither be retried nor failed, so the agent stalls. Expected behaviour (from the issue): **every request must reach a terminal state — complete or fail — so the caller can handle or retry it.**
+
+The video path runs through `GMICloudVideoProvider`, which inherits the shared poll loop in `GMICloudBase` (`libs/connectors/gmicloud/genblaze_gmicloud/_base.py`). The per-job wait loop lives in core: `_poll_fetch_once` (`libs/core/genblaze_core/providers/base.py:1443`) and its async twin `_apoll_fetch_once` (:1485), which drive `self.poll()` until it returns `True`.
+
+GMICloud's documented request-queue statuses are exactly `queued`, `processing`, `success`, `failed`, `cancelled` (verified against `docs.gmicloud.ai`). The connector's terminal set is therefore **correct**:
+
+```python
+_TERMINAL_STATUSES = frozenset({"success", "failed", "cancelled"})   # _base.py:33
+```
+
+So this is **not** a status-vocabulary mismatch. The real defect: under parallel load some Seedance jobs genuinely wedge upstream in `queued`/`processing` and never transition. `poll()` (`_base.py:267-290`) faithfully returns `False` for every non-terminal status, forever. The **only** backstop is the core loop's wall-clock timeout:
+
+- `timeout` is taken verbatim from the caller's config: `timeout = (config or {}).get("timeout", DEFAULT_TIMEOUT)` (`base.py:1712/1758/1769/1955`), `DEFAULT_TIMEOUT = 600.0` (`base.py:60`). There is **no upper clamp** and **no connector-enforced ceiling**.
+- Long video needs a large per-step `timeout` (the connector README examples use `.run(timeout=600)`); Samsar sets it large enough that the 60s+ Seedance jobs never trip it, so a wedged job outlives any practical wall clock.
+- When the timeout *does* fire, `invoke()` does not raise — it returns a `FAILED` step. The core raises a bare `"Poll timeout after Ns"` `ProviderError` (`base.py:1467`, `:1509`) with no explicit `error_code`, but the invoke handler classifies it to `TIMEOUT` via string-match (`"timeout" in msg`, `base.py:145`). So the step correctly ends `FAILED` / `error_code=timeout` — the message is just opaque (no request id / upstream status). The defect is purely that this only happens when the caller set a *bounded* timeout.
+
+### Reproduced locally (deterministic, no key)
+
+Stub the HTTP client so poll always returns `{"status": "processing"}` and drive the real `provider.invoke()`:
+
+- `timeout=12` → step ends `FAILED`, `error_code=ProviderErrorCode.TIMEOUT`, `"Poll timeout after 12.0s"` — the safety net firing.
+- `timeout=3600` (the long-video case) → the loop never terminates; it polls forever (after the ~24s `estimated_seconds` initial delay). **This is #262.**
+
+## Fix
+
+Add a **connector-enforced maximum polling ceiling** to `GMICloudBase` so a wedged upstream request always becomes a terminal, retryable failure within a bounded time, independent of the caller-supplied `config["timeout"]`. Keep the change inside the gmicloud connector (no core edits) to keep the blast radius minimal per CLAUDE.md.
+
+1. **`GMICloudBase.__init__`** (`_base.py`): add `max_poll_seconds: float | None = 1800.0` (30 min — generous for long video, still bounded; `None` disables and falls back to the core timeout only). Store it, and add a per-instance `_poll_first_seen: dict[str, float]` guarded by a `threading.Lock`, mirroring the existing thread-safe `_poll_cache` / `_poll_cache_lock` pattern in core (`base.py:541-581`) — required because sync fan-out shares one provider across a `ThreadPoolExecutor` and async fan-out calls `poll()` via `asyncio.to_thread` (`base.py:1498`).
+
+2. **`GMICloudBase.poll()`** (`_base.py:267`): on each call, record first-seen monotonic time for `prediction_id` (once), then after the normal terminal check:
+   - If status is terminal → clear the first-seen entry and return `True` (unchanged behaviour).
+   - If status is non-terminal **and** `max_poll_seconds` is set and elapsed-since-first-seen exceeds it → raise
+     `ProviderError(f"GMICloud request {prediction_id} stalled in status '{status}' after {elapsed:.0f}s (max_poll_seconds={max_poll_seconds})", error_code=ProviderErrorCode.TIMEOUT)`.
+   - Otherwise return `False`.
+
+   Because the loop calls `poll()` through `_retry_phase`, a `TIMEOUT`-coded raise is retried at most `max_attempts` times (default 6, `poll_transient_retries=5 + 1`) — the ceiling stays breached across those attempts, so it deterministically exhausts the budget and propagates as a **terminal `FAILED` step** with `error_code=TIMEOUT`. `TIMEOUT` is in `RETRYABLE_ERROR_CODES`, so Samsar (or genblaze step-retry) can re-drive it — exactly what the issue asks for. Termination is bounded by `max_attempts`, **not** by the caller's `timeout`, which is the whole point.
+
+3. **`GMICloudVideoProvider.__init__`** and the image/audio provider `__init__`s (`provider.py`, `image.py`, `audio.py`): thread the new `max_poll_seconds` kwarg through to `super().__init__` so it's configurable per provider (default inherited).
+
+4. **Defensive `fetch_output` hardening** (`provider.py:85-126`): today the failure branch only matches `("failed", "cancelled")`; any other non-`success` status that somehow reaches fetch produces a vague `"completed but no video URL found"`. Change the guard to raise a clear terminal error for **any status that is not `success`** (carrying the status), so fetch can never silently mis-handle an unexpected state. Low-risk belt-and-suspenders; the ceiling means fetch is normally only reached on a genuine terminal status.
+
+5. **README** (`libs/connectors/gmicloud/README.md`): document `max_poll_seconds` (default, meaning, `None` to disable) alongside `poll_interval` / `http_timeout`.
+
+Reused, not reinvented: core's `_poll_cache_lock` thread-safe-dict idiom (`base.py:541-581`), `ProviderErrorCode.TIMEOUT` + `RETRYABLE_ERROR_CODES` (`enums.py:56,69`), the existing `map_gmicloud_error` / `retry_after` plumbing (unchanged).
+
+## Risk
+
+Low–moderate; connector-scoped, no core or public-API-signature-breaking change (new kwarg is keyword-only with a default).
+
+- The ceiling changes observable behaviour: a job that previously hung "forever" now fails at ~`max_poll_seconds`. This is the intended fix; 1800s is well beyond normal Seedance completion, so legitimate jobs are unaffected.
+- New per-instance state (`_poll_first_seen`) is bounded — entries are cleared on terminal status and on ceiling breach; keys are distinct prediction ids. Mutations are lock-guarded, matching the existing poll-cache concurrency contract, so fan-out (threads / `to_thread`) is safe.
+- `estimated_seconds=30.0` on submit (`_base.py:265`) still delays the first poll — unchanged, and negligible against the ceiling.
+
+## Files to Modify
+
+| File | Change |
+| --- | --- |
+| `libs/connectors/gmicloud/genblaze_gmicloud/_base.py` | Add `max_poll_seconds` param + lock-guarded `_poll_first_seen`; enforce the stall ceiling in `poll()` |
+| `libs/connectors/gmicloud/genblaze_gmicloud/provider.py` | Thread `max_poll_seconds` through `GMICloudVideoProvider.__init__`; harden `fetch_output` non-`success` handling |
+| `libs/connectors/gmicloud/genblaze_gmicloud/image.py`, `audio.py` | Thread `max_poll_seconds` through their `__init__`s |
+| `libs/connectors/gmicloud/tests/test_gmicloud_provider.py` | New tests (below), following the file's `MagicMock`-response convention |
+| `libs/connectors/gmicloud/README.md` | Document `max_poll_seconds` |
+
+No production behaviour outside gmicloud changes. No version bump / CHANGELOG entry unless this ships in a release wave (per RELEASING.md / CONTRIBUTING.md).
+
+## Tests (TDD — write failing first)
+
+In `test_gmicloud_provider.py`:
+
+- `test_poll_raises_timeout_when_stalled_past_ceiling`: construct provider with a tiny `max_poll_seconds` (or pre-seed `_poll_first_seen` to an old monotonic value); stub the GET to keep returning `{"status": "processing"}`; assert `poll()` raises `ProviderError` with `error_code == ProviderErrorCode.TIMEOUT` and a message naming the status + request id.
+- `test_poll_does_not_raise_before_ceiling`: `processing` within the window → returns `False`, no raise.
+- `test_poll_terminal_clears_first_seen`: a `success`/`failed` poll returns `True` and removes the tracking entry (no leak).
+- `test_poll_ceiling_is_per_prediction_id`: two distinct ids tracked independently.
+- `test_stalled_job_terminates_as_failed_step`: drive `provider.invoke(...)` with a stubbed always-`processing` poll and a tiny ceiling + large `config["timeout"]`; assert the step ends `StepStatus.FAILED` with `error_code == TIMEOUT` — the end-to-end proof that a wedged job no longer hangs regardless of caller timeout.
+- `test_fetch_output_raises_on_unexpected_status`: `_fetch_detail` returns a non-`success`/non-`failed` status → terminal `ProviderError`.
+
+## Verification
+
+```bash
+# regression gate — new stall tests must fail before the fix
+cd libs/connectors/gmicloud && pytest tests/test_gmicloud_provider.py -k "stall or ceiling or timeout" -v
+
+# full connector suite (expect the pre-existing capability opt-out skips only)
+/test-package gmicloud    # or: cd libs/connectors/gmicloud && pytest tests/ -q -rs
+
+# lint / format
+ruff check libs/connectors/gmicloud/
+ruff format --check libs/connectors/gmicloud/
+
+# full-suite gate before done (CLAUDE.md)
+make test
+```
+
+Manual sanity: temporarily set `max_poll_seconds` small and confirm a stubbed always-`processing` request produces a terminal `FAILED` step with `error_code=timeout` and an actionable message, rather than hanging.

--- a/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
+++ b/docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md
@@ -1,7 +1,7 @@
 <!-- last_verified: 2026-09-03 -->
 # Issue 262: Seedance 2.0 requests in agent pipeline intermittently get infinitely stalled while returning "dispatched" status
 
-> **Status: PLAN (not yet implemented).** Placed here at the user's request. Branch `issue/262-gmicloud-poll-stall-timeout`.
+> **Status: IMPLEMENTED.** Branch `issue/262-gmicloud-poll-stall-timeout` (commit `6ee33b3`). gmicloud suite green (265 passed, 8 pre-existing skips); full-repo `make test` not yet re-run cleanly on this branch.
 
 ## Problem
 
@@ -44,7 +44,7 @@ Add a **connector-enforced maximum polling ceiling** to `GMICloudBase` so a wedg
 
    Because the loop calls `poll()` through `_retry_phase`, a `TIMEOUT`-coded raise is retried at most `max_attempts` times (default 6, `poll_transient_retries=5 + 1`) — the ceiling stays breached across those attempts, so it deterministically exhausts the budget and propagates as a **terminal `FAILED` step** with `error_code=TIMEOUT`. `TIMEOUT` is in `RETRYABLE_ERROR_CODES`, so Samsar (or genblaze step-retry) can re-drive it — exactly what the issue asks for. Termination is bounded by `max_attempts`, **not** by the caller's `timeout`, which is the whole point.
 
-3. **`GMICloudVideoProvider.__init__`** and the image/audio provider `__init__`s (`provider.py`, `image.py`, `audio.py`): thread the new `max_poll_seconds` kwarg through to `super().__init__` so it's configurable per provider (default inherited).
+3. **Provider constructors** — no change needed. `GMICloudVideoProvider`, `GMICloudImageProvider`, and `GMICloudAudioProvider` define **no** `__init__` of their own; they inherit `GMICloudBase.__init__`, so adding `max_poll_seconds` to the base automatically exposes it on all three (`GMICloudVideoProvider(max_poll_seconds=...)` works out of the box). `image.py` / `audio.py` were therefore **not** edited.
 
 4. **Defensive `fetch_output` hardening** (`provider.py:85-126`): today the failure branch only matches `("failed", "cancelled")`; any other non-`success` status that somehow reaches fetch produces a vague `"completed but no video URL found"`. Change the guard to raise a clear terminal error for **any status that is not `success`** (carrying the status), so fetch can never silently mis-handle an unexpected state. Low-risk belt-and-suspenders; the ceiling means fetch is normally only reached on a genuine terminal status.
 
@@ -57,18 +57,19 @@ Reused, not reinvented: core's `_poll_cache_lock` thread-safe-dict idiom (`base.
 Low–moderate; connector-scoped, no core or public-API-signature-breaking change (new kwarg is keyword-only with a default).
 
 - The ceiling changes observable behaviour: a job that previously hung "forever" now fails at ~`max_poll_seconds`. This is the intended fix; 1800s is well beyond normal Seedance completion, so legitimate jobs are unaffected.
-- New per-instance state (`_poll_first_seen`) is bounded — entries are cleared on terminal status and on ceiling breach; keys are distinct prediction ids. Mutations are lock-guarded, matching the existing poll-cache concurrency contract, so fan-out (threads / `to_thread`) is safe.
+- New per-instance state (`_poll_first_seen`) is bounded — entries are cleared on a terminal poll, with a FIFO cap (`_POLL_FIRST_SEEN_MAX = 512`) as the backstop for ids that only ever end via the ceiling. The entry is deliberately **not** cleared on ceiling breach: the core poll phase retries `poll()` a bounded number of times, and each retry must still see the deadline blown so the retry budget drains and the step terminates — clearing on breach would reset the clock and re-hang. Mutations are lock-guarded, matching the existing poll-cache concurrency contract, so fan-out (threads / `to_thread`) is safe.
 - `estimated_seconds=30.0` on submit (`_base.py:265`) still delays the first poll — unchanged, and negligible against the ceiling.
 
-## Files to Modify
+## Files Modified
 
 | File | Change |
 | --- | --- |
-| `libs/connectors/gmicloud/genblaze_gmicloud/_base.py` | Add `max_poll_seconds` param + lock-guarded `_poll_first_seen`; enforce the stall ceiling in `poll()` |
-| `libs/connectors/gmicloud/genblaze_gmicloud/provider.py` | Thread `max_poll_seconds` through `GMICloudVideoProvider.__init__`; harden `fetch_output` non-`success` handling |
-| `libs/connectors/gmicloud/genblaze_gmicloud/image.py`, `audio.py` | Thread `max_poll_seconds` through their `__init__`s |
-| `libs/connectors/gmicloud/tests/test_gmicloud_provider.py` | New tests (below), following the file's `MagicMock`-response convention |
+| `libs/connectors/gmicloud/genblaze_gmicloud/_base.py` | Add `max_poll_seconds` param (default 1800s) + lock-guarded `_poll_first_seen`; enforce the stall ceiling in `poll()` via `_enforce_poll_deadline` / `_clear_poll_deadline` |
+| `libs/connectors/gmicloud/genblaze_gmicloud/provider.py` | Harden `fetch_output` to fail on any non-`success` status |
+| `libs/connectors/gmicloud/tests/test_gmicloud_provider.py` | 7 new tests, following the file's `MagicMock`-response convention |
 | `libs/connectors/gmicloud/README.md` | Document `max_poll_seconds` |
+
+**Not modified:** `image.py` / `audio.py` — neither defines its own `__init__`, so `max_poll_seconds` reaches `GMICloudImageProvider` / `GMICloudAudioProvider` automatically through the inherited `GMICloudBase.__init__` (no per-subclass threading required).
 
 No production behaviour outside gmicloud changes. No version bump / CHANGELOG entry unless this ships in a release wave (per RELEASING.md / CONTRIBUTING.md).
 

--- a/libs/connectors/gmicloud/README.md
+++ b/libs/connectors/gmicloud/README.md
@@ -179,6 +179,25 @@ for step in run.steps:
         print(f"failed ({step.error_code}): {step.error}")
 ```
 
+### Stalled requests never hang forever
+
+GMICloud can occasionally leave a request wedged in `queued`/`processing`
+indefinitely (seen under heavy parallel fan-out). To guarantee every step
+reaches a terminal state — so an agent can retry rather than stall — each queue
+provider enforces a `max_poll_seconds` ceiling (default **1800s / 30 min**). A
+request that stays non-terminal past the ceiling fails with
+`error_code == ProviderErrorCode.TIMEOUT`, independent of the per-step `timeout`
+you pass to `.run()`:
+
+```python
+# Raise the ceiling for unusually long jobs, or pass None to disable it and
+# rely solely on the pipeline's own timeout.
+provider = GMICloudVideoProvider(max_poll_seconds=3600)  # 1 hour
+```
+
+Because the failure is a `TIMEOUT`, it's retryable — re-drive the step (or the
+run) to submit a fresh request.
+
 ## Documentation
 
 - **Main repo**: https://github.com/backblaze-labs/genblaze

--- a/libs/connectors/gmicloud/genblaze_gmicloud/_base.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/_base.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 import os
+import threading
+import time
 from dataclasses import replace
 from typing import Any
 
@@ -31,6 +33,21 @@ from ._errors import map_gmicloud_error
 _DEFAULT_BASE_URL = "https://console.gmicloud.ai/api/v1/ie/requestqueue/apikey"
 
 _TERMINAL_STATUSES = frozenset({"success", "failed", "cancelled"})
+
+# Default connector-side ceiling on how long a single request may sit in a
+# non-terminal state before we fail it (#262). GMICloud occasionally leaves a
+# request wedged in ``queued``/``processing`` indefinitely; the core poll loop's
+# only backstop is the caller-supplied ``config["timeout"]``, which long video
+# runs set very large (or leave unset), so a wedged job would otherwise poll
+# forever. 30 minutes is well beyond any real Seedance/Veo/Kling completion.
+_DEFAULT_MAX_POLL_SECONDS = 1800.0
+
+# Upper bound on the ``_poll_first_seen`` deadline map so a long-lived provider
+# that accumulates many wedged/abandoned request ids can't grow it unbounded.
+# Entries are removed on a terminal poll; this FIFO cap bounds the pathological
+# case where jobs only ever fail via the ceiling. 512 dwarfs any realistic
+# in-flight fan-out.
+_POLL_FIRST_SEEN_MAX = 512
 
 
 def _is_inference_endpoint_shaped(url: str) -> bool:
@@ -133,6 +150,14 @@ class GMICloudBase(BaseProvider):
         poll_interval: Seconds between request status polls (default 5).
         http_timeout: HTTP request timeout in seconds (default 120).
             Ignored when ``http_client`` is supplied.
+        max_poll_seconds: Connector-side ceiling on how long a single request
+            may remain in a non-terminal (``queued``/``processing``) state
+            before ``poll()`` fails it with a retryable ``TIMEOUT`` error
+            (default 1800). This is independent of — and a hard backstop for —
+            the caller-supplied per-step ``timeout``: a wedged upstream job
+            terminates here even when the caller set a very large or unbounded
+            ``timeout`` for long video (#262). Pass ``None`` to disable and rely
+            solely on the caller's ``timeout``.
         base_url: Override the request-queue base URL. Falls back to the
             GMI_BASE_URL env var, then the canonical production URL.
             Ignored when ``http_client`` is supplied.
@@ -173,6 +198,7 @@ class GMICloudBase(BaseProvider):
         *,
         poll_interval: float = 5.0,
         http_timeout: float = 120.0,
+        max_poll_seconds: float | None = _DEFAULT_MAX_POLL_SECONDS,
         base_url: str | None = None,
         http_client: httpx.Client | None = None,
         models: ModelRegistry | None = None,
@@ -191,6 +217,14 @@ class GMICloudBase(BaseProvider):
             probe_cache_max_entries=probe_cache_max_entries,
         )
         self.poll_interval = poll_interval
+        self._max_poll_seconds = max_poll_seconds
+        # Monotonic timestamp of the first poll seen for each in-flight
+        # prediction id, used to enforce ``max_poll_seconds``. Guarded by a
+        # lock because one provider instance is shared across a fan-out
+        # (sync ThreadPoolExecutor, or async via ``asyncio.to_thread``) — same
+        # concurrency contract as the core poll-result cache.
+        self._poll_first_seen: dict[str, float] = {}
+        self._poll_first_seen_lock = threading.Lock()
         self._api_key: str | None = api_key or os.environ.get("GMI_API_KEY")
         self._http_timeout = http_timeout
         self._base_url: str = base_url or os.environ.get("GMI_BASE_URL") or _DEFAULT_BASE_URL
@@ -264,8 +298,48 @@ class GMICloudBase(BaseProvider):
         request_id = data.get("request_id") or data.get("id")
         return SubmitResult(prediction_id=request_id, estimated_seconds=30.0)
 
+    def _clear_poll_deadline(self, key: str) -> None:
+        """Forget the stall deadline for a request that has finished polling."""
+        with self._poll_first_seen_lock:
+            self._poll_first_seen.pop(key, None)
+
+    def _enforce_poll_deadline(self, key: str, status: str) -> None:
+        """Fail a request that has sat in a non-terminal state past the ceiling.
+
+        Records the first time this ``key`` was seen (once), then raises a
+        retryable ``TIMEOUT`` ``ProviderError`` once elapsed exceeds
+        ``max_poll_seconds``. The deadline entry is deliberately *not* cleared
+        on breach: the core poll phase retries ``poll()`` a bounded number of
+        times, and each retry must see the deadline still blown so the retry
+        budget drains and the step terminates as ``FAILED`` — clearing here
+        would reset the clock and re-hang. Cleared instead on a terminal poll
+        (see ``poll``), with a FIFO cap as the backstop for abandoned ids.
+        """
+        if self._max_poll_seconds is None:
+            return
+        now = time.monotonic()
+        with self._poll_first_seen_lock:
+            first = self._poll_first_seen.get(key)
+            if first is None:
+                # FIFO-evict the oldest entry before inserting a new one so a
+                # long-lived provider can't grow the map without bound.
+                if len(self._poll_first_seen) >= _POLL_FIRST_SEEN_MAX:
+                    oldest = next(iter(self._poll_first_seen))
+                    self._poll_first_seen.pop(oldest, None)
+                self._poll_first_seen[key] = first = now
+        elapsed = now - first
+        if elapsed >= self._max_poll_seconds:
+            raise ProviderError(
+                f"GMICloud request {key} stalled in status {status!r} after "
+                f"{elapsed:.0f}s (max_poll_seconds={self._max_poll_seconds:.0f}); "
+                "upstream never reached a terminal state. Failing the step so it "
+                "can be retried.",
+                error_code=ProviderErrorCode.TIMEOUT,
+            )
+
     def poll(self, prediction_id: Any, config: RunnableConfig | None = None) -> bool:
         """Check if a GMICloud request is complete (shared across all modalities)."""
+        key = str(prediction_id)
         try:
             client = self._get_http_client()
             resp = client.get(f"/requests/{prediction_id}")
@@ -277,9 +351,15 @@ class GMICloudBase(BaseProvider):
                     retry_after=retry_after_from_response(resp),
                 )
             detail = resp.json()
-            if detail.get("status", "") in _TERMINAL_STATUSES:
+            status = detail.get("status", "")
+            if status in _TERMINAL_STATUSES:
+                self._clear_poll_deadline(key)
                 self._cache_poll_result(prediction_id, detail)
                 return True
+            # Non-terminal: enforce the connector-side stall ceiling so a wedged
+            # upstream job can't poll forever when the caller set a large or
+            # unbounded per-step timeout (#262).
+            self._enforce_poll_deadline(key, status)
             return False
         except ProviderError:
             raise

--- a/libs/connectors/gmicloud/genblaze_gmicloud/provider.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/provider.py
@@ -90,9 +90,14 @@ class GMICloudVideoProvider(GMICloudBase):
 
             step.provider_payload = {"gmicloud": {"request_id": prediction_id, "status": status}}
 
-            if status in ("failed", "cancelled"):
+            # Any status other than a clean success is a terminal failure here.
+            # ``failed``/``cancelled`` carry an upstream error message; any other
+            # non-``success`` status (e.g. a request that reached fetch still
+            # ``processing``) is surfaced explicitly rather than falling through
+            # to a vague "no video URL found" (#262).
+            if status != "success":
                 raise ProviderError(
-                    str(detail.get("error") or f"Video generation {status}"),
+                    str(detail.get("error") or f"Video generation ended in status {status!r}"),
                     error_code=ProviderErrorCode.UNKNOWN,
                 )
 

--- a/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
+++ b/libs/connectors/gmicloud/tests/test_gmicloud_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
@@ -100,6 +101,91 @@ def test_poll_returns_true_on_failed(provider):
     assert provider.poll("req-abc123") is True
 
 
+# --- Poll stall ceiling (issue #262) ---
+
+
+def _processing_provider(max_poll_seconds):
+    """Provider whose poll endpoint is wedged in 'processing' forever."""
+    from genblaze_gmicloud import GMICloudVideoProvider
+
+    p = GMICloudVideoProvider(api_key="test-api-key-123", max_poll_seconds=max_poll_seconds)
+    client = make_mock_http_client(outcome_url="https://gmicloud-output.com/video.mp4")
+    processing = MagicMock()
+    processing.status_code = 200
+    processing.json.return_value = {"request_id": "req-abc123", "status": "processing"}
+    client.get.return_value = processing
+    p._http_client = client
+    return p
+
+
+def test_poll_raises_timeout_when_stalled_past_ceiling():
+    p = _processing_provider(max_poll_seconds=1.0)
+    # Pretend this request has been polling far longer than the ceiling.
+    p._poll_first_seen["req-abc123"] = time.monotonic() - 100.0
+    with pytest.raises(ProviderError) as exc_info:
+        p.poll("req-abc123")
+    assert exc_info.value.error_code == ProviderErrorCode.TIMEOUT
+    msg = str(exc_info.value)
+    assert "req-abc123" in msg
+    assert "processing" in msg
+
+
+def test_poll_does_not_raise_before_ceiling():
+    p = _processing_provider(max_poll_seconds=1800.0)
+    # First poll seeds the deadline; well within the window → not done, no raise.
+    assert p.poll("req-abc123") is False
+    assert p.poll("req-abc123") is False
+
+
+def test_poll_ceiling_disabled_when_none():
+    p = _processing_provider(max_poll_seconds=None)
+    p._poll_first_seen["req-abc123"] = time.monotonic() - 100_000.0
+    # No ceiling → never raises, just keeps reporting "not done".
+    assert p.poll("req-abc123") is False
+
+
+def test_poll_terminal_clears_first_seen(provider):
+    # The provider fixture's mock GET returns status "success".
+    assert provider.poll("req-abc123") is True
+    assert "req-abc123" not in provider._poll_first_seen
+
+
+def test_poll_ceiling_is_per_prediction_id():
+    p = _processing_provider(max_poll_seconds=1.0)
+    p._poll_first_seen["req-old"] = time.monotonic() - 100.0
+    # A fresh id is tracked independently and stays within its own window.
+    assert p.poll("req-fresh") is False
+    assert "req-fresh" in p._poll_first_seen
+    with pytest.raises(ProviderError):
+        p.poll("req-old")
+
+
+def test_stalled_job_terminates_as_failed_step(monkeypatch):
+    # A wedged job with a large caller timeout must still terminate — the
+    # connector ceiling, not the caller's timeout, is what ends it (#262).
+    monkeypatch.setattr("genblaze_core.providers.base.time.sleep", lambda *a, **k: None)
+    p = _processing_provider(max_poll_seconds=1.0)
+    p.poll_interval = 0.0
+
+    # Suppress the estimated_seconds initial delay (same idiom as the
+    # compliance harness at the bottom of this file).
+    original_submit = p.submit
+
+    def fast_submit(step, config=None):
+        r = original_submit(step, config)
+        r.estimated_seconds = None
+        return r
+
+    p.submit = fast_submit
+    # Pre-age the request so the ceiling trips on the first poll.
+    p._poll_first_seen["req-abc123"] = time.monotonic() - 100.0
+
+    step = Step(provider="gmicloud", model="seedance-2-0-260128", prompt="a 60s sunset")
+    result = p.invoke(step, {"timeout": 3600.0})
+    assert result.status == StepStatus.FAILED
+    assert result.error_code == ProviderErrorCode.TIMEOUT
+
+
 # --- Fetch output ---
 
 
@@ -132,6 +218,18 @@ def test_fetch_output_cancelled_raises(provider):
     provider.poll("req-abc123")
     step = Step(provider="gmicloud", model="kling-text2video-v1.6-pro", prompt="test")
     with pytest.raises(ProviderError, match="cancelled"):
+        provider.fetch_output("req-abc123", step)
+
+
+def test_fetch_output_raises_on_unexpected_status(provider):
+    # A non-success status reaching fetch must produce a clear terminal error
+    # naming the status — not a vague "no video URL found".
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"status": "processing", "outcome": {}}
+    provider._http_client.get.return_value = resp
+    step = Step(provider="gmicloud", model="kling-text2video-v1.6-pro", prompt="test")
+    with pytest.raises(ProviderError, match="processing"):
         provider.fetch_output("req-abc123", step)
 
 


### PR DESCRIPTION
GMICloud's request-queue API occasionally leaves a video job wedged in `queued`/`processing` indefinitely — seen with Seedance 2.0 under parallel fan-out. genblaze's shared poll loop treats any non-terminal status as "keep polling", bounded only by the caller-supplied per-step `timeout`, which long-video callers set large or leave unset. So a wedged layer never reaches a terminal state: the step sits in `PROCESSING` for 60+ minutes and an agent driving the run can neither retry nor fail it. Reported by a user integrating genblaze + GMICloud into [Samsar](https://github.com/samsarone/samsar) — a 10-layer job where 7 layers completed and 3 stalled forever. GMICloud's documented statuses (`queued`, `processing`, `success`, `failed`, `cancelled`) are handled correctly; the gap is purely the unbounded wait, not a status-vocabulary mismatch.

Fixes [#262](https://github.com/backblaze-labs/genblaze/issues/262)

## Summary

Adds a connector-side polling ceiling so every GMICloud request reaches a terminal state within a bounded time, independent of the caller's `timeout`. A request that stays non-terminal past `max_poll_seconds` (default 1800s / 30 min) now fails with a **retryable** `TIMEOUT`, so the step ends `FAILED` and can be re-driven rather than hanging. No core changes — the fix is contained to the gmicloud connector.

## Changes

* `libs/connectors/gmicloud/genblaze_gmicloud/_base.py` — new `max_poll_seconds` ctor kwarg (default 1800s; `None` disables) plus a lock-guarded `_poll_first_seen` deadline map. `poll()` records first-seen time per prediction id and, once a non-terminal request exceeds the ceiling, raises a retryable `TIMEOUT` `ProviderError` naming the stuck status and request id. The deadline is cleared on a terminal poll, with a FIFO cap as a backstop against unbounded growth. Shared by all three queue providers (video/image/audio) via the base; safe under fan-out (`ThreadPoolExecutor` and `asyncio.to_thread`), mirroring the core poll-cache locking contract.
* `libs/connectors/gmicloud/genblaze_gmicloud/provider.py` — `fetch_output` now raises a clear terminal error for **any** non-`success` status instead of falling through to a vague "no video URL found".
* `libs/connectors/gmicloud/tests/test_gmicloud_provider.py` — 7 new tests: ceiling trips past the deadline / holds within it / disables on `None`, terminal poll clears state, deadlines are per-prediction-id, an end-to-end `invoke()` proving a wedged job with a large caller timeout terminates as `FAILED`/`TIMEOUT`, and `fetch_output` failing on an unexpected status.
* `libs/connectors/gmicloud/README.md` — documents `max_poll_seconds` (default, override, `None` to disable) under a "Stalled requests never hang forever" section.
* `docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md` — plan doc: problem, fix rationale, files, verification.

*(`image.py` / `audio.py` were not modified — they define no `__init__`, so `max_poll_seconds` reaches `GMICloudImageProvider` / `GMICloudAudioProvider` automatically via the inherited `GMICloudBase.__init__`.)*

## Test plan

* New tests fail against unmodified production code (7 red) and pass after the fix (7 green) — they exercise the new behavior, not a vacuous path.
* `cd libs/connectors/gmicloud && pytest tests/ -q -rs` → `265 passed, 8 skipped` (the 8 skips are pre-existing capability opt-outs, unrelated to this change).
* End-to-end repro: a stubbed always-`processing` request with a `timeout=3600` per-step config previously polled forever; it now terminates as `FAILED` with `error_code == ProviderErrorCode.TIMEOUT` and an actionable message.
* `ruff check` / `ruff format --check` on the touched Python files — clean.
* Full-repo `make test` gate → **exit 0, all packages green** (core `2144 passed`, gmicloud `265 passed`, plus every other connector / cli / meta / tools). The 7 new stall/ceiling tests are included and pass.

## Related

* Fixes [#262](https://github.com/backblaze-labs/genblaze/issues/262)
* Plan: `docs/exec-plans/completed/issue-262-gmicloud-poll-stall-timeout.md`