### PR TITLE
fix(google): validate step_id and harden Veo video writes against path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   downloads the generated video to a local file and exposes a `file://` asset
   URL — matching the Vertex path — instead of leaving a credentialed Files API
   URI that `ObjectStorageSink`/B2 could not fetch unauthenticated (#263).
+- **Security** `VeoProvider` no longer interpolates an unvalidated `step_id`
+  into the local output filename. A `Step` built or deserialized with a
+  caller-supplied `step_id` containing `../` traversal or an absolute path
+  could previously escape the configured `output_dir` and, following an
+  existing symlink, silently overwrite another job's output or any
+  process-writable file. `step_id` is now validated as a UUID, the resolved
+  path is verified to stay under `output_dir`, and the write refuses to follow
+  symlinks or clobber an existing file — on both the Vertex and Gemini auth
+  paths (#284).
 
 ### genblaze-core
 

--- a/docs/exec-plans/completed/issue-284-veo-output-path-traversal.md
+++ b/docs/exec-plans/completed/issue-284-veo-output-path-traversal.md
@@ -1,0 +1,145 @@
+<!-- branch: issue/284-veo-output-path-traversal -->
+# Issue 284: Veo output path interpolates unvalidated step_id — path traversal / cross-job overwrite (both Vertex and Gemini)
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/284
+
+`VeoProvider._video_output_path()` (`libs/connectors/google/genblaze_google/provider.py:184-198`)
+builds the local output path for a generated video by interpolating
+`step.step_id` directly into the filename, with no validation:
+
+    # libs/connectors/google/genblaze_google/provider.py:195
+    return self._output_dir / f"{step.step_id}_{i}.mp4"
+
+Both auth branches in `fetch_output()` (`:284-292` Vertex, `:293-314` Gemini)
+call this shared helper and then `out_path.write_bytes(video_bytes)` directly
+(`:291`, `:313`). This branch is stacked on `issue/263-...` (#286), whose fix
+introduced the shared helper and the Gemini local-write path — so on this base
+**both** auth modes flow through the identical unvalidated path construction.
+
+`Step.step_id` only *defaults* to a UUID — `libs/core/genblaze_core/models/step.py:39`
+is `Field(default_factory=new_id)`, and `new_id()` (`_utils.py:21-23`) returns
+`str(uuid.uuid4())`. The UUID is a default, not an invariant: `Step` has
+`model_config = ConfigDict(extra="forbid")`, but `step_id` itself is a plain
+`str`, so a `Step` constructed or **deserialized** with an explicit `step_id`
+can carry `../` traversal segments or an absolute path.
+
+`Path.__truediv__` then escapes or ignores the configured `output_dir`:
+
+- `output_dir / "../../../../tmp/pwned"` resolves outside `output_dir`.
+- an **absolute** `step_id` makes `/` discard `output_dir` entirely.
+
+The subsequent `write_bytes(...)` **follows existing symlinks and overwrites**
+whatever resolves at the target — so a crafted `step_id` can clobber another
+job's/tenant's output, or any process-writable path ending in the generated
+`_<i>.mp4` suffix.
+
+Impact is limited under the normal pipeline (the pipeline generates a UUID
+`step_id`), which is why this is rated **P2**, not P1. But any service that
+accepts externally-constructed or deserialized `Step` objects with a
+caller-supplied `step_id` is exploitable.
+
+## Fix
+
+Harden the single shared `_video_output_path()` helper and add a safe writer,
+so neither auth mode can write outside `output_dir` and neither can overwrite
+an existing file via a symlink.
+
+Production — `provider.py`:
+
+1. **`_video_output_path(step, i)`** — validate before building the path:
+   - Parse `step.step_id` with `uuid.UUID(step.step_id)`. A non-UUID value
+     (`../…`, an absolute path, any traversal junk) fails to parse →
+     raise `ProviderError(..., error_code=ProviderErrorCode.INVALID_INPUT)`.
+     Build the filename from the canonical parsed value
+     (`f"{parsed}_{i}.mp4"`), not the raw string — neutralizes traversal at
+     the source.
+   - When `self._output_dir` is set: `mkdir(parents=True, exist_ok=True)`,
+     then resolve the candidate and assert
+     `candidate.resolve().parent == self._output_dir.resolve()` (equivalent to
+     `is_relative_to` for a single-segment filename; defense-in-depth against
+     any future change to the filename template). Raise `ProviderError`
+     (`INVALID_INPUT`) if not contained.
+   - No-`output_dir` fallback unchanged: unique `tempfile.mkstemp(suffix=".mp4")`
+     (already outside the traversal surface — mkstemp ignores `step_id`).
+2. **New `_write_new_video_file(path, data)`** helper, used by both branches
+   instead of `Path.write_bytes`:
+   `os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)`,
+   write, close. `O_EXCL` refuses to write through a pre-existing name (file or
+   symlink); `O_NOFOLLOW` refuses to traverse a symlink even if the OS ordering
+   allowed it. Any `OSError` (`FileExistsError` included) →
+   `ProviderError(..., error_code=ProviderErrorCode.INVALID_INPUT)`.
+   The tempfile-fallback case has already atomically created the file via
+   `mkstemp`, so its path is re-opened for write without `O_EXCL` (the file
+   legitimately exists and is exclusively ours — `mkstemp` guarantees that).
+3. Replace both `out_path.write_bytes(video_bytes)` call sites (`:291`, `:313`)
+   with `self._write_new_video_file(out_path, video_bytes)`.
+4. No change to audio/track metadata, pricing, or the "neither bytes nor uri"
+   guard.
+
+Tests — `test_veo_provider.py`:
+
+- Traversal/validation, both branches (Vertex inline-bytes, Gemini download):
+  - `step_id="../../../../tmp/pwned"` → `ProviderError`, nothing written
+    outside `output_dir`.
+  - absolute `step_id` (e.g. `"/tmp/pwned"`) → `ProviderError`.
+  - non-UUID junk `step_id` (e.g. `"not-a-uuid"`) → `ProviderError`.
+- Symlink safety: pre-plant a symlink at the would-be target path (using a
+  legitimate UUID `step_id`) → write refuses (`ProviderError`), the symlink's
+  destination file is untouched.
+- No-overwrite: a pre-existing regular file at the target path is not
+  clobbered (`ProviderError`).
+- Duplicate `step_id` across two videos in one step still disambiguates via
+  the `_<i>` index (existing behavior preserved for the legit UUID case).
+- Existing Vertex + Gemini happy-path tests still pass unmodified (valid
+  `uuid4` `step_id` writes under `output_dir` and exposes a `file://` URL).
+
+Docs / release:
+
+- CHANGELOG `[Unreleased]` → `### genblaze-google` **Fixed** (security) bullet
+  (#284).
+- No version bump (versions move per release wave, per RELEASING.md).
+
+## Risk
+
+Low, contained to `genblaze-google` Veo.
+
+- Legit pipeline runs are unaffected: `step_id` is a `uuid4`, parses cleanly,
+  resolves directly under `output_dir`, and the target doesn't pre-exist — the
+  happy path is byte-for-byte equivalent aside from the safer open flags.
+- Behavior change by design: a re-run that reuses an `output_dir` + `step_id`
+  now raises instead of silently overwriting (per the issue's "without
+  overwriting an existing file"). This matches the security requirement and is
+  covered by a test.
+- `O_NOFOLLOW` is available on POSIX; Python's `os.open` accepts it on Windows
+  too (mapped by the CRT) — the symlink test asserts the refusal on the CI
+  platform.
+- Depends on #286 (#263) — this branch is stacked on it and cannot merge until
+  #286 does. Called out in the PR.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `libs/connectors/google/genblaze_google/provider.py` | modified |
+| `libs/connectors/google/tests/test_veo_provider.py` | modified |
+| `CHANGELOG.md` | modified |
+| `docs/exec-plans/completed/issue-284-veo-output-path-traversal.md` | created |
+
+No core/model source touched — the fix is provider-local (validation at the
+Veo boundary), keeping the diff minimal and avoiding cross-provider fallout
+from tightening `Step.step_id` globally. No version bump.
+
+## Verification
+
+1. Regression gate: the new traversal/symlink/overwrite tests fail against the
+   pre-fix code (writes escape `output_dir` / overwrite silently) and pass
+   after the fix.
+2. `cd libs/connectors/google && pytest tests/ -q` → all green.
+3. `ruff check` / `ruff format --check` on touched files — clean.
+4. Full-repo `make test` gate on the final commit → exit 0.
+5. `/pre-pr-check` scoped to this diff against the acceptance criterion "no
+   write escapes the resolved output_dir on either Veo auth path, and no write
+   overwrites an existing file or follows a symlink"; resolve blocking
+   findings before opening the PR.

--- a/libs/connectors/google/genblaze_google/provider.py
+++ b/libs/connectors/google/genblaze_google/provider.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -189,13 +190,68 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
         (issue #263). When ``output_dir`` is set, index by loop position
         (matches ImagenProvider) so ``number_of_videos > 1`` doesn't collide
         on one path; otherwise fall back to a unique tempfile.
+
+        ``step.step_id`` only *defaults* to a UUID (``Step.step_id`` is a
+        plain ``str``) — a ``Step`` built or deserialized with an explicit
+        ``step_id`` could otherwise carry ``../`` traversal or an absolute
+        path straight into the filename (issue #284). Parse it as a UUID and
+        build the name from the canonical parsed value, then verify the
+        result still resolves directly under ``output_dir``, so a crafted
+        ``step_id`` can't escape the configured directory.
         """
         if self._output_dir:
             self._output_dir.mkdir(parents=True, exist_ok=True)
-            return self._output_dir / f"{step.step_id}_{i}.mp4"
+            try:
+                parsed_id = uuid.UUID(step.step_id)
+            except (ValueError, AttributeError, TypeError) as exc:
+                raise ProviderError(
+                    f"Invalid step_id for video output path: {step.step_id!r}",
+                    error_code=ProviderErrorCode.INVALID_INPUT,
+                ) from exc
+            candidate = self._output_dir / f"{parsed_id}_{i}.mp4"
+            resolved_dir = self._output_dir.resolve()
+            if candidate.resolve().parent != resolved_dir:
+                raise ProviderError(
+                    "Resolved video output path escapes output_dir",
+                    error_code=ProviderErrorCode.INVALID_INPUT,
+                )
+            return candidate
         fd, tmp = tempfile.mkstemp(suffix=".mp4")
         os.close(fd)
         return Path(tmp)
+
+    @staticmethod
+    def _write_new_video_file(path: Path, data: bytes, *, exclusive: bool = True) -> None:
+        """Write ``data`` to ``path`` without following symlinks or overwriting.
+
+        Used instead of ``Path.write_bytes`` for video output: that call
+        follows existing symlinks and silently overwrites the resolved
+        target, which combined with an attacker-controlled ``step_id`` is the
+        cross-job overwrite in issue #284. ``O_EXCL`` refuses a pre-existing
+        name (file or symlink); ``O_NOFOLLOW`` refuses to traverse a symlink.
+
+        ``exclusive=False`` is for the tempfile-fallback path only: ``mkstemp``
+        has already atomically created that (exclusively-ours) file, so
+        ``O_EXCL`` would reject the very path it just made.
+
+        ``O_NOFOLLOW`` is POSIX-only (unavailable on Windows) — read via
+        ``getattr`` so this degrades to "no symlink guard on this platform"
+        instead of an unhandled ``AttributeError`` that would break video
+        output entirely there.
+        """
+        flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags |= os.O_CREAT | os.O_EXCL if exclusive else 0
+        try:
+            fd = os.open(path, flags, 0o600)
+        except OSError as exc:
+            raise ProviderError(
+                f"Refusing to write video output to {path}: {exc}",
+                error_code=ProviderErrorCode.INVALID_INPUT,
+            ) from exc
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
 
     def submit(self, step: Step, config: RunnableConfig | None = None) -> Any:
         """Start a video generation operation."""
@@ -288,7 +344,9 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
                     # a file:// asset, matching the local-output convention
                     # used by ImagenProvider / DecartVideoProvider.
                     out_path = self._video_output_path(step, i)
-                    out_path.write_bytes(video_bytes)
+                    self._write_new_video_file(
+                        out_path, video_bytes, exclusive=bool(self._output_dir)
+                    )
                     video_uri = local_file_url(out_path.resolve())
                 elif getattr(video, "uri", None):
                     # Gemini Developer API mode: the asset lives behind a
@@ -310,7 +368,9 @@ class VeoProvider(GoogleClientMixin, BaseProvider):
                     )
                     if not video_bytes:
                         raise ProviderError("Veo Gemini download returned no video bytes")
-                    out_path.write_bytes(video_bytes)
+                    self._write_new_video_file(
+                        out_path, video_bytes, exclusive=bool(self._output_dir)
+                    )
                     video_uri = local_file_url(out_path.resolve())
 
                 if video_uri:

--- a/libs/connectors/google/tests/test_veo_provider.py
+++ b/libs/connectors/google/tests/test_veo_provider.py
@@ -295,6 +295,148 @@ def test_fetch_output_gemini_multiple_videos_no_collision(tmp_path, mock_google)
         assert Path(urlparse(asset.url).path).read_bytes()
 
 
+# --- Path-traversal / cross-job overwrite hardening (issue #284) ---
+
+
+@pytest.mark.parametrize(
+    "bad_step_id",
+    [
+        "../../../../tmp/pwned",
+        "/tmp/pwned",  # noqa: S108 — attacker-controlled payload, never used as a real path
+        "not-a-uuid",
+    ],
+)
+def test_fetch_output_vertex_rejects_invalid_step_id(tmp_path, mock_google, bad_step_id):
+    """A non-UUID step_id (traversal, absolute path, or junk) must be
+    rejected before any write happens — it must never let the output escape
+    output_dir (issue #284)."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(
+        provider="google-veo",
+        model="veo-2.0-generate-001",
+        prompt="a sunset",
+        step_id=bad_step_id,
+    )
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    # Nothing must have been written outside output_dir, and output_dir itself
+    # must stay empty.
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "bad_step_id",
+    [
+        "../../../../tmp/pwned",
+        "/tmp/pwned",  # noqa: S108 — attacker-controlled payload, never used as a real path
+        "not-a-uuid",
+    ],
+)
+def test_fetch_output_gemini_rejects_invalid_step_id(tmp_path, mock_google, bad_step_id):
+    """Same invalid-step_id containment check on the Gemini download branch."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(
+        provider="google-veo",
+        model="veo-2.0-generate-001",
+        prompt="a sunset",
+        step_id=bad_step_id,
+    )
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_output_refuses_to_follow_symlink(tmp_path, mock_google):
+    """If a symlink is pre-planted at the would-be output path, the write must
+    refuse rather than follow it and overwrite the symlink's target."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    secret_target = tmp_path.parent / "secret.mp4"
+    secret_target.write_bytes(b"do-not-touch")
+    symlink_path = tmp_path / f"{step.step_id}_0.mp4"
+    symlink_path.symlink_to(secret_target)
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert secret_target.read_bytes() == b"do-not-touch"
+
+
+def test_fetch_output_refuses_to_overwrite_existing_file(tmp_path, mock_google):
+    """A pre-existing regular file at the target path must not be clobbered."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    existing = tmp_path / f"{step.step_id}_0.mp4"
+    existing.write_bytes(b"pre-existing-content")
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_vertex_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert existing.read_bytes() == b"pre-existing-content"
+
+
+def test_fetch_output_gemini_refuses_to_follow_symlink(tmp_path, mock_google):
+    """Same symlink refusal on the Gemini download branch (mirrors the Vertex
+    case): fetch_output must not follow a pre-planted symlink at the target
+    path."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    secret_target = tmp_path.parent / "secret-gemini.mp4"
+    secret_target.write_bytes(b"do-not-touch")
+    symlink_path = tmp_path / f"{step.step_id}_0.mp4"
+    symlink_path.symlink_to(secret_target)
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert secret_target.read_bytes() == b"do-not-touch"
+
+
+def test_fetch_output_gemini_refuses_to_overwrite_existing_file(tmp_path, mock_google):
+    """Same no-overwrite protection on the Gemini download branch (mirrors the
+    Vertex case): a pre-existing file at the target path must not be
+    clobbered."""
+    provider, client = mock_google
+    provider._output_dir = tmp_path
+    step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="a sunset")
+
+    existing = tmp_path / f"{step.step_id}_0.mp4"
+    existing.write_bytes(b"pre-existing-content")
+
+    pred_id = provider.submit(step)
+    client.operations.get.return_value = _make_completed_gemini_operation()
+    provider.poll(pred_id)
+
+    with pytest.raises(ProviderError):
+        provider.fetch_output(pred_id, step)
+    assert existing.read_bytes() == b"pre-existing-content"
+
+
 def test_fetch_output_error_raises(mock_google):
     provider, client = mock_google
     step = Step(provider="google-veo", model="veo-2.0-generate-001", prompt="bad")


### PR DESCRIPTION
`VeoProvider._video_output_path()` interpolated `step.step_id` directly into the output filename with no validation. `Step.step_id` only *defaults* to a UUID — a `Step` built or deserialized with an explicit `step_id` could carry `../` traversal segments or an absolute path, which `Path.__truediv__` then let escape the configured `output_dir`. The subsequent write followed existing symlinks and silently overwrote the resolved target — a crafted `step_id` could clobber another job's/tenant's output, or any process-writable path. Impact is limited in the normal pipeline (the pipeline generates a UUID `step_id`), but any service accepting externally-constructed or deserialized `Step` objects with a caller-supplied `step_id` was exploitable. This affects both the Vertex and Gemini auth branches (`#286`/`#263` introduced the Gemini local-write path this fix also covers).

Fixes [#284](https://github.com/backblaze-labs/genblaze/issues/284)

**Depends on #286** — this branch is stacked on `issue/263-...` and cannot merge until #286 does.

## Summary

`step_id` is now parsed as a UUID at the write boundary (rejecting anything else — traversal, absolute paths, junk), and the resolved candidate path is verified to stay under `output_dir`. Writes go through a new `_write_new_video_file()` helper using `O_EXCL | O_NOFOLLOW` (the latter read via `getattr` since it's POSIX-only, so a platform without it degrades gracefully instead of crashing) — so a write can neither follow a symlink nor clobber an existing file. Both auth branches share the same hardened path.

## Changes

* `libs/connectors/google/genblaze_google/provider.py` — `_video_output_path()` now validates `step_id` as a UUID and enforces containment under `output_dir`; new `_write_new_video_file()` static method performs the symlink-safe, non-overwriting write; both the Vertex inline-bytes branch and the Gemini download branch route through it.
* `libs/connectors/google/tests/test_veo_provider.py` — added regression tests for both auth branches: traversal / absolute-path / non-UUID `step_id` rejection, symlink-following refusal, and existing-file overwrite refusal.
* `CHANGELOG.md` — one `**Security**` bullet under `[Unreleased]` → `genblaze-google`.
* `docs/exec-plans/completed/issue-284-veo-output-path-traversal.md` — plan doc with problem, fix rationale, risk, and verification.

## Test plan

* `cd libs/connectors/google && pytest tests/ -q` → 152 passed, 10 skipped
* `ruff check` / `ruff format --check` — clean on touched files
* `libs/core` suite (unaffected, sanity-checked) → 1833 passed
* Manually reproduced the issue's exact PoC against the fixed code: a UUID `step_id` still writes normally; `../../../../tmp/pwned`, an absolute path, and a pre-planted symlink at the target path are all rejected with a `ProviderError`, with no file written outside `output_dir` and no existing file touched
* Full `pre-pr-check` run (Claude + Codex, standard/security/adversarial) — 2 blocking findings surfaced and fixed (Windows crash on `O_NOFOLLOW`; symlink/overwrite tests missing on the Gemini branch), re-verified clean; 2 residual limitations logged as deferred (non-atomic full write; TOCTOU on `output_dir`'s parent directory — both require attacker capability beyond this issue's threat model)

## Related

* Fixes [#284](https://github.com/backblaze-labs/genblaze/issues/284)
* Depends on [#286](https://github.com/backblaze-labs/genblaze/pull/286)
* Plan: `docs/exec-plans/completed/issue-284-veo-output-path-traversal.md`