### PR TITLE
fix(core): providers skipping BaseProvider.__init__ now fail fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ site/
 # Claude Code — local/ephemeral
 .claude/settings.local.json
 .claude/worktrees/
+.pre-pr-check/
 CLAUDE.local.md
 
 # Hypothesis test cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** lazy top-level exports now appear in `dir(genblaze_core)` before
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
+- **Fixed** `BaseProvider` subclasses now fail loudly at construction with a
+  `TypeError` if `super().__init__()` never ran — most commonly because the
+  subclass was decorated with `@dataclass`, whose generated `__init__` silently
+  replaces the inherited one. Previously this produced a half-initialized
+  provider that constructed fine and then failed confusingly inside
+  `invoke()`/`ainvoke()` with an `AttributeError` naming an unrelated private
+  attribute (#261).
 
 ## [0.7.0] - 2026-07-28
 

--- a/docs/exec-plans/completed/issue-261-dataclass-provider-init-skip.md
+++ b/docs/exec-plans/completed/issue-261-dataclass-provider-init-skip.md
@@ -1,0 +1,243 @@
+<!-- branch: issue/261-dataclass-provider-init-skip -->
+# Issue 261: @dataclass on a provider subclass silently skips BaseProvider.__init__
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/261
+
+Decorating a `SyncProvider` / `BaseProvider` subclass with `@dataclass` produces
+a half-initialized object. `@dataclass` generates an `__init__` that replaces
+the inherited one, so `BaseProvider.__init__`
+(`libs/core/genblaze_core/providers/base.py:406-497`) never runs and none of the
+instance attributes it sets exist. Construction succeeds silently; the failure
+surfaces much later from inside `providers/base.py`, naming private attributes
+the user never wrote.
+
+The reported double-fault is real and reproduces on `main` @ `46bbcc6`:
+
+1. `invoke()` (`:1766`) calls `_attempt_once` (`:1810`), which calls
+   `_cleanup_poll_cache()` (`:1536`) → reads `self._poll_cache_max_age`
+   (`:576`, set at `:440`) → **first `AttributeError`**.
+2. `invoke()`'s `except Exception` handler (`:1817`) then evaluates
+   `error_code in self.retry_policy.retryable_codes` (`:1828`) → the
+   `retry_policy` property (`:500`) reads `self._retry_policy_override`
+   (`:515`, set at `:452`) → **second `AttributeError`, raised from inside the
+   handler**.
+
+Because the second exception escapes the handler, the message the user sees
+names `_retry_policy_override` — not even the first thing that broke. `ainvoke()`
+has the identical shape (`:2012` / `:2030`). Nothing in either traceback mentions
+`@dataclass`, `__init__`, or `super().__init__()`.
+
+`__init_subclass__` already exists at `:382` but only resets `_models_cache`; it
+does not check `__init__` at all.
+
+### Why the issue's preferred fix cannot work as written
+
+The issue proposes detecting the case in `BaseProvider.__init_subclass__` via
+`dataclasses.is_dataclass(cls)`. **This does not work.** `__init_subclass__`
+runs during type creation — i.e. when the `class` statement's body finishes —
+whereas `@dataclass` is a decorator applied to the *already-created* class
+object afterwards. Verified:
+
+```python
+class B:
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        print(dataclasses.is_dataclass(cls), "__init__" in cls.__dict__)
+
+@dataclasses.dataclass
+class C(B):
+    x: int = 1
+# during __init_subclass__: False False
+# after the decorator:      True  True
+```
+
+Both signals the guard would key on are absent at `__init_subclass__` time, so
+the check would never fire. Class-definition-time detection of the decorator
+case is not achievable; the earliest reliable point is **construction**.
+
+## Fix
+
+Fail at construction with an error that names the cause, and stop `invoke()`'s
+error path from masking the original exception.
+
+Production — `libs/core/genblaze_core/providers/base.py`:
+
+1. Add a class-level sentinel `_base_init_done: bool = False` on `BaseProvider`
+   (class attribute, so reads never raise `AttributeError`), and set
+   `self._base_init_done = True` as the **last** statement of
+   `BaseProvider.__init__` — last, so a constructor that raises partway is also
+   caught.
+2. Add `class _ProviderMeta(ABCMeta)` whose `__call__` constructs the instance
+   via `super().__call__(...)`, then raises `TypeError` if
+   `getattr(obj, "_base_init_done", False)` is false. `BaseProvider` declares
+   `metaclass=_ProviderMeta`. `Runnable` is `ABC, Generic[In, Out]`
+   (`runnable/base.py:15`), so its metaclass is already `ABCMeta` and
+   subclassing it is conflict-free.
+3. Tailor the message by inspecting the class *at instantiation time*, where
+   `dataclasses.is_dataclass(cls)` is finally accurate:
+   - dataclass case → providers cannot be decorated with `@dataclass`, because
+     the generated `__init__` replaces `BaseProvider.__init__`; write a plain
+     `__init__` that calls `super().__init__()`.
+   - any other case → `<Class>.__init__` never called `super().__init__()`.
+
+   Both messages name the offending class and the concrete fix.
+4. Defense-in-depth in `invoke()` (`:1828`) and `ainvoke()` (`:2012`): resolve
+   the retry policy inside the exception handler defensively, and if resolving
+   it raises, re-raise the **original** `exc` instead of the handler's own
+   failure. The guard makes this unreachable via `@dataclass`, but it removes a
+   whole class of "the error you see is not the error that happened" for any
+   other broken-instance route (e.g. `object.__new__`, which bypasses the
+   metaclass).
+
+Scope note: the issue's "weaker alternative" (promote the lazy attributes to
+class-level defaults) is deliberately **not** taken. It would let a
+half-initialized provider run with silently-wrong defaults — shared mutable
+`_poll_cache` dicts across instances, no `_poll_cache_lock` — which is worse
+than a clear failure.
+
+Tests — new `libs/core/tests/unit/test_provider_init_guard.py`:
+
+- `@dataclass` provider raises `TypeError` at construction; message mentions
+  `@dataclass` and `super().__init__()`.
+- Hand-written `__init__` without `super().__init__()` raises `TypeError`
+  naming `super().__init__()`.
+- A correct provider constructs and completes `invoke()` unchanged.
+- Multi-level subclass (`SyncProvider` → mid → leaf) still constructs.
+- The failure is a `TypeError` at construction — assert the old
+  `AttributeError: '_retry_policy_override'` symptom no longer occurs.
+- Handler hardening: a provider built via `object.__new__` (bypassing the
+  metaclass) surfaces the *original* `AttributeError`, not the
+  `retry_policy` one — sync and async.
+
+Docs / release:
+
+- `docs/guides/new-provider.md` — add "never decorate a provider with
+  `@dataclass`" alongside the existing `super().__init__()` guidance at `:131-142`
+  and `:531`, and a checklist line at `:692`.
+- `CHANGELOG.md` `[Unreleased]` → `### genblaze-core` **Fixed** bullet (#261).
+- No version bump (versions move per release wave, per RELEASING.md).
+
+## Risk
+
+Low, and measured rather than assumed.
+
+- **Does the guard break any existing provider?** No. An AST scan across all of
+  `libs/` (excluding `.venv`/`node_modules`) for classes with a `Provider` base
+  that define `__init__` without `super().__init__()` returns **zero hits** —
+  production connectors and test doubles alike. There are also **no existing
+  `@dataclass` providers** (the four `@dataclass` uses in connectors are on
+  internal spec/config types, e.g. `openai/dalle.py:95 _ImageModelSpec`, not
+  provider subclasses).
+- **Metaclass conflict?** None possible in-repo: `grep metaclass=` across `libs/`
+  returns no other metaclass, and `_ProviderMeta` derives from the `ABCMeta`
+  that `BaseProvider` already has via `Runnable(ABC, Generic[...])`. A
+  third-party subclass combining `BaseProvider` with a non-`ABCMeta` metaclass
+  would need `_ProviderMeta` in its MRO — an acceptable and documented cost of
+  enforcing the invariant.
+- **Runtime cost:** one `getattr` per provider instantiation. Nothing on the
+  per-step hot path.
+- **Test doubles built via `Mock(spec=...)` or `object.__new__`** bypass
+  `type.__call__` entirely and are unaffected by the guard — which is why the
+  handler hardening in step 4 is kept as a separate, independent safety net.
+- **Behavior change for third parties:** a downstream provider that *is* a
+  dataclass goes from "constructs, then fails confusingly at invoke" to "fails
+  loudly at construction". That is the intended fix, and it converts a silent
+  half-broken object into an actionable error, but it is a visible change and is
+  called out in the CHANGELOG.
+- **Sentinel spoofing (accepted residual risk):** the guard's "did
+  `BaseProvider.__init__` run" signal is `_base_init_token is _BASE_INIT_TOKEN`,
+  an identity check against a module-private sentinel — not an unbreakable
+  boundary. A provider author who deliberately imports `_BASE_INIT_TOKEN` and
+  assigns it in a broken `__init__` still bypasses the guard. Accepted: this
+  requires a deliberate act against a leading-underscore, non-exported symbol
+  by code already running in the same trust domain (provider authors are not
+  an adversarial boundary) — not something a `@dataclass` decorator or an
+  accidental attribute collision can trigger. Confirmed by three independent
+  reviews (2 Codex, 1 Claude) during `/pre-pr-check`.
+- **Two accepted diagnostic-quality limitations, both contrived nested-`@dataclass`
+  topologies with zero occurrence in this repo, found by Codex's adversarial
+  pass and reproduced directly against the live code:**
+  1. A `@dataclass` provider whose `__post_init__` itself reads missing
+     `BaseProvider` state raises a raw `AttributeError` (naming the actual
+     missing attribute) instead of the guard's `TypeError`, because the guard's
+     check runs only *after* `__init__` returns — if `__init__` itself raises,
+     the guard's check never executes. Construction still fails immediately
+     (the core anti-regression goal holds); only the exception type and
+     wording differ from the common case. Not fixed: a reliable fix requires
+     distinguishing "the exception came from the dataclass-generated
+     `__init__`" from "the exception came from a legitimate custom `__init__`"
+     (e.g. the valid `@dataclass(init=False)` + hand-written `__init__` pattern
+     that calls `super().__init__()`), which isn't reliably inspectable without
+     risking a false positive on that legal pattern.
+  2. (Found and **fixed** — kept here for context since round 1 initially
+     deferred it before testing it.) `class Child(BrokenDataclassProvider):
+     pass` — no new `__init__` — got a message asserting `Child.__init__`
+     never called `super().__init__()`, which is false (`Child` has no
+     `__init__` of its own). Verified worse than just imprecise: even adding
+     `Child.__init__` that calls `super().__init__()` (the message's own
+     suggested fix) still fails, because that call resolves to the
+     dataclass-generated `__init__` on the broken ancestor, which never
+     forwards to `BaseProvider.__init__`. Fixed by rewording the fallback
+     message to describe the whole `__init__` chain rather than asserting a
+     specific class is the culprit; pinned by
+     `test_message_does_not_blame_a_specific_init_that_is_not_the_real_cause`.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `libs/core/genblaze_core/providers/base.py` | modified |
+| `libs/core/tests/unit/test_provider_init_guard.py` | created |
+| `docs/guides/new-provider.md` | modified |
+| `CHANGELOG.md` | modified |
+| `docs/exec-plans/completed/issue-261-dataclass-provider-init-skip.md` | created |
+
+No connector source touched. No version bump (versions move per release wave,
+per RELEASING.md).
+
+## Verification
+
+Actual results, this branch:
+
+1. Exact repro from the issue body run as a script: `MyProv()` raises `TypeError`
+   naming `@dataclass`, and the old `_retry_policy_override` `AttributeError` is
+   gone.
+2. `cd libs/core && pytest tests/ -q` — **1805 passed, 25 skipped** (the 2
+   failures seen mid-development, `test_url_policy_reexported_from_s3_for_back_compat`
+   and `test_spool_threshold_matches_multipart_threshold`, are pre-existing —
+   reproduced identically against unmodified `main` in an isolated `libs/core`
+   env; both are `ModuleNotFoundError: genblaze_s3` from running `libs/core`
+   without the sibling package installed, not caused by this change. They do
+   not occur under `make test`, which installs every package into one env.)
+3. `cd libs/core && pytest tests/unit/test_provider_init_guard.py -v` —
+   **12 passed** (new file).
+4. Full-repo `make test` (all 18 packages, single shared `.venv` with every
+   connector installed editable) — **exit 0**. `genblaze-core` 2155 passed, 3
+   skipped; every connector, `cli`, `libs/meta`, and `tools/tests` green.
+5. `ruff check` / `ruff format --check` on touched files — clean.
+6. `mypy libs/core/genblaze_core/ --ignore-missing-imports` — same 2
+   pre-existing errors in `_utils.py` as on unmodified `main` (confirmed via
+   `git stash`); none in the new metaclass or touched code.
+7. `/pre-pr-check`, full 6-check sequence (3 Claude + 3 Codex), run twice:
+   - **Round 1** found 2 real MEDIUM findings, both fixed: (a) the `invoke()`/
+     `ainvoke()` exception-handler hardening was over-broad and could mask a
+     genuine bug in a correctly-constructed provider's `retry_policy`
+     override, leaking an unsanitized exception; (b) the construction guard's
+     signal was a plain `_base_init_done: bool`, spoofable by a same-named
+     subclass/dataclass-field attribute — replaced with an identity-checked
+     module-private sentinel (`_base_init_token` / `_BASE_INIT_TOKEN`).
+   - **Round 2** (re-run after both fixes): 5 of 6 checks clean; Codex's
+     adversarial pass (check 6) found 2 further findings in contrived nested
+     `@dataclass` topologies with zero real-world occurrence in this repo —
+     see the two accepted limitations in Risk, below. One of the two
+     (misleading remediation message for a subclass of an already-broken
+     `@dataclass` ancestor) was fixed anyway, since the fix was cheap and
+     removed a message that was not just imprecise but demonstrably wrong —
+     the message's own suggested fix, verified against the live code, did not
+     resolve the failure. A 12th regression test pins this.
+   - All findings, classifications, and fixes are recorded in this repo's
+     pre-pr-check run log (`~/.claude/pre-pr-check-log.md`); the working
+     `.pre-pr-check/` folder is deleted on a clean run, per that skill's
+     process.

--- a/docs/guides/new-provider.md
+++ b/docs/guides/new-provider.md
@@ -139,6 +139,11 @@ class MyProvider(SyncProvider):
         # registry or tune retry behavior without subclassing. Always call
         # super().__init__() — it sets up poll caching, retry policy,
         # preflight gates, and the registry.
+        #
+        # Never decorate a provider class with @dataclass: the generated
+        # __init__ replaces this one, so super().__init__() never runs and
+        # the instance is missing all of the state above. Construction fails
+        # loudly with a TypeError if this happens.
         super().__init__(models=models, retry_policy=retry_policy)
         self._api_key = api_key
         self._client: Any = None
@@ -528,7 +533,10 @@ def fetch_output(self, prediction_id, step):
     ...
 ```
 
-`super().__init__()` (from §3) initializes the cache — never skip it.
+`super().__init__()` (from §3) initializes the cache — never skip it. Do not
+decorate a provider subclass with `@dataclass`: it generates its own
+`__init__` that replaces the one you wrote, so `super().__init__()` never runs
+and construction fails with a `TypeError`.
 
 ## 13. Advanced: timing hints with SubmitResult (BaseProvider only)
 
@@ -690,6 +698,7 @@ pip install -e "libs/connectors/myprovider[dev]"
 **Provider class**
 - [ ] Subclass `SyncProvider` (preferred) or `BaseProvider` (polling APIs only)
 - [ ] `super().__init__(models=models)` called in constructor
+- [ ] Provider class is **not** decorated with `@dataclass` (its generated `__init__` would replace yours and skip `super().__init__()`)
 - [ ] `get_capabilities()` declares supported modalities, inputs, models, `accepts_chain_input`
 - [ ] `normalize_params()` maps standard names (`duration`, `resolution`, `aspect_ratio`, `voice_id`, `output_format`) and is idempotent
 - [ ] `create_registry()` returns a `ModelRegistry` with per-model `pricing` strategies (or documents why it doesn't)

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -8,7 +8,7 @@ import os
 import threading
 import time
 import warnings
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -315,7 +315,69 @@ def validate_chain_input_url(
             )
 
 
-class BaseProvider(Runnable[Step, Step]):
+#: Private identity sentinel — see ``_ProviderInitGuardMeta``. Deliberately not
+#: a plain ``bool``: a bool default (e.g. ``_base_init_done = True``) is a
+#: one-line accidental or naive bypass for a subclass/dataclass field of the
+#: same name. Checking identity against this module-private object doesn't
+#: make bypass impossible (a subclass could still import and assign this
+#: exact object), but it rules out the accidental collision and raises the
+#: bar to a deliberate act.
+_BASE_INIT_TOKEN = object()
+
+
+class _ProviderInitGuardMeta(ABCMeta):
+    """Fails construction loudly when a subclass never ran ``BaseProvider.__init__``.
+
+    ``@dataclass`` on a provider subclass replaces the inherited ``__init__``
+    with a generated one, so ``BaseProvider.__init__`` silently never runs and
+    the instance is missing attributes (``_poll_cache``, ``_retry_policy_override``,
+    etc.). That surfaces later as a confusing ``AttributeError`` deep inside
+    ``invoke()``, naming a private attribute the caller never wrote.
+
+    This can't be caught in ``__init_subclass__``: that hook runs while the
+    ``class`` statement's body is being built, but ``@dataclass`` is a
+    decorator applied to the class object *afterward* — so at
+    ``__init_subclass__`` time the class isn't a dataclass yet and has no
+    generated ``__init__``. Construction is the earliest point at which both
+    signals (``__dataclass_fields__`` on the class itself, and whether
+    ``BaseProvider.__init__`` actually ran) are reliably observable.
+    """
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        obj = super().__call__(*args, **kwargs)
+        if getattr(obj, "_base_init_token", None) is not _BASE_INIT_TOKEN:
+            # ``__dataclass_fields__ in cls.__dict__`` (not ``is_dataclass(cls)``,
+            # which is also true when only an inherited *base* is the
+            # dataclass) — so the message names the class actually decorated,
+            # not an unrelated mixin ancestor.
+            if "__dataclass_fields__" in cls.__dict__:
+                raise TypeError(
+                    f"{cls.__name__} is decorated with @dataclass, which replaces "
+                    "BaseProvider.__init__ with a generated one — so BaseProvider "
+                    "never initializes its poll cache, retry policy, or preflight "
+                    "state. Providers cannot be dataclasses. Write a plain "
+                    "__init__ that calls super().__init__() instead."
+                )
+            # Deliberately does not name a specific __init__ as "the" culprit:
+            # cls.__init__ might already call super().__init__() correctly and
+            # still hit this — e.g. a base class further up the MRO is itself
+            # a @dataclass whose generated __init__ doesn't forward the call
+            # any further, so "add super().__init__() to {cls.__name__}"
+            # would be wrong advice in that case. Point at the whole chain.
+            raise TypeError(
+                f"BaseProvider.__init__ never ran for this {cls.__name__} "
+                "instance, so its poll cache, retry policy, and preflight "
+                "state were never initialized. Check every __init__ in "
+                f"{cls.__name__}'s class hierarchy — including any inherited "
+                "from a base class — and make sure each one calls "
+                "super().__init__(). A base class decorated with @dataclass "
+                "is a common cause: its generated __init__ does not forward "
+                "to BaseProvider.__init__ on its own."
+            )
+        return obj
+
+
+class BaseProvider(Runnable[Step, Step], metaclass=_ProviderInitGuardMeta):
     """Abstract base for all provider adapters.
 
     Providers implement the 3-method lifecycle:
@@ -338,6 +400,14 @@ class BaseProvider(Runnable[Step, Step]):
     """
 
     name: str = "base"
+
+    #: Sentinel read by ``_ProviderInitGuardMeta.__call__``. Class-level default
+    #: so a subclass whose ``__init__`` never ran ``super().__init__()`` reads
+    #: ``None`` here instead of raising ``AttributeError``. Set to the private
+    #: ``_BASE_INIT_TOKEN`` object as the last statement of
+    #: ``BaseProvider.__init__`` — last, so a constructor that raises partway
+    #: through still leaves this ``None``.
+    _base_init_token: object | None = None
 
     #: Per-provider declaration of upstream catalog API support. Drives
     #: ``validate_model()`` outcome semantics and the ``tools/probe_models.py``
@@ -495,6 +565,9 @@ class BaseProvider(Runnable[Step, Step]):
         # In-flight probe events keyed by slug; entry exists while a
         # probe is mid-flight, gets removed once the result is cached.
         self._probe_inflight: dict[str, threading.Event] = {}
+        # Last statement: marks this instance as fully initialized for
+        # ``_ProviderInitGuardMeta``. Keep this at the end of ``__init__``.
+        self._base_init_token = _BASE_INIT_TOKEN
 
     @property
     def retry_policy(self) -> RetryPolicy:
@@ -1825,7 +1898,20 @@ class BaseProvider(Runnable[Step, Step]):
 
                     # Step-level retry: budget from config.max_retries (caller-driven),
                     # retryable codes from the unified RetryPolicy so users tune one knob.
-                    retryable = error_code in self.retry_policy.retryable_codes
+                    # Resolving retry_policy touches instance state set up by
+                    # BaseProvider.__init__. Only re-raise the *original* exc when
+                    # that state is genuinely missing (an improperly-constructed
+                    # provider that bypassed the metaclass guard, e.g. via
+                    # object.__new__) — not for every AttributeError, which would
+                    # also swallow a genuine bug in a *correctly* constructed
+                    # provider's own retry_policy override (pre-existing behavior
+                    # for that case: propagate raw, same as before this guard).
+                    try:
+                        retryable = error_code in self.retry_policy.retryable_codes
+                    except AttributeError:
+                        if getattr(self, "_base_init_token", None) is not _BASE_INIT_TOKEN:
+                            raise exc from None
+                        raise
                     if not retryable or attempt >= max_retries:
                         step.status = StepStatus.FAILED
                         step.error = sanitize_error(str(exc))
@@ -2009,7 +2095,16 @@ class BaseProvider(Runnable[Step, Step]):
                     if resume_prediction_id is not None:
                         retry_state.record_resume_failure()
 
-                    retryable = error_code in self.retry_policy.retryable_codes
+                    # See the matching comment in invoke() — only re-raise the
+                    # original exc if the instance genuinely bypassed the
+                    # metaclass guard; otherwise let a real provider bug in
+                    # retry_policy propagate as-is.
+                    try:
+                        retryable = error_code in self.retry_policy.retryable_codes
+                    except AttributeError:
+                        if getattr(self, "_base_init_token", None) is not _BASE_INIT_TOKEN:
+                            raise exc from None
+                        raise
                     if not retryable or attempt >= max_retries:
                         step.status = StepStatus.FAILED
                         step.error = sanitize_error(str(exc))

--- a/libs/core/tests/unit/test_provider_init_guard.py
+++ b/libs/core/tests/unit/test_provider_init_guard.py
@@ -1,0 +1,286 @@
+"""Tests for the BaseProvider construction guard (issue #261).
+
+A ``@dataclass``-decorated provider subclass (or one with a hand-written
+``__init__`` that skips ``super().__init__()``) must fail loudly at
+construction, not silently succeed and blow up later inside ``invoke()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from genblaze_core.exceptions import ProviderError
+from genblaze_core.models.step import Step
+from genblaze_core.providers.base import SyncProvider
+
+
+class _GoodSync(SyncProvider):
+    name = "good-sync"
+
+    def generate(self, step: Step, config=None) -> Step:
+        return step
+
+
+class _GoodMid(SyncProvider):
+    """Intermediate subclass with no __init__ of its own."""
+
+    name = "good-mid"
+
+    def generate(self, step: Step, config=None) -> Step:
+        return step
+
+
+class _GoodLeaf(_GoodMid):
+    """Multi-level subclass, still no __init__ override."""
+
+    name = "good-leaf"
+
+
+def test_correct_provider_constructs_and_invokes():
+    provider = _GoodSync()
+    step = Step(provider="good-sync", model="m", prompt="hi")
+    result = provider.invoke(step)
+    assert result.status.value == "succeeded"
+
+
+def test_multi_level_subclass_constructs():
+    provider = _GoodLeaf()
+    assert provider._base_init_token is not None
+
+
+def test_dataclass_provider_raises_typeerror_at_construction():
+    @dataclass
+    class DataclassProvider(SyncProvider):
+        api_key: str = "k"
+
+        @property
+        def name(self):
+            return "dataclass-prov"
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    with pytest.raises(TypeError) as exc_info:
+        DataclassProvider()
+
+    message = str(exc_info.value)
+    assert "@dataclass" in message
+    assert "super().__init__()" in message
+    # The old symptom from the issue must not resurface as an
+    # AttributeError bleeding out of construction.
+    assert "_retry_policy_override" not in message
+
+
+def test_hand_written_init_without_super_raises_typeerror():
+    class NoSuperInit(SyncProvider):
+        name = "no-super"
+
+        def __init__(self):
+            pass
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    with pytest.raises(TypeError) as exc_info:
+        NoSuperInit()
+
+    assert "super().__init__()" in str(exc_info.value)
+
+
+def test_dataclass_provider_never_reaches_the_old_attributeerror():
+    """Before the fix, MyProv() constructed fine and invoke() raised
+    AttributeError twice (first _poll_cache_max_age, then masked by
+    _retry_policy_override). Now construction itself fails, so invoke()
+    is never reached with a broken instance."""
+
+    @dataclass
+    class MyProv(SyncProvider):
+        api_key: str = "k"
+
+        @property
+        def name(self):
+            return "myprov"
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    with pytest.raises(TypeError):
+        MyProv()
+
+
+class _BrokenBypassMeta(SyncProvider):
+    """A provider whose instance never ran __init__ at all, constructed via
+    object.__new__ to bypass the metaclass guard entirely (simulating any
+    other route to a half-initialized instance, e.g. pickle/copy internals)."""
+
+    name = "broken-bypass"
+
+    def generate(self, step: Step, config=None) -> Step:
+        return step
+
+
+def test_invoke_reraises_original_error_when_bypassing_the_guard():
+    """If an instance somehow bypasses the metaclass (object.__new__), invoke()'s
+    error handler must not mask the real AttributeError with a second one from
+    touching self.retry_policy."""
+    provider = object.__new__(_BrokenBypassMeta)
+    step = Step(provider="broken-bypass", model="m", prompt="hi")
+
+    with pytest.raises(AttributeError) as exc_info:
+        provider.invoke(step)
+
+    # Must be the *original* failure (from _cleanup_poll_cache reading
+    # _poll_cache_max_age), not the masking one from self.retry_policy.
+    assert "_poll_cache_max_age" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_reraises_original_error_when_bypassing_the_guard():
+    provider = object.__new__(_BrokenBypassMeta)
+    step = Step(provider="broken-bypass", model="m", prompt="hi")
+
+    with pytest.raises(AttributeError) as exc_info:
+        await provider.ainvoke(step)
+
+    assert "_poll_cache_max_age" in str(exc_info.value)
+
+
+def test_declaring_base_init_done_true_does_not_bypass_the_guard():
+    """The guard's signal is an identity-checked private token, not a plain
+    bool — so a subclass can't defeat it by declaring the old-style attribute
+    name (or any other truthy value) under a name it guesses at."""
+
+    class Sneaky(SyncProvider):
+        name = "sneaky"
+        _base_init_done = True  # not the real signal; must not bypass anything
+        _base_init_token = True  # guessed attempt at the real attribute name
+
+        def __init__(self):
+            pass  # deliberately skips super().__init__()
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    with pytest.raises(TypeError) as exc_info:
+        Sneaky()
+
+    assert "super().__init__()" in str(exc_info.value)
+
+
+def test_dataclass_mixin_base_does_not_misattribute_cause_to_the_subclass():
+    """dataclasses.is_dataclass(cls) is true for any class with a dataclass
+    ancestor anywhere in the MRO. The guard must check whether *this* class
+    was decorated, not whether some unrelated mixin base was, so the message
+    doesn't send the reader looking for a decorator that isn't there."""
+
+    @dataclass
+    class _DataclassMixin:
+        unrelated: int = 1
+
+    class SubclassNotItselfADataclass(SyncProvider, _DataclassMixin):
+        name = "not-a-dataclass-itself"
+
+        def __init__(self):
+            pass  # forgot super().__init__() -- no @dataclass on THIS class
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    with pytest.raises(TypeError) as exc_info:
+        SubclassNotItselfADataclass()
+
+    message = str(exc_info.value)
+    assert "super().__init__()" in message
+    # The message may mention @dataclass generically as a common cause to
+    # check for, but must not assert that THIS class is the one decorated —
+    # that would be false and send the reader looking for a decorator that
+    # isn't on SubclassNotItselfADataclass.
+    assert "SubclassNotItselfADataclass is decorated with @dataclass" not in message
+
+
+def test_message_does_not_blame_a_specific_init_that_is_not_the_real_cause():
+    """A subclass of an already-broken @dataclass provider, with NO new
+    __init__ of its own, must not get a message asserting ITS __init__ never
+    called super() -- it has no __init__ at all; it inherited the broken one.
+    (Regression for a message that was previously provably wrong: even a
+    Child.__init__ that *does* call super().__init__() still fails here,
+    because super().__init__() resolves to the dataclass-generated __init__
+    on the broken parent, which never forwards to BaseProvider.__init__ --
+    so telling the user to "add super().__init__() to Child" is not just
+    unhelpful, it's advice that doesn't fix anything.)"""
+
+    @dataclass
+    class _BrokenDataclassAncestor(SyncProvider):
+        api_key: str = "k"
+
+        @property
+        def name(self):
+            return "broken-ancestor"
+
+        def generate(self, step: Step, config=None) -> Step:
+            return step
+
+    class Child(_BrokenDataclassAncestor):
+        pass
+
+    with pytest.raises(TypeError) as exc_info:
+        Child()
+    message = str(exc_info.value)
+    assert "Child.__init__ never called super().__init__()" not in message
+
+    # Confirm the guard's OWN general advice ("make sure each __init__ in
+    # the hierarchy calls super().__init__()") is not itself falsified: even
+    # adding a Child.__init__ that calls super().__init__() still fails,
+    # because the break is in the inherited dataclass-generated __init__,
+    # further up the chain -- this is exactly why the message must not
+    # single out Child's own __init__ as the fix.
+    class ChildWithSuperCall(_BrokenDataclassAncestor):
+        def __init__(self):
+            super().__init__()
+
+    with pytest.raises(TypeError):
+        ChildWithSuperCall()
+
+
+class _BuggyRetryPolicyProvider(SyncProvider):
+    """A correctly-constructed provider (super().__init__() ran fine) whose
+    own retry_policy override has an unrelated bug. This must NOT be treated
+    as a guard-bypass case: invoke() should return a normally-failed step
+    through the standard bookkeeping, not swallow the real AttributeError and
+    re-raise a stale, unrelated exception."""
+
+    name = "buggy-retry-policy"
+
+    @property
+    def retry_policy(self):
+        return self._this_attribute_does_not_exist  # genuine provider bug
+
+    def generate(self, step: Step, config=None) -> Step:
+        raise ProviderError("upstream failure")
+
+
+def test_genuine_retry_policy_bug_in_a_correctly_constructed_provider_is_not_masked():
+    provider = _BuggyRetryPolicyProvider()
+    assert provider._base_init_token is not None  # sanity: guard passed normally
+
+    step = Step(provider="buggy-retry-policy", model="m", prompt="hi")
+
+    # Must raise the REAL bug (AttributeError from the broken retry_policy
+    # override), not something derived from the ProviderError raised inside
+    # generate() -- and must not silently skip invoke()'s failure bookkeeping.
+    with pytest.raises(AttributeError) as exc_info:
+        provider.invoke(step)
+
+    assert "_this_attribute_does_not_exist" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_genuine_retry_policy_bug_in_a_correctly_constructed_provider_is_not_masked_async():
+    provider = _BuggyRetryPolicyProvider()
+    step = Step(provider="buggy-retry-policy", model="m", prompt="hi")
+
+    with pytest.raises(AttributeError) as exc_info:
+        await provider.ainvoke(step)
+
+    assert "_this_attribute_does_not_exist" in str(exc_info.value)


### PR DESCRIPTION
A `@dataclass`-decorated `SyncProvider`/`BaseProvider` subclass — the idiomatic way to write a small provider — silently produces a half-initialized object: `@dataclass` generates an `__init__` that replaces the inherited one, so `BaseProvider.__init__` never runs and none of its instance state (`_poll_cache`, `_retry_policy_override`, preflight locks, etc.) exists. Construction succeeds. Nothing warns. The failure surfaces much later, from inside `providers/base.py`, naming private attributes the caller never wrote — and the traceback the user actually sees is a *second*, unrelated `AttributeError` from `invoke()`'s own error handler touching `self.retry_policy`, masking the real cause. Nothing in either traceback mentions `@dataclass`, `__init__`, or `super().__init__()`.

Fixes [#261 (→ github.com)](https://github.com/backblaze-labs/genblaze/issues/261)

## Summary

Adds a metaclass guard (`_ProviderInitGuardMeta`) on `BaseProvider` that fails construction immediately with a `TypeError` naming the real cause — instead of a silent half-initialized object that crashes confusingly later. The issue's own preferred approach (detect this in `__init_subclass__`) doesn't work: that hook runs during class creation, before `@dataclass` (a decorator) has run on the class, so neither signal is observable yet. Construction is the earliest reliable point.

## Changes

* `libs/core/genblaze_core/providers/base.py` — `_ProviderInitGuardMeta(ABCMeta)` on `BaseProvider`, checking an identity-checked private sentinel (`_base_init_token`) set as the last statement of `BaseProvider.__init__`, so a constructor that raises partway through is also caught. Raises a `TypeError` naming `@dataclass` specifically when that's the cause (checked via `"__dataclass_fields__" in cls.__dict__`, not `is_dataclass()`, so an unrelated dataclass mixin ancestor isn't blamed), or a generic message describing the whole `__init__` chain otherwise. Also hardens `invoke()`/`ainvoke()`'s exception handler so a genuinely bypassed instance's original exception isn't masked by a secondary `AttributeError` from `self.retry_policy` — while leaving a *correctly constructed* provider's own `retry_policy` bugs to propagate exactly as before (no new masking, no sanitization regression).
* `libs/core/tests/unit/test_provider_init_guard.py` — 12 new tests: `@dataclass` provider, hand-written `__init__` missing `super()`, multi-level subclass, dataclass-mixin misattribution, sentinel-spoofing attempt, a correctly-constructed provider's own `retry_policy` bug surfacing undisturbed (sync + async), and a chained-inheritance case where the error message doesn't blame the wrong class.
* `docs/guides/new-provider.md` — adds an explicit "never decorate a provider with `@dataclass`" note and checklist item alongside the existing `super().__init__()` guidance.
* `CHANGELOG.md` — `[Unreleased]` → `genblaze-core` **Fixed** bullet (#261).
* `docs/exec-plans/completed/issue-261-dataclass-provider-init-skip.md` — plan doc: problem, fix rationale, files, verification.

## Test plan

* Exact repro from the issue body: `MyProv()` now raises `TypeError` naming `@dataclass`; the old `_retry_policy_override` `AttributeError` is gone.
* `cd libs/core && pytest tests/ -q` → `1805 passed, 25 skipped` (2 failures seen mid-development are pre-existing, reproduced identically against unmodified `main` in an isolated env — a missing sibling package, not caused by this change; they don't occur under `make test`).
* `ruff check` / `ruff format --check` on touched files — clean. `mypy` — same 2 pre-existing errors as on unmodified `main`, none new.
* Full-repo `make test` gate (all 18 packages, one shared env) → exit 0, all green (core `2155 passed`, plus every connector / cli / meta / tools).
* `/pre-pr-check`, full 6-check sequence (3 Claude + 3 Codex), run twice: round 1 caught 2 real bugs in the fix itself (an over-broad exception handler that could mask genuine errors and leak an unsanitized exception; a spoofable guard signal) — both fixed and independently re-verified. Round 2 found a 3rd issue (a misleading error message whose own suggested remediation didn't actually fix the problem, verified by reproduction) — also fixed. Two remaining edge cases in contrived nested-`@dataclass` topologies with zero real-world occurrence are documented as accepted limitations in the plan doc's Risk section.

## Related

* Fixes [#261 (→ github.com)](https://github.com/backblaze-labs/genblaze/issues/261)
* Plan: `docs/exec-plans/completed/issue-261-dataclass-provider-init-skip.md`