### PR TITLE
fix(google): materialize Veo Gemini downloads as file:// assets so B2 upload works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ CLAUDE.local.md
 *.tmp
 *.bak
 *.log
+
+# pre-pr-check run history (audit trail, not tracked)
+.pre-pr-check/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   downloads the generated video to a local file and exposes a `file://` asset
   URL — matching the Vertex path — instead of leaving a credentialed Files API
   URI that `ObjectStorageSink`/B2 could not fetch unauthenticated (#263).
+- **Security** `VeoProvider` no longer interpolates an unvalidated `step_id`
+  into the local output filename. A `Step` built or deserialized with a
+  caller-supplied `step_id` containing `../` traversal or an absolute path
+  could previously escape the configured `output_dir` and, following an
+  existing symlink, silently overwrite another job's output or any
+  process-writable file. `step_id` is now validated as a UUID, the resolved
+  path is verified to stay under `output_dir`, and the write refuses to follow
+  symlinks or clobber an existing file — on both the Vertex and Gemini auth
+  paths (#284).
 
 ### genblaze-core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### genblaze-google
+
+- **Fixed** Veo on the Gemini Developer API (`api_key` / `GEMINI_API_KEY`) now
+  downloads the generated video to a local file and exposes a `file://` asset
+  URL — matching the Vertex path — instead of leaving a credentialed Files API
+  URI that `ObjectStorageSink`/B2 could not fetch unauthenticated (#263).
+
 ### genblaze-core
 
 - **Fixed** lazy top-level exports now appear in `dir(genblaze_core)` before

--- a/docs/exec-plans/completed/issue-263-veo-gemini-files-uri-to-file-url.md
+++ b/docs/exec-plans/completed/issue-263-veo-gemini-files-uri-to-file-url.md
@@ -1,0 +1,158 @@
+<!-- branch: issue/263-google-veo-gemini-files-uri-to-file-url -->
+# Issue 263: Veo Gemini Developer API path keeps Files API URIs that ObjectStorageSink/B2 cannot fetch
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/263
+
+`VeoProvider.fetch_output()` (`libs/connectors/google/genblaze_google/provider.py:262-308`)
+handles the two auth modes asymmetrically, so B2/object-storage transfers
+succeed on Vertex but fail on the Gemini Developer API (`api_key` /
+`GEMINI_API_KEY`).
+
+The branch discriminator is `video_bytes`, read at `:264` **before** any
+download:
+
+- **Vertex AI** — video comes back inline (`video.video_bytes` set, `uri` is
+  `None`). The `if` branch (`:266-282`) writes the bytes to disk and exposes a
+  `file://` URL via `local_file_url()`. `ObjectStorageSink` uploads to B2 with
+  no Google auth. Correct.
+- **Gemini Developer API** — video comes back as a Files API reference (`uri`
+  set, `video_bytes` `None`). The `else` branch (`:283-290`) calls
+  `client.files.download(file=video)` — which fetches the bytes — then **throws
+  them away** and sets `video_uri = getattr(video, "uri", None)`, a credentialed
+  `https://…` Files API URI. `validate_asset_url()` passes it (it is HTTPS), the
+  asset is attached, and downstream `ObjectStorageSink` fetches it
+  **unauthenticated** → the download fails and the asset never lands on B2.
+
+#136 fixed the Vertex inline-bytes path and explicitly left the Gemini path
+unchanged, leaving `api_key` + B2 users broken end-to-end.
+
+SDK contract, confirmed against the pinned `google-genai` (`>=1.0,<3`) source
+(`google/genai/files.py:675-765`):
+
+- `download(file=video)` with `destination=None` returns the bytes **and** sets
+  `video.video_bytes` as a side effect (`:759-763`) — so the current code
+  already pays the full download cost, then discards it.
+- `download(file=video, destination=<path>)` **streams to disk in chunks
+  without holding the file in memory** (`:687-692`) and returns `None`.
+
+A test currently **codifies the bug**: `test_fetch_output_attaches_asset`
+(`libs/connectors/google/tests/test_veo_provider.py:106`) asserts the asset host
+stays `storage.googleapis.com`. The default mock operation
+(`_make_completed_operation`, `:17-22`) drives this same Gemini path, so several
+other tests depend transitively on the buggy URI-passthrough. This is not an
+additive fix — the fixture and these assertions change.
+
+## Fix
+
+Make the Gemini path reach the **same `file://` outcome** as Vertex, and share
+the file-materialization logic so the two modes can't drift again.
+
+Production — `provider.py` `fetch_output()` loop (`:262-308`):
+
+1. Extract `_video_output_path(step, i) -> Path`, encapsulating the path
+   selection currently inlined in the Vertex branch (`:272-280`): if
+   `self._output_dir` is set, `mkdir(parents=True, exist_ok=True)` and return
+   `output_dir / f"{step.step_id}_{i}.mp4"`; otherwise a unique
+   `tempfile.mkstemp(suffix=".mp4")` path. One definition, both modes.
+2. Restructure the loop so each mode only *fills* the file, then both share one
+   `file://` emission:
+   - **Vertex** (`video_bytes` truthy): `out_path.write_bytes(video_bytes)`
+     (unchanged behavior).
+   - **Gemini** (`elif uri`): `video_bytes = client.files.download(file=video)`
+     — the byte-returning download form (also sets `video.video_bytes`); then
+     `out_path.write_bytes(video_bytes)`. **Do NOT** use the streaming
+     `destination=` argument: it was only added in google-genai **2.21.0**, but
+     this connector supports `google-genai>=1.0,<3`, so passing it would
+     `TypeError` on every earlier allowed release. Raise `ProviderError` if the
+     download yields no bytes.
+   - Both: `video_uri = local_file_url(out_path.resolve())`.
+3. Drop the now-unreachable `validate_asset_url(video_uri)` call on the Gemini
+   branch (it only guarded the remote HTTPS URI, which no longer escapes the
+   provider). Preserve the guard that raises `ProviderError` when neither inline
+   bytes nor a downloadable `uri` exist.
+4. Remove the unused `validate_asset_url` import (ruff F401).
+
+Net behavioral change: on `api_key` mode, `asset.url` changes from a credentialed
+`https://…` Files API URI to a `file://` URL backed by bytes on local disk —
+matching Vertex, matching `ImagenProvider` / `gemini_image` /
+`DecartVideoProvider`, and letting `ObjectStorageSink` upload to B2 without
+Google auth. Audio/track metadata handling (`:293-306`) is untouched.
+
+Tests — `test_veo_provider.py`:
+
+- Update the `mock_google` fixture: give `mock_client.files.download` a
+  `side_effect` that returns fake bytes and sets `file.video_bytes` (mirroring
+  the real byte-returning contract) and asserts `destination` is NOT passed,
+  instead of `return_value = None`.
+- Rewrite `test_fetch_output_attaches_asset`: assert
+  `asset.url.startswith("file://")`, the file exists with the expected bytes,
+  and `files.download` was called **without** a `destination=` (the compat
+  guard). Remove the `storage.googleapis.com` host assertion.
+- Add Gemini-path tests mirroring the existing Vertex trio:
+  `test_fetch_output_gemini_downloads_to_file_url` (output_dir → indexed name),
+  `test_fetch_output_gemini_no_output_dir` (tempfile fallback),
+  `test_fetch_output_gemini_multiple_videos_no_collision`.
+- Confirm the other operations-get-driven tests still pass under the new
+  fixture; adjust any lingering URI assertion.
+
+Docs / release:
+
+- CHANGELOG `[Unreleased]` → `### genblaze-google` **Fixed** bullet (#263).
+- No version bump (versions move per release wave, per RELEASING.md).
+
+## Risk
+
+Low–moderate, contained to `genblaze-google` Veo.
+
+- The Vertex path is byte-for-byte unchanged (still `write_bytes`); only its
+  path-selection lines move into a helper.
+- The Gemini path already performed the full download (the old code called
+  `client.files.download(file=video)` and discarded the bytes). The fix simply
+  keeps those bytes and writes them to a local file — the only new external
+  behavior is the local write, what every other local-output connector already
+  does through `local_file_url`.
+- SDK compatibility (why byte-buffering, not `destination=` streaming): the
+  streaming `destination=` argument was added only in google-genai **2.21.0**,
+  but the connector declares `google-genai>=1.0,<3`. Using it would `TypeError`
+  on every earlier allowed release. Byte-buffering works across the whole range.
+  A test asserts the download call passes no `destination=` so this can't
+  regress.
+- Memory: like the Vertex path, the Gemini path now holds one clip in memory
+  before writing. Veo clips are short (`max_duration` 8s → tens of MB) and are
+  processed one at a time, so this is bounded and acceptable. A future
+  bounded-memory streaming path is possible via SDK feature-detection if the
+  floor is later raised — tracked as a follow-up, not required for this fix.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `libs/connectors/google/genblaze_google/provider.py` | modified |
+| `libs/connectors/google/tests/test_veo_provider.py` | modified |
+| `libs/connectors/google/README.md` | modified |
+| `CHANGELOG.md` | modified |
+| `.gitignore` | modified (ignore `.pre-pr-check/` audit trail) |
+| `docs/exec-plans/completed/issue-263-veo-gemini-files-uri-to-file-url.md` | created |
+
+No unrelated production source touched. No version bump (versions move per
+release wave, per RELEASING.md).
+
+## Verification
+
+1. Regression gate — the rewritten + new tests fail against the old
+   URI-passthrough code and pass after the fix. Additionally, reintroducing the
+   `destination=` kwarg fails 12 tests (the compat guard), proving the
+   version-safety assertion is load-bearing.
+2. `cd libs/connectors/google && pytest tests/ -q` → **142 passed, 10 skipped**
+   against the fixed source.
+3. `ruff check` / `ruff format --check` on the touched files — clean; no F401
+   from the dropped `validate_asset_url` import.
+4. Full-repo `make test` gate on the final commit → **exit 0, all packages
+   green** (core `2144 passed`, google `142 passed`, plus every other connector /
+   cli / meta / tools).
+5. Pre-PR review (3 Claude + 3 Codex checks) caught the SDK-compat blocker
+   pre-merge; re-run after the fix returned zero blocking findings. Two items
+   deferred to a follow-up issue (shared output-path hardening; bounded-memory
+   streaming) — neither affects this acceptance criterion.

--- a/docs/exec-plans/completed/issue-284-veo-output-path-traversal.md
+++ b/docs/exec-plans/completed/issue-284-veo-output-path-traversal.md
@@ -1,0 +1,145 @@
+<!-- branch: issue/284-veo-output-path-traversal -->
+# Issue 284: Veo output path interpolates unvalidated step_id — path traversal / cross-job overwrite (both Vertex and Gemini)
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/284
+
+`VeoProvider._video_output_path()` (`libs/connectors/google/genblaze_google/provider.py:184-198`)
+builds the local output path for a generated video by interpolating
+`step.step_id` directly into the filename, with no validation:
+
+    # libs/connectors/google/genblaze_google/provider.py:195
+    return self._output_dir / f"{step.step_id}_{i}.mp4"
+
+Both auth branches in `fetch_output()` (`:284-292` Vertex, `:293-314` Gemini)
+call this shared helper and then `out_path.write_bytes(video_bytes)` directly
+(`:291`, `:313`). This branch is stacked on `issue/263-...` (#286), whose fix
+introduced the shared helper and the Gemini local-write path — so on this base
+**both** auth modes flow through the identical unvalidated path construction.
+
+`Step.step_id` only *defaults* to a UUID — `libs/core/genblaze_core/models/step.py:39`
+is `Field(default_factory=new_id)`, and `new_id()` (`_utils.py:21-23`) returns
+`str(uuid.uuid4())`. The UUID is a default, not an invariant: `Step` has
+`model_config = ConfigDict(extra="forbid")`, but `step_id` itself is a plain
+`str`, so a `Step` constructed or **deserialized** with an explicit `step_id`
+can carry `../` traversal segments or an absolute path.
+
+`Path.__truediv__` then escapes or ignores the configured `output_dir`:
+
+- `output_dir / "../../../../tmp/pwned"` resolves outside `output_dir`.
+- an **absolute** `step_id` makes `/` discard `output_dir` entirely.
+
+The subsequent `write_bytes(...)` **follows existing symlinks and overwrites**
+whatever resolves at the target — so a crafted `step_id` can clobber another
+job's/tenant's output, or any process-writable path ending in the generated
+`_<i>.mp4` suffix.
+
+Impact is limited under the normal pipeline (the pipeline generates a UUID
+`step_id`), which is why this is rated **P2**, not P1. But any service that
+accepts externally-constructed or deserialized `Step` objects with a
+caller-supplied `step_id` is exploitable.
+
+## Fix
+
+Harden the single shared `_video_output_path()` helper and add a safe writer,
+so neither auth mode can write outside `output_dir` and neither can overwrite
+an existing file via a symlink.
+
+Production — `provider.py`:
+
+1. **`_video_output_path(step, i)`** — validate before building the path:
+   - Parse `step.step_id` with `uuid.UUID(step.step_id)`. A non-UUID value
+     (`../…`, an absolute path, any traversal junk) fails to parse →
+     raise `ProviderError(..., error_code=ProviderErrorCode.INVALID_INPUT)`.
+     Build the filename from the canonical parsed value
+     (`f"{parsed}_{i}.mp4"`), not the raw string — neutralizes traversal at
+     the source.
+   - When `self._output_dir` is set: `mkdir(parents=True, exist_ok=True)`,
+     then resolve the candidate and assert
+     `candidate.resolve().parent == self._output_dir.resolve()` (equivalent to
+     `is_relative_to` for a single-segment filename; defense-in-depth against
+     any future change to the filename template). Raise `ProviderError`
+     (`INVALID_INPUT`) if not contained.
+   - No-`output_dir` fallback unchanged: unique `tempfile.mkstemp(suffix=".mp4")`
+     (already outside the traversal surface — mkstemp ignores `step_id`).
+2. **New `_write_new_video_file(path, data)`** helper, used by both branches
+   instead of `Path.write_bytes`:
+   `os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)`,
+   write, close. `O_EXCL` refuses to write through a pre-existing name (file or
+   symlink); `O_NOFOLLOW` refuses to traverse a symlink even if the OS ordering
+   allowed it. Any `OSError` (`FileExistsError` included) →
+   `ProviderError(..., error_code=ProviderErrorCode.INVALID_INPUT)`.
+   The tempfile-fallback case has already atomically created the file via
+   `mkstemp`, so its path is re-opened for write without `O_EXCL` (the file
+   legitimately exists and is exclusively ours — `mkstemp` guarantees that).
+3. Replace both `out_path.write_bytes(video_bytes)` call sites (`:291`, `:313`)
+   with `self._write_new_video_file(out_path, video_bytes)`.
+4. No change to audio/track metadata, pricing, or the "neither bytes nor uri"
+   guard.
+
+Tests — `test_veo_provider.py`:
+
+- Traversal/validation, both branches (Vertex inline-bytes, Gemini download):
+  - `step_id="../../../../tmp/pwned"` → `ProviderError`, nothing written
+    outside `output_dir`.
+  - absolute `step_id` (e.g. `"/tmp/pwned"`) → `ProviderError`.
+  - non-UUID junk `step_id` (e.g. `"not-a-uuid"`) → `ProviderError`.
+- Symlink safety: pre-plant a symlink at the would-be target path (using a
+  legitimate UUID `step_id`) → write refuses (`ProviderError`), the symlink's
+  destination file is untouched.
+- No-overwrite: a pre-existing regular file at the target path is not
+  clobbered (`ProviderError`).
+- Duplicate `step_id` across two videos in one step still disambiguates via
+  the `_<i>` index (existing behavior preserved for the legit UUID case).
+- Existing Vertex + Gemini happy-path tests still pass unmodified (valid
+  `uuid4` `step_id` writes under `output_dir` and exposes a `file://` URL).
+
+Docs / release:
+
+- CHANGELOG `[Unreleased]` → `### genblaze-google` **Fixed** (security) bullet
+  (#284).
+- No version bump (versions move per release wave, per RELEASING.md).
+
+## Risk
+
+Low, contained to `genblaze-google` Veo.
+
+- Legit pipeline runs are unaffected: `step_id` is a `uuid4`, parses cleanly,
+  resolves directly under `output_dir`, and the target doesn't pre-exist — the
+  happy path is byte-for-byte equivalent aside from the safer open flags.
+- Behavior change by design: a re-run that reuses an `output_dir` + `step_id`
+  now raises instead of silently overwriting (per the issue's "without
+  overwriting an existing file"). This matches the security requirement and is
+  covered by a test.
+- `O_NOFOLLOW` is available on POSIX; Python's `os.open` accepts it on Windows
+  too (mapped by the CRT) — the symlink test asserts the refusal on the CI
+  platform.
+- Depends on #286 (#263) — this branch is stacked on it and cannot merge until
+  #286 does. Called out in the PR.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `libs/connectors/google/genblaze_google/provider.py` | modified |
+| `libs/connectors/google/tests/test_veo_provider.py` | modified |
+| `CHANGELOG.md` | modified |
+| `docs/exec-plans/completed/issue-284-veo-output-path-traversal.md` | created |
+
+No core/model source touched — the fix is provider-local (validation at the
+Veo boundary), keeping the diff minimal and avoiding cross-provider fallout
+from tightening `Step.step_id` globally. No version bump.
+
+## Verification
+
+1. Regression gate: the new traversal/symlink/overwrite tests fail against the
+   pre-fix code (writes escape `output_dir` / overwrite silently) and pass
+   after the fix.
+2. `cd libs/connectors/google && pytest tests/ -q` → all green.
+3. `ruff check` / `ruff format --check` on touched files — clean.
+4. Full-repo `make test` gate on the final commit → exit 0.
+5. `/pre-pr-check` scoped to this diff against the acceptance criterion "no
+   write escapes the resolved output_dir on either Veo auth path, and no write
+   overwrites an existing file or follows a symlink"; resolve blocking
+   findings before opening the PR.

--- a/libs/connectors/google/README.md
+++ b/libs/connectors/google/README.md
@@ -58,10 +58,12 @@ Vertex AI auth instead:
 provider = VeoProvider(project="my-gcp-project", location="us-central1")
 ```
 
-Vertex returns generated video bytes inline (no Files API on Vertex), so
-`fetch_output()` saves them to a local file and exposes a `file://` asset —
-pass `output_dir` to control where those files land (default: system temp),
-same as `ImagenProvider` below.
+Both auth modes materialize the generated video to a local `file://` asset, so
+`ObjectStorageSink` can upload it to B2 without Google credentials in the sink.
+Vertex returns the bytes inline (no Files API on Vertex); the Gemini API path
+downloads them from the Files API — either way `fetch_output()` writes a local
+file and exposes a `file://` asset. Pass `output_dir` to control where those
+files land (default: system temp), same as `ImagenProvider` below.
 
 ## Quickstart — Imagen 3 text-to-image
 

--- a/libs/connectors/google/genblaze_google/provider.py
+++ b/libs/connectors/google/genblaze_google/provider.py
@@ -34,7 +34,6 @@ from genblaze_core.providers import (
     ModelSpec,
     ProviderCapabilities,
     RetryPolicy,
-    validate_asset_url,
 )
 from genblaze_core.providers.retry import retry_after_from_response
 from genblaze_core.runnable.config import RunnableConfig
@@ -61,8 +60,11 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
         project: GCP project ID for Vertex AI auth (mutually exclusive with api_key).
         location: GCP region for Vertex AI (default "us-central1").
         poll_interval: Seconds between operation polls (default 10).
-        output_dir: Directory for locally-saved video files when the SDK
-            returns bytes inline (Vertex AI mode; default system temp).
+        output_dir: Directory for locally-saved video files. Both auth modes
+            materialize the generated video to a local ``file://`` asset —
+            Vertex returns bytes inline; Gemini downloads them from the Files
+            API (issue #263) — so ObjectStorageSink can upload to B2 without
+            Google auth (default: system temp).
         models: Optional custom ``ModelRegistry`` — overrides the class default.
         retry_policy: Optional retry policy override.
         probe_cache_ttl: Per-instance probe-cache TTL.
@@ -179,6 +181,22 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
             return types.GenerateVideosOperation(name=prediction_id)  # type: ignore[call-arg]
         return prediction_id
 
+    def _video_output_path(self, step: Step, i: int) -> Path:
+        """Pick the local path for the ``i``-th generated video.
+
+        Shared by both auth modes so the Vertex (inline-bytes) and Gemini
+        (Files API download) paths can't drift on where the file lands
+        (issue #263). When ``output_dir`` is set, index by loop position
+        (matches ImagenProvider) so ``number_of_videos > 1`` doesn't collide
+        on one path; otherwise fall back to a unique tempfile.
+        """
+        if self._output_dir:
+            self._output_dir.mkdir(parents=True, exist_ok=True)
+            return self._output_dir / f"{step.step_id}_{i}.mp4"
+        fd, tmp = tempfile.mkstemp(suffix=".mp4")
+        os.close(fd)
+        return Path(tmp)
+
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
         """Start a video generation operation."""
         client = self._get_client()
@@ -262,32 +280,38 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
             for i, gv in enumerate(response.generated_videos):
                 video = gv.video
                 video_bytes = getattr(video, "video_bytes", None)
-                video_uri: str | None
+                video_uri: str | None = None
                 if video_bytes:
                     # Vertex AI mode: video comes back inline — there's no
                     # Files API on Vertex, so client.files.download() raises
                     # ValueError there (issue #136). Save locally and expose
                     # a file:// asset, matching the local-output convention
                     # used by ImagenProvider / DecartVideoProvider.
-                    if self._output_dir:
-                        self._output_dir.mkdir(parents=True, exist_ok=True)
-                        # Index by loop position (matches ImagenProvider) so
-                        # number_of_videos > 1 doesn't collide on one path.
-                        out_path = self._output_dir / f"{step.step_id}_{i}.mp4"
-                    else:
-                        fd, tmp = tempfile.mkstemp(suffix=".mp4")
-                        os.close(fd)
-                        out_path = Path(tmp)
+                    out_path = self._video_output_path(step, i)
                     out_path.write_bytes(video_bytes)
                     video_uri = local_file_url(out_path.resolve())
-                else:
-                    # Gemini Developer API mode: the Files API download
-                    # populates video_bytes as a side effect; the response's
-                    # public `uri` is the asset URL.
-                    client.files.download(file=video)
-                    video_uri = getattr(video, "uri", None)
-                    if video_uri:
-                        validate_asset_url(video_uri)
+                elif getattr(video, "uri", None):
+                    # Gemini Developer API mode: the asset lives behind a
+                    # credentialed Files API URI that ObjectStorageSink/B2
+                    # cannot fetch unauthenticated (issue #263). Download the
+                    # bytes and write them to a local file, exposing the same
+                    # file:// asset the Vertex path produces so the sink can
+                    # upload to B2 without any Google auth.
+                    #
+                    # Use the byte-returning download form (no ``destination=``):
+                    # ``download(file=video)`` both returns the bytes and sets
+                    # ``video.video_bytes`` as a side effect. The streaming
+                    # ``destination=`` argument was only added in google-genai
+                    # 2.21.0, but this connector supports ``google-genai>=1.0``
+                    # — passing it would ``TypeError`` on every earlier release.
+                    out_path = self._video_output_path(step, i)
+                    video_bytes = client.files.download(file=video) or getattr(
+                        video, "video_bytes", None
+                    )
+                    if not video_bytes:
+                        raise ProviderError("Veo Gemini download returned no video bytes")
+                    out_path.write_bytes(video_bytes)
+                    video_uri = local_file_url(out_path.resolve())
 
                 if video_uri:
                     vm_kwargs: dict[str, Any] = {"has_audio": has_audio}

--- a/libs/connectors/google/genblaze_google/provider.py
+++ b/libs/connectors/google/genblaze_google/provider.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -189,13 +190,68 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
         (issue #263). When ``output_dir`` is set, index by loop position
         (matches ImagenProvider) so ``number_of_videos > 1`` doesn't collide
         on one path; otherwise fall back to a unique tempfile.
+
+        ``step.step_id`` only *defaults* to a UUID (``Step.step_id`` is a
+        plain ``str``) — a ``Step`` built or deserialized with an explicit
+        ``step_id`` could otherwise carry ``../`` traversal or an absolute
+        path straight into the filename (issue #284). Parse it as a UUID and
+        build the name from the canonical parsed value, then verify the
+        result still resolves directly under ``output_dir``, so a crafted
+        ``step_id`` can't escape the configured directory.
         """
         if self._output_dir:
             self._output_dir.mkdir(parents=True, exist_ok=True)
-            return self._output_dir / f"{step.step_id}_{i}.mp4"
+            try:
+                parsed_id = uuid.UUID(step.step_id)
+            except (ValueError, AttributeError, TypeError) as exc:
+                raise ProviderError(
+                    f"Invalid step_id for video output path: {step.step_id!r}",
+                    error_code=ProviderErrorCode.INVALID_INPUT,
+                ) from exc
+            candidate = self._output_dir / f"{parsed_id}_{i}.mp4"
+            resolved_dir = self._output_dir.resolve()
+            if candidate.resolve().parent != resolved_dir:
+                raise ProviderError(
+                    "Resolved video output path escapes output_dir",
+                    error_code=ProviderErrorCode.INVALID_INPUT,
+                )
+            return candidate
         fd, tmp = tempfile.mkstemp(suffix=".mp4")
         os.close(fd)
         return Path(tmp)
+
+    @staticmethod
+    def _write_new_video_file(path: Path, data: bytes, *, exclusive: bool = True) -> None:
+        """Write ``data`` to ``path`` without following symlinks or overwriting.
+
+        Used instead of ``Path.write_bytes`` for video output: that call
+        follows existing symlinks and silently overwrites the resolved
+        target, which combined with an attacker-controlled ``step_id`` is the
+        cross-job overwrite in issue #284. ``O_EXCL`` refuses a pre-existing
+        name (file or symlink); ``O_NOFOLLOW`` refuses to traverse a symlink.
+
+        ``exclusive=False`` is for the tempfile-fallback path only: ``mkstemp``
+        has already atomically created that (exclusively-ours) file, so
+        ``O_EXCL`` would reject the very path it just made.
+
+        ``O_NOFOLLOW`` is POSIX-only (unavailable on Windows) — read via
+        ``getattr`` so this degrades to "no symlink guard on this platform"
+        instead of an unhandled ``AttributeError`` that would break video
+        output entirely there.
+        """
+        flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags |= os.O_CREAT | os.O_EXCL if exclusive else 0
+        try:
+            fd = os.open(path, flags, 0o600)
+        except OSError as exc:
+            raise ProviderError(
+                f"Refusing to write video output to {path}: {exc}",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            ) from exc
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
 
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
         """Start a video generation operation."""
@@ -288,7 +344,9 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
                     # a file:// asset, matching the local-output convention
                     # used by ImagenProvider / DecartVideoProvider.
                     out_path = self._video_output_path(step, i)
-                    out_path.write_bytes(video_bytes)
+                    self._write_new_video_file(
+                        out_path, video_bytes, exclusive=bool(self._output_dir)
+                    )
                     video_uri = local_file_url(out_path.resolve())
                 elif getattr(video, "uri", None):
                     # Gemini Developer API mode: the asset lives behind a
@@ -310,7 +368,9 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
                     )
                     if not video_bytes:
                         raise ProviderError("Veo Gemini download returned no video bytes")
-                    out_path.write_bytes(video_bytes)
+                    self._write_new_video_file(
+                        out_path, video_bytes, exclusive=bool(self._output_dir)
+                    )
                     video_uri = local_file_url(out_path.resolve())
 
                 if video_uri:

--- a/libs/connectors/google/tests/test_veo_provider.py
+++ b/libs/connectors/google/tests/test_veo_provider.py
@@ -26,6 +26,18 @@ def _make_pending_operation():
     return SimpleNamespace(done=False, name="op-123", error=None, response=None)
 
 
+def _make_completed_gemini_operation(count: int = 1):
+    """Gemini Developer API mode: videos come back as Files API references
+    (``uri`` set, no inline ``video_bytes``). fetch_output must download each
+    to a local file and expose a ``file://`` asset (issue #263)."""
+    videos = [
+        SimpleNamespace(uri=f"https://storage.googleapis.com/video/out-{i}.mp4", video_bytes=None)
+        for i in range(count)
+    ]
+    response = SimpleNamespace(generated_videos=[SimpleNamespace(video=v) for v in videos])
+    return SimpleNamespace(done=True, name="op-123", error=None, response=response)
+
+
 def _make_completed_vertex_operation(count: int = 1):
     """Vertex AI mode: video bytes come back inline, no Files API ``uri``."""
     videos = [
@@ -61,7 +73,20 @@ def mock_google():
     mock_client = MagicMock()
     mock_client.models.generate_videos.return_value = _make_pending_operation()
     mock_client.operations.get.return_value = _make_completed_operation()
-    mock_client.files.download.return_value = None
+
+    # Mirror the real SDK's byte-returning ``download(file=video)``: it returns
+    # the bytes AND sets ``video.video_bytes`` as a side effect (google/genai/
+    # files.py). ``destination=`` is deliberately NOT used — it only exists on
+    # google-genai >= 2.21.0, but the connector supports >= 1.0 (issue #263).
+    def _download_returns_bytes(*, file, **kwargs):
+        assert "destination" not in kwargs, (
+            "fetch_output must not pass destination= (needs google-genai>=2.21)"
+        )
+        data = f"fake-mp4-bytes::{getattr(file, 'uri', '')}".encode()
+        file.video_bytes = data  # side effect the real SDK performs
+        return data
+
+    mock_client.files.download.side_effect = _download_returns_bytes
 
     with patch.dict(
         "sys.modules",
@@ -104,6 +129,10 @@ def test_poll_returns_true_when_done(mock_google):
 
 
 def test_fetch_output_attaches_asset(mock_google):
+    """Gemini Developer API mode: the credentialed Files API URI must be
+    downloaded to a local file and exposed as a file:// asset, so
+    ObjectStorageSink/B2 can upload it without Google auth (issue #263).
+    It must NOT leak the storage.googleapis.com URI downstream."""
     provider, client = mock_google
     step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
     pred_id = provider.submit(step)
@@ -113,9 +142,17 @@ def test_fetch_output_attaches_asset(mock_google):
 
     result = provider.fetch_output(pred_id, step)
     assert len(result.assets) == 1
-    assert result.assets[0].media_type == "video/mp4"
-    _host = urlparse(result.assets[0].url).hostname or ""
-    assert _host == "storage.googleapis.com" or _host.endswith(".storage.googleapis.com")
+    asset = result.assets[0]
+    assert asset.media_type == "video/mp4"
+    assert asset.url.startswith("file://"), (
+        "must materialize a local file:// asset, not a Files URI"
+    )
+    # Bytes were downloaded and written to a real local file. The download must
+    # NOT pass destination= — that arg only exists on google-genai>=2.21, but the
+    # connector supports >=1.0, so passing it would TypeError on older releases.
+    client.files.download.assert_called_once()
+    assert "destination" not in client.files.download.call_args.kwargs
+    assert Path(urlparse(asset.url).path).read_bytes()
 
 
 def test_poll_wraps_bare_operation_name_string(mock_google):
@@ -197,6 +234,65 @@ def test_fetch_output_vertex_multiple_videos_no_collision(tmp_path, mock_google)
     for asset in result.assets:
         path = urlparse(asset.url).path
         assert Path(path).read_bytes()  # each file actually has its own bytes
+
+
+def test_fetch_output_gemini_downloads_to_file_url(tmp_path, mock_google):
+    """Gemini mode with output_dir set: stream the Files API download to an
+    indexed local file and expose a file:// asset (issue #263)."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    result = provider.fetch_output(pred_id, step)
+    assert len(result.assets) == 1
+    asset = result.assets[0]
+    assert asset.url.startswith("file://")
+    assert asset.media_type == "video/mp4"
+    out_file = tmp_path / f"{step.step_id}_0.mp4"
+    assert out_file.exists() and out_file.read_bytes()
+    # Version-safe download: no destination= (google-genai>=1.0 compatibility).
+    assert "destination" not in client.files.download.call_args.kwargs
+
+
+def test_fetch_output_gemini_no_output_dir(mock_google):
+    """Gemini mode without a configured output_dir falls back to a unique
+    tempfile, still exposing a file:// asset."""
+    provider, client = mock_google
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    result = provider.fetch_output(pred_id, step)
+    asset = result.assets[0]
+    assert asset.url.startswith("file://")
+    assert Path(urlparse(asset.url).path).read_bytes()
+
+
+def test_fetch_output_gemini_multiple_videos_no_collision(tmp_path, mock_google):
+    """number_of_videos > 1 in Gemini mode must download each video to its own
+    file — no collision on a single output path (mirrors the Vertex case)."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(
+        provider="google-veo",
+        model="veo-2.0-generate-001",
+        prompt="a sunset",
+        params={"number_of_videos": "2"},
+    )
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation(count=2)
+    provider.poll(pred_id)
+
+    result = provider.fetch_output(pred_id, step)
+    assert len(result.assets) == 2
+    urls = {asset.url for asset in result.assets}
+    assert len(urls) == 2, "each video must get a distinct file:// path"
+    for asset in result.assets:
+        assert Path(urlparse(asset.url).path).read_bytes()
 
 
 def test_fetch_output_error_raises(mock_google):
@@ -411,7 +507,8 @@ class TestVeoCompliance(ProviderComplianceTests):
         mock_client = MagicMock()
         mock_client.models.generate_videos.return_value = _make_pending_operation()
         mock_client.operations.get.return_value = _make_completed_operation()
-        mock_client.files.download.return_value = None
+        # Gemini path: download returns bytes (no destination=); see fixture.
+        mock_client.files.download.return_value = b"fake-mp4-bytes"
         provider = VeoProvider(api_key="test-key")
         provider._client = mock_client
         return provider

--- a/libs/connectors/google/tests/test_veo_provider.py
+++ b/libs/connectors/google/tests/test_veo_provider.py
@@ -295,6 +295,148 @@ def test_fetch_output_gemini_multiple_videos_no_collision(tmp_path, mock_google)
         assert Path(urlparse(asset.url).path).read_bytes()
 
 
+# --- Path-traversal / cross-job overwrite hardening (issue #284) ---
+
+
+@pytest.mark.parametrize(
+    "bad_step_id",
+    [
+        "../../../../tmp/pwned",
+        "/tmp/pwned",  # noqa: S108 — attacker-controlled payload, never used as a real path
+        "not-a-uuid",
+    ],
+)
+def test_fetch_output_vertex_rejects_invalid_step_id(tmp_path, mock_google, bad_step_id):
+    """A non-UUID step_id (traversal, absolute path, or junk) must be
+    rejected before any write happens — it must never let the output escape
+    output_dir (issue #284)."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(
+        provider="google-veo",
+        model="veo-2.0-generate-001",
+        prompt="a sunset",
+        step_id=bad_step_id,
+    )
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    # Nothing must have been written outside output_dir, and output_dir itself
+    # must stay empty.
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "bad_step_id",
+    [
+        "../../../../tmp/pwned",
+        "/tmp/pwned",  # noqa: S108 — attacker-controlled payload, never used as a real path
+        "not-a-uuid",
+    ],
+)
+def test_fetch_output_gemini_rejects_invalid_step_id(tmp_path, mock_google, bad_step_id):
+    """Same invalid-step_id containment check on the Gemini download branch."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(
+        provider="google-veo",
+        model="veo-2.0-generate-001",
+        prompt="a sunset",
+        step_id=bad_step_id,
+    )
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_output_refuses_to_follow_symlink(tmp_path, mock_google):
+    """If a symlink is pre-planted at the would-be output path, the write must
+    refuse rather than follow it and overwrite the symlink's target."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    secret_target = tmp_path.parent / "secret.mp4"
+    secret_target.write_bytes(b"do-not-touch")
+    symlink_path = tmp_path / f"{step.step_id}_0.mp4"
+    symlink_path.symlink_to(secret_target)
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert secret_target.read_bytes() == b"do-not-touch"
+
+
+def test_fetch_output_refuses_to_overwrite_existing_file(tmp_path, mock_google):
+    """A pre-existing regular file at the target path must not be clobbered."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    existing = tmp_path / f"{step.step_id}_0.mp4"
+    existing.write_bytes(b"pre-existing-content")
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert existing.read_bytes() == b"pre-existing-content"
+
+
+def test_fetch_output_gemini_refuses_to_follow_symlink(tmp_path, mock_google):
+    """Same symlink refusal on the Gemini download branch (mirrors the Vertex
+    case): fetch_output must not follow a pre-planted symlink at the target
+    path."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    secret_target = tmp_path.parent / "secret-gemini.mp4"
+    secret_target.write_bytes(b"do-not-touch")
+    symlink_path = tmp_path / f"{step.step_id}_0.mp4"
+    symlink_path.symlink_to(secret_target)
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert secret_target.read_bytes() == b"do-not-touch"
+
+
+def test_fetch_output_gemini_refuses_to_overwrite_existing_file(tmp_path, mock_google):
+    """Same no-overwrite protection on the Gemini download branch (mirrors the
+    Vertex case): a pre-existing file at the target path must not be
+    clobbered."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    existing = tmp_path / f"{step.step_id}_0.mp4"
+    existing.write_bytes(b"pre-existing-content")
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert existing.read_bytes() == b"pre-existing-content"
+
+
 def test_fetch_output_error_raises(mock_google):
     provider, client = mock_google
     step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="bad")


### PR DESCRIPTION
`VeoProvider.fetch_output()` handled the two auth modes asymmetrically, breaking Backblaze B2 transfers for API-key users. On **Vertex AI** the generated video comes back inline and is written to a local `file://` asset (added in #136), which `ObjectStorageSink` uploads to B2 with no Google auth. On the **Gemini Developer API** (`api_key` / `GEMINI_API_KEY`) path, after `client.files.download(file=video)` the asset URL was left as `video.uri` — a credentialed Google Files API URI. The B2 sink then fetched that URI **unauthenticated**, so the download failed and the asset never landed in durable storage. #136 fixed the Vertex path and explicitly left this one broken end-to-end.

Fixes [#263](https://github.com/backblaze-labs/genblaze/issues/263)

## Summary

Gives the Gemini path parity with Vertex: after a successful download, the bytes are written to a local file and the asset URL is set to a `file://` URL (honoring `output_dir`, unique tempfile otherwise), so `ObjectStorageSink` uploads to B2 without any Google credentials in the sink. The file-materialization logic is shared between both auth modes so they can't drift again. No core changes — the fix is contained to the `genblaze-google` connector.

Note on SDK compatibility: the download deliberately uses the **byte-returning** `client.files.download(file=video)` form, **not** the streaming `destination=` argument. `destination=` was only added in `google-genai` 2.21.0, but the connector supports `google-genai>=1.0,<3` — passing it would `TypeError` on every earlier allowed release. A test asserts `destination=` is never passed, so this can't regress.

## Changes

* `libs/connectors/google/genblaze_google/provider.py` — the Gemini branch now downloads the bytes (`client.files.download(file=video)`, with a `video.video_bytes` fallback), writes them to a local file, and exposes a `file://` asset instead of the raw Files API URI; raises a clear `ProviderError` if the download yields no bytes. New shared `_video_output_path(step, i)` helper centralizes the `output_dir`-indexed / tempfile path selection used by both auth modes (indexed by loop position so `number_of_videos > 1` can't collide). Dropped the now-unused `validate_asset_url` import (the credentialed URI no longer escapes the provider).
* `libs/connectors/google/tests/test_veo_provider.py` — fixture now emulates the real byte-returning download contract and asserts `destination=` is never passed; rewrote `test_fetch_output_attaches_asset` (it previously asserted the asset stayed a `storage.googleapis.com` URI — codifying the bug); added Gemini `file://` tests for `output_dir`, tempfile fallback, and multi-video no-collision.
* `libs/connectors/google/README.md` + `VeoProvider` docstring — describe `file://` / `output_dir` materialization for **both** auth modes, not Vertex-only.
* `CHANGELOG.md` — `[Unreleased]` › `genblaze-google` **Fixed** bullet (#263).
* `docs/exec-plans/completed/issue-263-veo-gemini-files-uri-to-file-url.md` — plan doc: problem, fix rationale, SDK-compat reasoning, files, verification.

## Test plan

* New/rewritten tests fail against the old URI-passthrough code and pass after the fix — they exercise the real behavior, not a vacuous path. The compat guard is load-bearing: reintroducing `destination=` fails 12 tests.
* `cd libs/connectors/google && pytest tests/ -q` → **142 passed, 10 skipped** against the fixed source.
* `ruff check` / `ruff format --check` on the touched files — clean.
* Full-repo `make test` gate on the final commit → **exit 0, all packages green** (core `2144 passed`, google `142 passed`, plus every other connector / cli / meta / tools).
* Pre-PR review (3 Claude + 3 Codex passes) caught a version-compat blocker before merge — the original approach used `destination=`, which would break on `google-genai < 2.21`; fixed to the byte-returning form and re-verified clean.

## Related

* Fixes [#263](https://github.com/backblaze-labs/genblaze/issues/263)
* Builds on [#136](https://github.com/backblaze-labs/genblaze/issues/136) (Vertex inline-bytes → `file://`)
* Plan: `docs/exec-plans/completed/issue-263-veo-gemini-files-uri-to-file-url.md`
* Deferred to follow-up issues (out of scope, do not block this fix): shared Veo output-path hardening (`step_id` containment, both auth modes); bounded-memory streaming for Gemini downloads.