### PR TITLE
fix(gmicloud): probe unmatched slugs so validate_model() distinguishes real models from fake ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ CLAUDE.local.md
 *.tmp
 *.bak
 *.log
+
+# Pre-PR check run history (local audit trail, never committed)
+.pre-pr-check/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** lazy top-level exports now appear in `dir(genblaze_core)` before
   first access, and `RunnableConfig` is available directly from
   `genblaze_core` (#55).
+- **Added** `ModelRegistry(fallback_probe=...)` — an optional liveness probe
+  connectors can attach for slugs that match no `ModelFamily`. Previously
+  `validate_model()` only ever consulted a probe when a family pattern
+  matched, so any slug covered only by the permissive fallback (a
+  connector's mainline models included) graded `UNKNOWN_PERMISSIVE`
+  regardless of whether it was real or fabricated. `fallback_probe` is the
+  liveness counterpart to the existing `fallback` param-shape spec; it is
+  opt-in and defaults to `None`, so registries that don't configure it are
+  unaffected (#248).
+
+### genblaze-gmicloud
+
+- **Fixed** `validate_model()` now probes slugs that match none of the
+  connector's specialized model families (Seedream, Gemini-Flash,
+  FLUX-Kontext, Reve create, Bria fibo, and any new GMI model) using the
+  same empty-payload probe the specialized families already use. Previously
+  these slugs — including a connector's actual production models — graded
+  identically to a fabricated slug (`unknown_permissive`, no signal). A slug
+  the probe confirms dead now raises at `Pipeline` preflight instead of
+  failing mid-run; a slug the probe confirms live grades authoritative
+  (#248).
 
 ## [0.7.0] - 2026-07-28
 

--- a/docs/exec-plans/completed/issue-248-gmicloud-validate-model-unmatched-slugs.md
+++ b/docs/exec-plans/completed/issue-248-gmicloud-validate-model-unmatched-slugs.md
@@ -1,0 +1,221 @@
+<!-- branch: issue/248-gmicloud-validate-model-unmatched-slugs -->
+# Issue 248: validate_model() never probes slugs that match no family — a working
+# model and a fabricated one both grade UNKNOWN_PERMISSIVE
+
+## Problem
+
+GitHub issue: https://github.com/backblaze-labs/genblaze/issues/248
+
+The report has two claims. **The first is already fixed on main**;
+`libs/connectors/gmicloud/genblaze_gmicloud/image.py:55` declares
+`_entitlement_gated_slugs = frozenset({"seededit-3-0-i2i-250628"})` and
+`_base.py:357` re-grades a probe-LIVE verdict on a gated slug down to
+`OK_PROVISIONAL` (#193, shipped in genblaze-gmicloud 0.3.5 — the reporter
+is on 0.3.3). No further work; answer on the issue.
+
+The second claim is real and reproduces on main. `BaseProvider.validate_model()`
+(`libs/core/genblaze_core/providers/base.py:670`) only consults a liveness probe
+when a **family pattern matched**:
+
+    # base.py:747
+    match = self._models.match_family(model_id)
+    if match is not None and match.family.probe is not None:
+        probe_result = self._cached_probe(...)
+
+GMICloud's image registry (`models/image.py:132`) ships three narrow families —
+`bria-(genfill|eraser)`, `^(seededit-|reve-edit|reve-remix)`, `^gpt-image-2-edit$`
+— plus a permissive `ModelSpec(model_id="*")` fallback. Everything else
+(Seedream, Gemini-Flash, FLUX-Kontext, Reve create, Bria fibo) matches no
+family. Video and audio registries have the same shape.
+
+So for `gemini-3-pro-image-preview` — which serves all of the reporter's
+production traffic:
+
+1. `match_family()` → `None` (`model_registry.py:388`).
+2. `discovery_support` is `PARTIAL` (`_base.py:146`), so the NATIVE-discovery
+   branches are skipped.
+3. `model_registry.py:458` → `unknown_permissive()`.
+4. Back in `base.py:747`, `match is None`, so **the probe never fires**.
+
+`totally-made-up-model-xyz` takes the identical path to the identical outcome.
+The outcome carries no signal for exactly the slugs an account actually uses,
+and the `preflight.unknown` WARN (`pipeline.py:963`) is noise the reporter
+learned to ignore — which is when a real warning gets missed.
+
+The probe that could answer is already written and already generic:
+`empty_payload_request_probe` (`_probe.py:39`) reads 404 as DEAD, 400 as LIVE,
+2xx as LIVE (with best-effort cancel), everything else as UNKNOWN. It takes only
+`(slug, *, http)` — nothing family-specific. It is structurally unreachable for
+fallback slugs.
+
+Third note in the report is accurate but by design: `build_image_registry().get(
+"reve-edit-v1")` returns the fallback `ModelSpec` for any string because `"*"`
+matches everything. `.get()` is a param-shape lookup, not an existence check,
+and nothing says so.
+
+`list_available_models()` (the reporter's suggested fix) is not buildable:
+`DiscoverySupport.PARTIAL` records that GMI's request-queue API exposes no
+catalog endpoint. The console reads an internal surface. Answer that on the
+issue rather than promising the API.
+
+## Fix
+
+Make the existing probe reachable on the fallback path, opt-in per registry.
+
+Core — `providers/model_registry.py`:
+
+1. New constructor kwarg `fallback_probe: FamilyProbe | None = None`, stored as
+   `self._fallback_probe`. Semantics: "the probe to consult for slugs that
+   matched no family" — the liveness counterpart to the existing `fallback`
+   spec, which is the param-shape counterpart.
+2. Carry it through `fork()` (`:223`) alongside `_fallback` /
+   `_unstable_slugs`, so per-request multi-tenant forks don't silently lose
+   the signal.
+3. `validate()` (`:370`) is unchanged — it stays non-network by contract. The
+   registry only *holds* the probe; the provider invokes it.
+
+Core — `providers/base.py`:
+
+4. In `validate_model()`, after the existing family-probe block, add the
+   no-family-match branch for `PARTIAL` / `NONE`: when `match is None` and
+   `self._models._fallback_probe is not None`, route it through the same
+   `_cached_probe()` → `_invoke_family_probe()` path (same LRU + single-flight
+   + TTL, so at most one probe per slug per TTL window):
+   - `LIVE` → `ValidationResult.ok_authoritative(ValidationSource.PROBE)` with
+     no `family_name` (there is none) and a `detail` naming it a fallback probe.
+   - `DEAD` → `ValidationResult.not_found(ValidationSource.PROBE, detail=
+     "upstream fallback probe returned DEAD")` — preflight then raises
+     (`pipeline.py:927`) before any credit is spent.
+   - `UNKNOWN` → fall through to today's `unknown_permissive`. No regression on
+     auth failures, 429s, or 5xx.
+
+   Two guards protect a `ValidationSource.USER` result from ever being
+   probed under the wrong string (found in pre-pr-check review, not in the
+   original design): (a) resolve `model_id` via `resolve_canonical()` first —
+   if it differs, the input was an alias to a genuine user-registered spec
+   (`match is None` rules out family resolution, so any non-identity
+   canonicalization here can only come from the user/alias layer), and the
+   branch returns `ok_authoritative(USER)` directly without probing; (b) the
+   probe path itself only runs when the pre-probe `result.outcome` is
+   `UNKNOWN_PERMISSIVE` — a `USER` exact match under `refresh=True` is
+   already `OK_AUTHORITATIVE` at that point, so it falls straight through to
+   `return result` instead of being handed to the probe.
+5. Docstring update on `validate_model()` and on `ValidationOutcome` in
+   `validation.py`: a positive outcome means the slug exists in upstream's
+   catalog, **not** that this account is entitled to call it. That distinction
+   is the reporter's actual ask and is what `_entitlement_gated_slugs` already
+   encodes for the one slug GMI knows about.
+
+Connector — `genblaze_gmicloud/models/{image,video,audio}.py`:
+
+6. Pass `fallback_probe=empty_payload_request_probe` to each
+   `build_*_registry()`'s `ModelRegistry(...)`. The transport hook
+   (`_base.py:166`, forwards the provider's authed `httpx.Client`) already
+   exists, so **`_base.py` needs no changes** — no line-level overlap with the
+   open #283.
+7. The #193 entitlement re-grade in `_base.py:357` keeps applying on top: it
+   matches on `outcome is OK_AUTHORITATIVE and source is PROBE`, which the new
+   fallback-LIVE result satisfies, so gated slugs still cannot over-claim.
+
+Docs:
+
+8. `ModelRegistry.get()` docstring — state explicitly it is not an existence
+   check (`"*"` fallback matches any string) and point to `validate_model()`.
+9. `libs/connectors/gmicloud/README.md` — short note that unmatched slugs are
+   now probe-validated, and what each outcome does and does not prove.
+10. CHANGELOG `[Unreleased]` → `### genblaze-core` **Added** (fallback_probe)
+    and `### genblaze-gmicloud` **Fixed** (#248). No version bump (versions
+    move per release wave, per RELEASING.md).
+
+Tests:
+
+- New `libs/core/tests/unit/test_fallback_probe.py`: `fallback_probe`
+  stored on `ModelRegistry` and carried by `fork()`; on a stub `PARTIAL`
+  provider, unmatched slug + LIVE → `OK_AUTHORITATIVE`/`PROBE`, no
+  `family_name`; + DEAD → `NOT_FOUND`; + UNKNOWN → `UNKNOWN_PERMISSIVE`;
+  probe fires **once** across repeated `validate_model()` calls (cache);
+  `refresh=True` re-probes; family-matched slugs still take the family
+  probe, not the fallback one (pins existing behavior); registries without
+  a `fallback_probe` are unaffected. Also covers a pre-pr-check regression:
+  the fallback probe must never override a USER-registered spec, directly
+  or via an alias to one — verified with dedicated tests asserting the
+  probe callable is never invoked for those cases.
+- `libs/core/tests/unit/test_pipeline_preflight.py`: unmatched-slug DEAD now
+  raises `ProviderError(MODEL_ERROR)` at preflight; UNKNOWN still WARNs and
+  proceeds; the flip side (LIVE stays silent) is also covered.
+- `libs/connectors/gmicloud/tests/test_catalog_decoupling.py`: with a
+  mocked `httpx.Client` on `GMICloudAudioProvider`, an unmatched slug that
+  404s grades `NOT_FOUND`/`PROBE` (previously `UNKNOWN_PERMISSIVE` — the
+  exact regression from the issue) and one the fallback probe can't
+  classify (500) stays `UNKNOWN_PERMISSIVE`; the orphan `unstable_slugs`
+  case on `GMICloudVideoProvider` (`vidu-q1`) is re-pinned for both the
+  LIVE (`OK_AUTHORITATIVE`, `known_unstable` detail preserved) and DEAD
+  (`NOT_FOUND`) outcomes now that its registry carries a `fallback_probe`.
+- Registries without a `fallback_probe` (every other connector) behave
+  byte-for-byte as today — pinned by the existing suites.
+
+## Risk
+
+Medium-low. Core surface is additive (a new optional kwarg; no signature
+changes, no default behavior change for connectors that don't opt in), but the
+GMI behavior change is real and deliberate:
+
+- **New round-trip.** Preflight on a fallback slug now POSTs
+  `/requests` where it previously did nothing. `_probe.py`'s politeness note
+  applies: that POST creates an audit-log record on the user's GMI account
+  even when rejected. Bounded by the same single-flight LRU the family
+  probes already use — for a definitive LIVE/DEAD verdict, once per slug
+  per TTL window (default 1h). An inconclusive (`UNKNOWN`) verdict is
+  deliberately *not* cached (pre-existing `_cached_probe` behavior, shared
+  with every family probe, unchanged by this diff) so a slug the upstream
+  can't classify (auth error, rate limit, 5xx) re-probes on every
+  `validate_model()` call rather than being pinned to "inconclusive" for
+  the rest of the window — callers who don't want any of this can construct
+  a registry without `fallback_probe`.
+- **Stricter preflight.** A genuinely dead slug now raises before the wire
+  instead of failing mid-pipeline. That is the point of the issue, but it can
+  turn a late failure into an early one for anyone relying on the permissive
+  pass-through — including a slug GMI temporarily 404s during an incident.
+  Mitigated: only 404 yields DEAD; 401/403/429/5xx stay UNKNOWN and permissive.
+- **Entitlement is still not proven.** LIVE means "exists in the catalog". The
+  reporter's `seededit` scar was an entitlement failure, and only the curated
+  `_entitlement_gated_slugs` list catches that class. Documented, not claimed
+  away.
+- No overlap with any open PR: #283 touches `gmicloud/_base.py` (untouched
+  here), #265 touches `models/audio.py` in the alias/param region, not the
+  `ModelRegistry(...)` call. Merges independently off main.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `libs/core/genblaze_core/providers/model_registry.py` | modified |
+| `libs/core/genblaze_core/providers/base.py` | modified |
+| `libs/core/genblaze_core/providers/validation.py` | modified (docs) |
+| `libs/core/tests/unit/test_fallback_probe.py` | created |
+| `libs/core/tests/unit/test_pipeline_preflight.py` | modified |
+| `libs/connectors/gmicloud/genblaze_gmicloud/models/image.py` | modified |
+| `libs/connectors/gmicloud/genblaze_gmicloud/models/video.py` | modified |
+| `libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py` | modified |
+| `libs/connectors/gmicloud/tests/test_catalog_decoupling.py` | modified |
+| `libs/connectors/gmicloud/README.md` | modified |
+| `CHANGELOG.md` | modified |
+| `docs/exec-plans/completed/issue-248-gmicloud-validate-model-unmatched-slugs.md` | created |
+
+`genblaze_gmicloud/_base.py` deliberately untouched — the probe transport hook
+and the #193 entitlement re-grade already sit at the right seam, which also
+keeps this diff free of #283.
+
+## Verification
+
+1. Regression gate: the two GMI tests from the issue fail against pre-fix code
+   (both slugs grade `UNKNOWN_PERMISSIVE`) and pass after.
+2. `/test-package gmicloud` and `/test-package core` → green.
+3. `make lint` clean on touched files.
+4. Full-repo `make test` gate on the final commit → exit 0.
+5. `/pre-pr-check` scoped to this diff against the acceptance criterion "a slug
+   that 404s on submit grades NOT_FOUND at preflight, a slug that submits
+   successfully grades OK_AUTHORITATIVE, and no probe fires more than once per
+   slug per TTL window"; resolve blocking findings before opening the PR.
+6. Reply on #248: claim 1 fixed in 0.3.5 (upgrade), claim 2 fixed here,
+   `list_available_models()` not feasible while GMI ships no catalog endpoint.

--- a/libs/connectors/gmicloud/README.md
+++ b/libs/connectors/gmicloud/README.md
@@ -167,6 +167,45 @@ GMICloud surfaces five related names; they look interchangeable but come from di
 
 The `GMI_` env prefix is short on purpose; the class / import / PyPI names use the full `gmicloud` for precision and to leave room for future `genblaze-gmi*` packages if needed.
 
+## Checking whether a slug is real
+
+`provider.validate_model(slug)` grades whether a model slug is usable. GMICloud
+has no `GET /models` catalog endpoint, so most slugs — Seedream, Gemini-Flash,
+FLUX-Kontext, Reve create, Bria fibo, and any new model GMI adds — are checked
+with the same empty-payload probe used by the connector's specialized model
+families: `POST /requests` with an empty payload; a `404` means the slug is
+gone, a `400`/`2xx` means it's callable.
+
+- `OK_AUTHORITATIVE` — the probe confirms the slug exists in GMICloud's
+  catalog. This is **not** an entitlement check: a handful of GMI models
+  (`seededit-3-0-i2i-250628` today) exist in the catalog but 404 "you do not
+  have access" on a real submit for accounts without extra entitlement —
+  `validate_model()` re-grades those known slugs to `OK_PROVISIONAL` instead
+  of over-claiming. If you hit an access 404 on a slug that validated
+  `OK_AUTHORITATIVE`, verify catalog access at https://console.gmicloud.ai/.
+- `NOT_FOUND` — the probe returned a 404; `Pipeline` preflight raises before
+  spending any credit.
+- `UNKNOWN_PERMISSIVE` — the probe was inconclusive (auth error, rate limit,
+  5xx) or transiently unreachable; the slug passes through untouched and
+  liveness is unverified.
+
+Note the probe does create an entry in your GMICloud account's request-audit
+log (even on a rejected payload). A `LIVE`/`DEAD` (i.e. `OK_AUTHORITATIVE`
+or `NOT_FOUND`) verdict is cached, bounding a given slug to at most one
+probe per provider instance per hour. An `UNKNOWN_PERMISSIVE` verdict
+(auth error, rate limit, 5xx) is deliberately **not** cached — a transient
+upstream failure re-probes on the next `validate_model()` call rather than
+being stuck reading as inconclusive for the rest of the cache window — so a
+slug stuck at `UNKNOWN` can probe more often than once an hour. If your
+pipeline holds separate `GMICloudImageProvider` / `GMICloudVideoProvider` /
+`GMICloudAudioProvider` instances, each maintains its own cache, so the same
+slug can probe once per instance.
+
+`ModelRegistry.get(slug)` is a different question — it returns the parameter
+shape to use for a slug, not whether the slug exists. It returns a usable spec
+for *any* string via the permissive fallback, so it is never a substitute for
+`validate_model()`.
+
 ## Reading outputs safely
 
 `step.assets[0]` is only valid when the step succeeded. Always check `step.status` first — especially in fan-out runs where one step may fail and others succeed:

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/audio.py
@@ -159,4 +159,8 @@ def build_audio_registry() -> ModelRegistry:
             _GMI_AUDIO_TTS_FAMILY,
         ),
         fallback=_FALLBACK,
+        # See ``build_image_registry()`` for why unmatched slugs need a
+        # liveness probe (#248): without one, a real GMI audio slug and a
+        # fabricated one both grade UNKNOWN_PERMISSIVE.
+        fallback_probe=empty_payload_request_probe,
     )

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/image.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/image.py
@@ -139,4 +139,12 @@ def build_image_registry() -> ModelRegistry:
             _GMI_IMAGE_MINIMAL_EDIT_FAMILY,
         ),
         fallback=_FALLBACK,
+        # Everything the specialized families don't cover (Seedream,
+        # Gemini-Flash, FLUX-Kontext, Reve create, Bria fibo, and any new
+        # GMI image slug) falls through to the permissive fallback above —
+        # which previously meant validate_model() could never distinguish
+        # a real slug from a fabricated one for exactly the models most
+        # accounts actually use (#248). The same empty-payload probe the
+        # specialized families already use answers that question here too.
+        fallback_probe=empty_payload_request_probe,
     )

--- a/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
+++ b/libs/connectors/gmicloud/genblaze_gmicloud/models/video.py
@@ -316,4 +316,8 @@ def build_video_registry() -> ModelRegistry:
         ),
         fallback=_FALLBACK,
         unstable_slugs=_UNSTABLE_SLUGS,
+        # See ``build_image_registry()`` for why unmatched slugs need a
+        # liveness probe (#248): without one, a real GMI video slug and a
+        # fabricated one both grade UNKNOWN_PERMISSIVE.
+        fallback_probe=empty_payload_request_probe,
     )

--- a/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
+++ b/libs/connectors/gmicloud/tests/test_catalog_decoupling.py
@@ -338,12 +338,24 @@ class TestValidateModelEndToEnd:
         result = provider.validate_model("pixverse-v5.6-t2v")
         assert result.outcome is ValidationOutcome.OK_AUTHORITATIVE
 
-    def test_unknown_namespace_falls_through_permissive(self) -> None:
-        """A slug that doesn't match any family AND no probe attached
-        falls through to UNKNOWN_PERMISSIVE — preflight emits a one-time
-        WARN and proceeds."""
-        # Audio families don't cover lowercase slugs; this passes through.
+    def test_unknown_namespace_probed_via_fallback_probe(self) -> None:
+        """A slug that doesn't match any family is no longer a silent
+        UNKNOWN_PERMISSIVE — the registry's fallback_probe (#248) runs the
+        same empty-payload check the specialized families use, so a 404
+        grades NOT_FOUND instead of carrying no signal at all."""
+        # Audio families don't cover lowercase slugs; this used to pass
+        # through untouched. Now the fallback probe answers it.
         provider = _provider_with_probe_status(GMICloudAudioProvider, status=404)
+        result = provider.validate_model("totally-unknown-tts-slug")
+        assert result.outcome is ValidationOutcome.NOT_FOUND
+        assert result.source is ValidationSource.PROBE
+
+    def test_unknown_namespace_unknown_probe_status_stays_permissive(self) -> None:
+        """When the fallback probe itself can't tell (auth/rate-limit/5xx),
+        the unmatched slug still falls through to UNKNOWN_PERMISSIVE — the
+        fallback probe only sharpens the LIVE/DEAD cases, not the
+        already-inconclusive ones."""
+        provider = _provider_with_probe_status(GMICloudAudioProvider, status=500)
         result = provider.validate_model("totally-unknown-tts-slug")
         assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
 
@@ -505,13 +517,23 @@ class TestPreflightOptOut:
 
 class TestUnstableSlugSurfaces:
     """0.3.2 cleanup: the only remaining ``unstable_slug`` is the orphan
-    ``vidu-q1`` (no family, registry-level). It surfaces as
-    ``UNKNOWN_PERMISSIVE`` + ``known_unstable`` via the fallback path —
-    there's no family probe to upgrade it to ``OK_AUTHORITATIVE``."""
+    ``vidu-q1`` (no family, registry-level). Since #248 wired a
+    ``fallback_probe`` onto the video registry, an orphan unstable slug is
+    now probed too — LIVE upgrades it to ``OK_AUTHORITATIVE`` while
+    preserving the ``known_unstable`` hint (ops still want the flag even
+    though the slug currently answers); DEAD would grade ``NOT_FOUND``."""
 
-    def test_orphan_unstable_slug_surfaces_known_unstable(self) -> None:
-        http = _http_with_status(400)  # LIVE — irrelevant; no family probe runs
+    def test_orphan_unstable_slug_live_preserves_known_unstable(self) -> None:
+        http = _http_with_status(400)  # LIVE via the fallback probe
         provider = GMICloudVideoProvider(api_key="test", http_client=http)
         result = provider.validate_model("vidu-q1")
-        assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
+        assert result.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert result.source is ValidationSource.PROBE
         assert "known_unstable" in (result.detail or "")
+
+    def test_orphan_unstable_slug_dead_not_found(self) -> None:
+        http = _http_with_status(404)  # DEAD via the fallback probe
+        provider = GMICloudVideoProvider(api_key="test", http_client=http)
+        result = provider.validate_model("vidu-q1")
+        assert result.outcome is ValidationOutcome.NOT_FOUND
+        assert result.source is ValidationSource.PROBE

--- a/libs/core/genblaze_core/providers/base.py
+++ b/libs/core/genblaze_core/providers/base.py
@@ -678,17 +678,29 @@ class BaseProvider(Runnable[Step, Step]):
         Outcomes (see ``ValidationOutcome``):
 
         * ``OK_AUTHORITATIVE`` — user-registered, NATIVE-discovery-confirmed,
-          or family probe returned LIVE.
+          or a probe (family-level, or the registry's ``fallback_probe`` when
+          no family matched) returned LIVE.
         * ``OK_PROVISIONAL`` — family-matched but liveness unverifiable.
           Pipeline preflight emits a WARN and proceeds.
-        * ``UNKNOWN_PERMISSIVE`` — no family match; permissive fallback applies.
-        * ``NOT_FOUND`` — discovery says absent or probe returned DEAD.
-          Pipeline preflight raises before any wire calls.
+        * ``UNKNOWN_PERMISSIVE`` — no family match, no ``fallback_probe``
+          configured (or the probe returned UNKNOWN); permissive fallback
+          applies.
+        * ``NOT_FOUND`` — discovery says absent, or a probe (family-level or
+          fallback) returned DEAD. Pipeline preflight raises before any wire
+          calls.
+
+        A positive outcome (``OK_AUTHORITATIVE`` / ``OK_PROVISIONAL``) means
+        the slug is known to exist — it does **not** mean this account is
+        entitled to call it. A probe can only observe what the upstream API
+        reveals before an entitlement check runs (see connectors' own
+        gating overrides, e.g. GMICloud's ``_entitlement_gated_slugs``).
 
         For ``DiscoverySupport.NATIVE`` providers, this method may issue
         a single discovery fetch (subject to TTL and single-flight). For
         ``PARTIAL`` / ``NONE``, it may invoke a family-level ``probe()``
-        when present. ``refresh=True`` forces a fresh discovery snapshot.
+        when present, or the registry's ``fallback_probe`` when no family
+        matched and one is configured. ``refresh=True`` forces a fresh
+        discovery snapshot or re-probe.
         """
         # First pass: non-network — return immediately if we already know.
         result = self._models.validate(model_id, discovery_support=self.discovery_support)
@@ -761,6 +773,62 @@ class BaseProvider(Runnable[Step, Step]):
                     detail="upstream probe returned DEAD",
                 )
             # UNKNOWN: fall through to provisional answer below.
+
+        # No family matched at all (the permissive-fallback case). Connectors
+        # without a full catalog can still opt in to a liveness check here —
+        # ``fallback_probe`` is the liveness counterpart to the registry's
+        # ``fallback`` param-shape spec. Without this, every slug the
+        # fallback covers (a provider's mainline models, as well as
+        # fabricated ones) grades identically as UNKNOWN_PERMISSIVE, with no
+        # way to tell "this account can call this" from "this string looks
+        # plausible" (#248).
+        elif match is None and self._models._fallback_probe is not None:
+            # ``resolve_canonical`` is cheap and non-network (no fetch, no
+            # wire call) — it only ever differs from ``model_id`` here when
+            # ``get()`` resolved through the user-spec or alias layer to
+            # something other than the permissive fallback (family
+            # resolution was already ruled out above by ``match is None``).
+            # That means ``model_id`` is a (possibly deprecated) alias for a
+            # genuine USER-registered spec that ``ModelRegistry.validate()``
+            # missed — it only checks ``_user`` by exact key, not through
+            # ``_alias_index``. Treat it exactly as validating the canonical
+            # slug directly would: USER is documented as "strongest signal
+            # regardless of provider class" and must never be handed to a
+            # probe under the alias's literal (and often non-wire) string
+            # (#248 review).
+            canonical = self._models.resolve_canonical(model_id)
+            if canonical != model_id:
+                return ValidationResult.ok_authoritative(ValidationSource.USER)
+            # Gating on UNKNOWN_PERMISSIVE (not just ``match is None``) is
+            # the second half of that same protection: it excludes a plain
+            # USER exact-match slug under ``refresh=True`` — such a result
+            # is already OK_AUTHORITATIVE/USER, never UNKNOWN_PERMISSIVE, so
+            # this branch leaves it untouched and ``return result`` below
+            # preserves it instead of letting the probe overrule it.
+            if result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE:
+                # The pre-probe ``result.detail`` may carry "known_unstable"
+                # for a registry-level unstable slug that matched no family
+                # (the orphan case). Preserve it on the LIVE path for the
+                # same reason as the family-probe branch above; NOT_FOUND
+                # speaks for itself on DEAD.
+                fallback_unstable_detail = result.detail
+                probe_result = self._cached_probe(
+                    self._models._fallback_probe, model_id, refresh=refresh
+                )
+                if probe_result is LiveProbeResult.LIVE:
+                    return ValidationResult.ok_authoritative(
+                        ValidationSource.PROBE,
+                        detail=(
+                            fallback_unstable_detail
+                            or "fallback probe: slug matched no family pattern"
+                        ),
+                    )
+                if probe_result is LiveProbeResult.DEAD:
+                    return ValidationResult.not_found(
+                        ValidationSource.PROBE,
+                        detail="upstream fallback probe returned DEAD",
+                    )
+                # UNKNOWN: fall through to permissive answer below.
 
         return result
 

--- a/libs/core/genblaze_core/providers/model_registry.py
+++ b/libs/core/genblaze_core/providers/model_registry.py
@@ -39,6 +39,7 @@ from genblaze_core.providers.family import (
     MAX_USER_FAMILIES,
     DiscoverySupport,
     FamilyMatch,
+    FamilyProbe,
     ModelFamily,
 )
 from genblaze_core.providers.pricing import PricingStrategy
@@ -80,6 +81,15 @@ class ModelRegistry:
             list).
         strict_params: If True, unknown keys raise instead of being silently
             dropped when an allowlist is set.
+        fallback_probe: Optional liveness probe consulted by
+            ``BaseProvider.validate_model()`` for slugs that match no
+            ``ModelFamily`` (the fallback path). The liveness counterpart to
+            ``fallback`` — that spec governs param shape for unmatched
+            slugs, this probe (when set) governs whether ``validate_model()``
+            can grade them ``OK_AUTHORITATIVE``/``NOT_FOUND`` instead of
+            always falling through to ``UNKNOWN_PERMISSIVE``. ``None``
+            (default) preserves today's behavior: unmatched slugs are never
+            probed.
     """
 
     def __init__(
@@ -90,6 +100,7 @@ class ModelRegistry:
         discovery_cache: _DiscoveryCache | None = None,
         unstable_slugs: Iterable[str] = (),
         strict_params: bool = False,
+        fallback_probe: FamilyProbe | None = None,
     ) -> None:
         if len(provider_families) > MAX_PROVIDER_FAMILIES:
             raise ValueError(
@@ -123,6 +134,7 @@ class ModelRegistry:
         # every request would re-log indefinitely).
         self._warned_canonical_rewrite: set[tuple[str, str]] = set()
         self._fallback = fallback
+        self._fallback_probe = fallback_probe
         self._strict = strict_params
         self._lock = threading.RLock()
         self._rebuild_alias_index()
@@ -243,6 +255,7 @@ class ModelRegistry:
                 # Pass the unioned set; the constructor will re-union with
                 # family.unstable_examples (idempotent — frozenset union).
                 unstable_slugs=self._unstable_slugs,
+                fallback_probe=self._fallback_probe,
             )
             # Carry the user layer over. ``extend`` performs a single bulk
             # write under its own lock and does one alias-index rebuild —
@@ -277,6 +290,12 @@ class ModelRegistry:
         → deprecated alias → fallback. Emits ``DeprecationWarning`` when the
         lookup resolves via a ``deprecated_aliases`` entry. Never returns
         ``None``.
+
+        **Not an existence check.** ``fallback`` is a catch-all spec (its
+        ``model_id`` is typically ``"*"``), so ``get()`` returns a usable
+        ``ModelSpec`` for any string, including one nobody registered and
+        that no upstream model actually answers to. Use ``validate_model()``
+        to ask whether a slug is real.
         """
         spec = self._user.get(model_id)
         if spec is not None:

--- a/libs/core/genblaze_core/providers/validation.py
+++ b/libs/core/genblaze_core/providers/validation.py
@@ -4,15 +4,26 @@
 outcome is graded by what the SDK can honestly substantiate:
 
 * ``OK_AUTHORITATIVE`` — positive confirmation from a user registration,
-  a NATIVE discovery cache hit, or a ``FamilyProbe`` that returned LIVE.
+  a NATIVE discovery cache hit, a ``FamilyProbe`` that returned LIVE, or
+  (when no family matched) the registry's ``fallback_probe`` returning LIVE.
 * ``OK_PROVISIONAL`` — slug matched a family pattern but liveness is
   unverifiable on this provider's ``DiscoverySupport``. Pipeline preflight
   emits a WARN and proceeds; failures will surface mid-pipeline.
-* ``UNKNOWN_PERMISSIVE`` — no family match. The permissive fallback
-  applies; the slug passes through to upstream untouched. Preflight
-  cannot say anything about liveness.
-* ``NOT_FOUND`` — discovery says absent (NATIVE) or probe returned DEAD.
-  Pipeline preflight raises before any wire calls.
+* ``UNKNOWN_PERMISSIVE`` — no family match, and either no ``fallback_probe``
+  is configured or it returned UNKNOWN. The permissive fallback applies; the
+  slug passes through to upstream untouched. Preflight cannot say anything
+  about liveness.
+* ``NOT_FOUND`` — discovery says absent (NATIVE), or a probe (family-level
+  or fallback) returned DEAD. Pipeline preflight raises before any wire
+  calls.
+
+**A positive outcome confirms existence, not entitlement.** A probe (family
+or fallback) can only observe what upstream reveals before an
+account-entitlement check runs — a slug can be ``OK_AUTHORITATIVE`` here and
+still 404 "you do not have access" on a real submit. Connectors with known
+gated slugs re-grade those explicitly (e.g. GMICloud's
+``_entitlement_gated_slugs``); absent that, treat ``OK_AUTHORITATIVE`` as
+"this slug exists", not "this key can call it".
 
 The ``ValidationOutcome`` × ``ValidationSource`` matrix is the single
 source of truth for slug-validity questions. ``probe_model()`` (deprecated
@@ -54,7 +65,8 @@ class ValidationOutcome(StrEnum):
 
     OK_AUTHORITATIVE = "ok_authoritative"
     """Positive confirmation: user-registered, NATIVE-discovery-confirmed,
-    or family.probe() returned LIVE."""
+    family.probe() returned LIVE, or (no family matched) the registry's
+    fallback_probe returned LIVE. Confirms existence, not entitlement."""
 
     OK_PROVISIONAL = "ok_provisional"
     """Family-matched but liveness is unverifiable. Honest answer when the
@@ -62,8 +74,9 @@ class ValidationOutcome(StrEnum):
     NONE provider with no probe configured, or probe returned UNKNOWN)."""
 
     UNKNOWN_PERMISSIVE = "unknown_permissive"
-    """No family match. Permissive fallback applies; the slug will pass
-    through to upstream untouched. The SDK cannot pre-flight liveness."""
+    """No family match, and no fallback_probe configured (or it returned
+    UNKNOWN). Permissive fallback applies; the slug will pass through to
+    upstream untouched. The SDK cannot pre-flight liveness."""
 
     NOT_FOUND = "not_found"
     """NATIVE discovery says the slug is absent, or family.probe() returned

--- a/libs/core/tests/unit/test_fallback_probe.py
+++ b/libs/core/tests/unit/test_fallback_probe.py
@@ -1,0 +1,251 @@
+"""Tests for ``ModelRegistry.fallback_probe`` and its use in
+``BaseProvider.validate_model()`` (#248).
+
+Before this, a slug matching no ``ModelFamily`` could never be probed —
+``validate_model()`` only consulted a liveness probe when
+``match_family()`` returned a hit. For PARTIAL/NONE providers whose
+families cover only a subset of real slugs (the common shape: a few
+narrow families plus a permissive ``"*"`` fallback), every unmatched
+slug graded ``UNKNOWN_PERMISSIVE`` regardless of whether it was a real,
+callable model or a fabricated string — no signal either way.
+
+``fallback_probe`` is the liveness counterpart to the registry's
+``fallback`` param-shape spec: when no family matched, and a
+``fallback_probe`` is configured, it's now consulted the same way a
+family probe is (same cache, same single-flight, same LiveProbeResult
+grading).
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+from genblaze_core.models.enums import Modality
+from genblaze_core.models.step import Step
+from genblaze_core.providers import (
+    DiscoverySupport,
+    LiveProbeResult,
+    ModelFamily,
+    ModelRegistry,
+    ModelSpec,
+)
+from genblaze_core.providers.base import SyncProvider
+from genblaze_core.providers.validation import ValidationOutcome, ValidationSource
+
+_MATCHED_FAMILY = ModelFamily(
+    name="matched",
+    pattern=re.compile(r"^matched-"),
+    spec_template=ModelSpec(model_id="*", modality=Modality.IMAGE),
+    description="A family with its own probe, to pin that fallback_probe "
+    "never overrides a family match.",
+    example_slugs=("matched-1",),
+    probe=lambda slug, **kw: LiveProbeResult.DEAD,
+)
+
+
+class _FallbackProbeProvider(SyncProvider):
+    """PARTIAL provider whose registry has one family plus a fallback_probe.
+
+    ``_invoke_family_probe`` forwards straight to the probe callable
+    (family or fallback — the framework doesn't distinguish at this
+    layer) so tests can swap behavior via ``fallback_probe_result``.
+    """
+
+    name = "fallback-probe-test"
+    discovery_support = DiscoverySupport.PARTIAL
+
+    def __init__(self, *, fallback_probe_result: LiveProbeResult | None) -> None:
+        # Build the registry per-instance and pass it via ``models=``
+        # rather than overriding ``create_registry()`` — that classmethod
+        # is cached once per *class* (``models_default()``), so an
+        # override closing over per-instance state would leak into every
+        # other instance of this same test class.
+        def _fallback_probe(slug: str, **kwargs: object) -> LiveProbeResult:
+            assert fallback_probe_result is not None, (
+                "fallback_probe invoked but no result configured for this test"
+            )
+            return fallback_probe_result
+
+        registry = ModelRegistry(
+            provider_families=(_MATCHED_FAMILY,), fallback_probe=_fallback_probe
+        )
+        super().__init__(models=registry)
+
+    def _invoke_family_probe(self, probe, model_id):  # type: ignore[override]
+        return probe(model_id)
+
+    def generate(self, step: Step, config=None) -> Step:  # pragma: no cover
+        return step
+
+
+class TestFallbackProbeGrading:
+    def test_unmatched_slug_live_grades_ok_authoritative(self) -> None:
+        provider = _FallbackProbeProvider(fallback_probe_result=LiveProbeResult.LIVE)
+        result = provider.validate_model("totally-unmatched-slug")
+        assert result.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert result.source is ValidationSource.PROBE
+        assert result.family_name is None
+
+    def test_unmatched_slug_dead_grades_not_found(self) -> None:
+        provider = _FallbackProbeProvider(fallback_probe_result=LiveProbeResult.DEAD)
+        result = provider.validate_model("totally-fabricated-slug")
+        assert result.outcome is ValidationOutcome.NOT_FOUND
+        assert result.source is ValidationSource.PROBE
+
+    def test_unmatched_slug_unknown_stays_permissive(self) -> None:
+        provider = _FallbackProbeProvider(fallback_probe_result=LiveProbeResult.UNKNOWN)
+        result = provider.validate_model("some-slug")
+        assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
+
+    def test_matched_slug_uses_family_probe_not_fallback(self) -> None:
+        """A family match takes the family's own probe (DEAD, per
+        ``_MATCHED_FAMILY``) even though the registry also carries a
+        ``fallback_probe`` — the fallback path only fires when no family
+        matched at all."""
+        provider = _FallbackProbeProvider(fallback_probe_result=None)
+        result = provider.validate_model("matched-1")
+        assert result.outcome is ValidationOutcome.NOT_FOUND
+        assert result.family_name == "matched"
+
+
+class TestFallbackProbeCaching:
+    def test_probe_fires_once_across_repeated_calls(self) -> None:
+        provider = _FallbackProbeProvider(fallback_probe_result=LiveProbeResult.LIVE)
+        with patch.object(
+            _FallbackProbeProvider,
+            "_invoke_family_probe",
+            wraps=provider._invoke_family_probe,
+        ) as spy:
+            provider.validate_model("unmatched-a")
+            provider.validate_model("unmatched-a")
+            provider.validate_model("unmatched-a")
+        assert spy.call_count == 1
+
+    def test_refresh_forces_reprobe(self) -> None:
+        provider = _FallbackProbeProvider(fallback_probe_result=LiveProbeResult.LIVE)
+        with patch.object(
+            _FallbackProbeProvider,
+            "_invoke_family_probe",
+            wraps=provider._invoke_family_probe,
+        ) as spy:
+            provider.validate_model("unmatched-b")
+            provider.validate_model("unmatched-b", refresh=True)
+        assert spy.call_count == 2
+
+
+class TestNoFallbackProbeConfigured:
+    def test_registries_without_fallback_probe_are_unaffected(self) -> None:
+        """Default construction (no ``fallback_probe=``) preserves today's
+        behavior byte-for-byte: an unmatched slug is UNKNOWN_PERMISSIVE,
+        no probe is ever consulted."""
+
+        class _NoFallbackProbeProvider(SyncProvider):
+            name = "no-fallback-probe-test"
+            discovery_support = DiscoverySupport.PARTIAL
+
+            @classmethod
+            def create_registry(cls) -> ModelRegistry:
+                return ModelRegistry(provider_families=(_MATCHED_FAMILY,))
+
+            def generate(self, step: Step, config=None) -> Step:  # pragma: no cover
+                return step
+
+        provider = _NoFallbackProbeProvider()
+        result = provider.validate_model("anything-unmatched")
+        assert result.outcome is ValidationOutcome.UNKNOWN_PERMISSIVE
+
+
+class TestFallbackProbeDoesNotOverrideUserSpecs:
+    """Regression tests for a pre-pr-check finding on #248: the fallback
+    probe must never overrule a USER-registered spec — directly, or via an
+    alias to one — even though ``match_family()`` returns ``None`` for both
+    (aliases and user exact-matches aren't family patterns).
+
+    ``ValidationSource.USER`` is documented as "strongest signal regardless
+    of provider class" (``model_registry.py``). Before the fix, the
+    fallback-probe branch fired on any ``match is None`` case and probed
+    the caller-supplied string verbatim — which is wrong for an alias (the
+    literal alias string is usually not itself a real wire slug; only its
+    canonical resolution is) and, under ``refresh=True``, could downgrade
+    a USER exact match's cached ``OK_AUTHORITATIVE`` straight to
+    ``NOT_FOUND`` if the probe happened to 404 that same literal string.
+    """
+
+    @staticmethod
+    def _make_provider(*, fallback_probe_result: LiveProbeResult, spec: ModelSpec) -> SyncProvider:
+        calls: list[str] = []
+
+        def _fallback_probe(slug: str, **kwargs: object) -> LiveProbeResult:
+            calls.append(slug)
+            return fallback_probe_result
+
+        registry = ModelRegistry(fallback_probe=_fallback_probe)
+        registry.register(spec)
+
+        class _P(SyncProvider):
+            name = "user-spec-fallback-test"
+            discovery_support = DiscoverySupport.PARTIAL
+
+            def _invoke_family_probe(self, probe, model_id):  # type: ignore[override]
+                return probe(model_id)
+
+            def generate(self, step: Step, config=None) -> Step:  # pragma: no cover
+                return step
+
+        provider = _P(models=registry)
+        provider._probe_calls = calls  # type: ignore[attr-defined]
+        return provider
+
+    def test_alias_resolves_via_user_source_not_probed(self) -> None:
+        """An alias whose literal string the probe would grade DEAD must
+        still resolve to its registered canonical spec's OK_AUTHORITATIVE —
+        the probe must never even see the raw alias string."""
+        spec = ModelSpec(model_id="real-wire-slug", modality=Modality.IMAGE, aliases=("friendly",))
+        provider = self._make_provider(fallback_probe_result=LiveProbeResult.DEAD, spec=spec)
+        result = provider.validate_model("friendly")
+        assert result.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert result.source is ValidationSource.USER
+        assert provider._probe_calls == []  # type: ignore[attr-defined]
+
+    def test_unmatched_fabricated_slug_still_probed(self) -> None:
+        """Sanity check alongside the alias case: a slug that truly isn't
+        registered under any name still goes through the fallback probe
+        and can still grade NOT_FOUND."""
+        spec = ModelSpec(model_id="real-wire-slug", modality=Modality.IMAGE, aliases=("friendly",))
+        provider = self._make_provider(fallback_probe_result=LiveProbeResult.DEAD, spec=spec)
+        result = provider.validate_model("totally-unregistered-slug")
+        assert result.outcome is ValidationOutcome.NOT_FOUND
+        assert result.source is ValidationSource.PROBE
+        assert provider._probe_calls == ["totally-unregistered-slug"]  # type: ignore[attr-defined]
+
+    def test_user_exact_match_refresh_true_not_overridden(self) -> None:
+        """``refresh=True`` on a USER-registered exact-match slug must not
+        let the fallback probe downgrade it, even when the probe would
+        grade that literal slug DEAD."""
+        spec = ModelSpec(model_id="user-only-slug", modality=Modality.IMAGE)
+        provider = self._make_provider(fallback_probe_result=LiveProbeResult.DEAD, spec=spec)
+        r1 = provider.validate_model("user-only-slug")
+        assert r1.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert r1.source is ValidationSource.USER
+        r2 = provider.validate_model("user-only-slug", refresh=True)
+        assert r2.outcome is ValidationOutcome.OK_AUTHORITATIVE
+        assert r2.source is ValidationSource.USER
+        assert provider._probe_calls == []  # type: ignore[attr-defined]
+
+
+class TestFallbackProbeConstruction:
+    def test_stored_on_registry(self) -> None:
+        probe = lambda slug, **kw: LiveProbeResult.LIVE  # noqa: E731
+        reg = ModelRegistry(fallback_probe=probe)
+        assert reg._fallback_probe is probe
+
+    def test_defaults_to_none(self) -> None:
+        reg = ModelRegistry()
+        assert reg._fallback_probe is None
+
+    def test_fork_carries_fallback_probe(self) -> None:
+        probe = lambda slug, **kw: LiveProbeResult.LIVE  # noqa: E731
+        reg = ModelRegistry(fallback_probe=probe)
+        fork = reg.fork()
+        assert fork._fallback_probe is probe

--- a/libs/core/tests/unit/test_pipeline_preflight.py
+++ b/libs/core/tests/unit/test_pipeline_preflight.py
@@ -31,7 +31,7 @@ from genblaze_core.providers.discovery import (
     DiscoveryResult,
     _DiscoveryCache,
 )
-from genblaze_core.providers.family import DiscoverySupport, ModelFamily
+from genblaze_core.providers.family import DiscoverySupport, LiveProbeResult, ModelFamily
 from genblaze_core.providers.model_registry import ModelRegistry
 from genblaze_core.providers.spec import ModelSpec
 
@@ -101,6 +101,37 @@ def _make_family_provider(family: ModelFamily) -> BaseProvider:
     return _FamilyProvider()
 
 
+def _make_fallback_probe_provider(result: LiveProbeResult) -> BaseProvider:
+    """A PARTIAL provider with no families at all — everything hits the
+    fallback path — and a ``fallback_probe`` that always returns ``result``
+    (#248)."""
+
+    class _FallbackProbeProvider(BaseProvider):
+        name = "fallback-probe-test"
+        discovery_support = DiscoverySupport.PARTIAL
+
+        @classmethod
+        def create_registry(cls) -> ModelRegistry:
+            return ModelRegistry(fallback_probe=lambda slug, **kw: result)
+
+        def _invoke_family_probe(self, probe, model_id):  # type: ignore[override]
+            return probe(model_id)
+
+        def get_capabilities(self) -> ProviderCapabilities:
+            return ProviderCapabilities(supported_modalities=[Modality.IMAGE], models=[])
+
+        def submit(self, step, config=None):  # type: ignore[no-untyped-def]
+            return "pid"
+
+        def poll(self, prediction_id, config=None):  # type: ignore[no-untyped-def]
+            return True
+
+        def fetch_output(self, prediction_id, step):  # type: ignore[no-untyped-def]
+            return step
+
+    return _FallbackProbeProvider()
+
+
 class TestNotFoundRaises:
     def test_native_missing_slug_raises(self) -> None:
         p = _make_native_provider({"live-slug-1", "live-slug-2"})
@@ -128,6 +159,18 @@ class TestNotFoundRaises:
             pipe._validate_steps()
         msg = str(exc.value)
         assert "refresh=True" in msg, f"NOT_FOUND error must mention the refresh recovery: {msg}"
+
+    def test_fallback_probe_dead_raises(self) -> None:
+        """#248: a slug matching no family, on a registry with a
+        ``fallback_probe`` configured, now raises at preflight when the
+        probe returns DEAD — instead of silently passing through as
+        UNKNOWN_PERMISSIVE with no signal either way."""
+        p = _make_fallback_probe_provider(LiveProbeResult.DEAD)
+        pipe = Pipeline("t").step(p, model="fabricated-slug", modality=Modality.IMAGE, prompt="hi")
+        with pytest.raises(ProviderError) as exc:
+            pipe._validate_steps()
+        assert "not found" in str(exc.value).lower()
+        assert "fabricated-slug" in str(exc.value)
 
     def test_error_message_propagates_validation_detail(self) -> None:
         """When validate_model returns a NOT_FOUND with a ``detail``
@@ -164,6 +207,18 @@ class TestOkAuthoritativeSilent:
         with caplog.at_level(logging.WARNING, logger="genblaze.pipeline"):
             pipe._validate_steps()
         # No preflight WARNs emitted for OK_AUTHORITATIVE.
+        preflight_warns = [r for r in caplog.records if "preflight." in r.getMessage()]
+        assert preflight_warns == []
+
+    def test_fallback_probe_live_silent(self, caplog) -> None:
+        """#248: the flip side of ``test_fallback_probe_dead_raises`` — a
+        slug matching no family but confirmed LIVE by the fallback_probe
+        grades OK_AUTHORITATIVE and preflight stays silent, same as any
+        other authoritative confirmation."""
+        p = _make_fallback_probe_provider(LiveProbeResult.LIVE)
+        pipe = Pipeline("t").step(p, model="real-slug", modality=Modality.IMAGE, prompt="hi")
+        with caplog.at_level(logging.WARNING, logger="genblaze.pipeline"):
+            pipe._validate_steps()
         preflight_warns = [r for r in caplog.records if "preflight." in r.getMessage()]
         assert preflight_warns == []
 
@@ -216,6 +271,20 @@ class TestUnknownPermissiveWarns:
         with caplog.at_level(logging.WARNING, logger="genblaze.pipeline"):
             pipe._validate_steps()
 
+        unknown_warns = [r for r in caplog.records if "preflight.unknown" in r.getMessage()]
+        assert len(unknown_warns) == 1
+
+    def test_fallback_probe_unknown_still_warns(self, caplog) -> None:
+        """#248: when the fallback_probe itself can't tell (auth/rate-limit/
+        5xx → UNKNOWN), preflight still falls through to the same
+        UNKNOWN_PERMISSIVE WARN as a registry with no fallback_probe at
+        all — the probe only sharpens the LIVE/DEAD cases."""
+        p = _make_fallback_probe_provider(LiveProbeResult.UNKNOWN)
+        pipe = Pipeline("t").step(
+            p, model="inconclusive-slug", modality=Modality.IMAGE, prompt="hi"
+        )
+        with caplog.at_level(logging.WARNING, logger="genblaze.pipeline"):
+            pipe._validate_steps()
         unknown_warns = [r for r in caplog.records if "preflight.unknown" in r.getMessage()]
         assert len(unknown_warns) == 1
 


### PR DESCRIPTION
GMICloud's `validate_model()` only ever consulted a liveness probe when a slug matched one
of a connector's narrow `ModelFamily` patterns. GMICloud's image/video/audio registries each
ship 2-3 specialized families (Bria inpaint, Seededit/Reve edit, gpt-image-2-edit, Pixverse,
Wan-r2v, Veo, Kling V2.1, Seedance, audio clone/music/TTS) plus a permissive `"*"` fallback —
so every other slug, including a connector's actual mainline production models (Seedream,
Gemini-Flash, FLUX-Kontext, Reve create, Bria fibo), skipped probing entirely and graded
`unknown_permissive`. A real model and a fabricated one were indistinguishable. Reported by a
user building on genblaze-gmicloud whose production model (`gemini-3-pro-image-preview`)
graded identically to `totally-made-up-model-xyz` — the preflight WARN carried no signal, so
they'd learned to ignore it, which is exactly when a real warning gets missed. (The issue's
other claim — a gated model wrongly grading `ok_authoritative` — was already fixed in
genblaze-gmicloud 0.3.5 via #193; the reporter was on 0.3.3.)

Fixes #248

## Summary

Adds an opt-in `ModelRegistry(fallback_probe=...)` — the liveness counterpart to the
registry's existing `fallback` param-shape spec — consulted by `validate_model()` for slugs
that match no family. GMICloud wires `empty_payload_request_probe` (the same probe its
specialized families already use) into all three registries. A slug the probe confirms dead
now raises at preflight before any wire call; a slug confirmed live grades authoritative;
an inconclusive probe (auth error, rate limit, 5xx) stays permissive. Connectors that don't
opt in are unaffected — `fallback_probe` defaults to `None`.

## Changes

* `libs/core/genblaze_core/providers/model_registry.py` — new `fallback_probe` ctor kwarg,
  carried through `fork()`. `get()` docstring now states plainly it is not an existence check.
* `libs/core/genblaze_core/providers/base.py` — `validate_model()` gains a branch for
  `match is None and fallback_probe is not None`, routed through the existing cached/
  single-flight probe path (LIVE → `OK_AUTHORITATIVE`, DEAD → `NOT_FOUND`, UNKNOWN → unchanged
  permissive fallthrough). Two guards protect a `USER`-registered spec from ever being probed
  under the wrong string: resolves the canonical slug first (an alias to a registered spec
  short-circuits to `OK_AUTHORITATIVE`/`USER`, never probed) and only proceeds when the
  pre-probe result is `UNKNOWN_PERMISSIVE` (so `refresh=True` can't let the probe override an
  exact `USER` match). Docstrings clarify a positive outcome means "exists in the catalog",
  not "this account is entitled to call it."
* `libs/core/genblaze_core/providers/validation.py` — matching docstring updates on
  `ValidationOutcome`.
* `libs/core/tests/unit/test_fallback_probe.py` — new, 16 tests: grading (LIVE/DEAD/UNKNOWN),
  caching + single-flight + `refresh=True`, family match takes precedence over fallback,
  no-op when `fallback_probe` isn't configured, and the alias/USER-registration protection.
* `libs/core/tests/unit/test_pipeline_preflight.py` — preflight raises on fallback-DEAD, stays
  silent on fallback-LIVE, still WARNs once on fallback-UNKNOWN.
* `libs/connectors/gmicloud/genblaze_gmicloud/models/{image,video,audio}.py` — wire
  `fallback_probe=empty_payload_request_probe` into each registry.
* `libs/connectors/gmicloud/tests/test_catalog_decoupling.py` — updated 2 tests that had
  pinned the old (buggy) permissive behavior, added the DEAD/UNKNOWN split and the orphan
  `unstable_slugs` (`vidu-q1`) LIVE/DEAD cases now that the video registry probes its fallback.
* `libs/connectors/gmicloud/README.md` — new "Checking whether a slug is real" section:
  what each outcome does and doesn't prove, and the probe's audit-log/caching behavior.
* `CHANGELOG.md` — `[Unreleased]` entries for `genblaze-core` (Added `fallback_probe`) and
  `genblaze-gmicloud` (Fixed #248).
* `docs/exec-plans/completed/issue-248-gmicloud-validate-model-unmatched-slugs.md` — plan doc.

`genblaze_gmicloud/_base.py` is untouched — the probe transport hook and the existing #193
entitlement re-grade (`_entitlement_gated_slugs`) already sit at the right seam and continue
to apply unchanged on top of this fix, including for slugs reached via the new fallback path.

## Test plan

* New/updated tests fail against the pre-fix code (real regression tests, not vacuous) and
  pass after.
* `cd libs/core && pytest tests/ -q` → **1910 passed, 19 skipped**.
* `cd libs/connectors/gmicloud && pytest tests/ -q` → **260 passed, 8 skipped**.
* `ruff check` / `ruff format --check` on all touched files — clean.
* `/pre-pr-check`, scoped to this diff against the acceptance criterion "a slug that 404s
  grades NOT_FOUND at preflight, a slug that's accepted grades OK_AUTHORITATIVE, an
  inconclusive probe stays UNKNOWN_PERMISSIVE, no probe fires more than once per slug per TTL
  window for a definitive verdict, and registries without `fallback_probe` are unaffected":
  the first pass found 2 MEDIUM blocking bugs in the new branch (an alias to a registered
  spec was probed under its raw string instead of its canonical slug; `refresh=True` could
  let the probe override a `USER`-registered result). Both fixed and re-verified clean across
  2 rounds × (Claude code review, Claude security review, full test suite) + 2 rounds × 3
  Codex reviews (review / security-focused / adversarial) — 12 checks total, no security
  bypass found. A structurally identical bug in the *pre-existing* family-probe branch
  (confirmed unrelated to this diff — reproduces identically with `fallback_probe` absent
  entirely) was found in passing and filed as a separate follow-up rather than expanding
  this PR's scope.

## Related

* Fixes #248
* Plan: `docs/exec-plans/completed/issue-248-gmicloud-validate-model-unmatched-slugs.md`