### PR TITLE
docs: merge the duplicated genblaze-google CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is verified to stay under `output_dir`, and the write refuses to follow
   symlinks or clobber an existing file — on both the Vertex and Gemini auth
   paths (#284).
+- **Fixed** README and `examples/imagen_pipeline.py` quickstarts referenced
+  the delisted `imagen-3.0-*` slugs, which now 404 at preflight for every
+  new user; updated to the catalog-listed `imagen-4.0-*` slugs, documented
+  the entitlement caveat, and documented the previously-unlisted
+  `GeminiImageProvider` as the no-entitlement alternative (#233).
 
 ### genblaze-core
 
@@ -81,14 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the probe confirms dead now raises at `Pipeline` preflight instead of
   failing mid-run; a slug the probe confirms live grades authoritative
   (#248).
-
-### genblaze-google
-
-- **Fixed** README and `examples/imagen_pipeline.py` quickstarts referenced
-  the delisted `imagen-3.0-*` slugs, which now 404 at preflight for every
-  new user; updated to the catalog-listed `imagen-4.0-*` slugs, documented
-  the entitlement caveat, and documented the previously-unlisted
-  `GeminiImageProvider` as the no-entitlement alternative (#233).
 
 ## [0.7.0] - 2026-07-28
 


### PR DESCRIPTION
## What

`main` currently has `### genblaze-google` **twice** under `[Unreleased]` — once from #286 (carrying #263 and #284) and again from #287 (carrying #233). Both PRs added the heading independently, and because the two additions landed at different line positions git merged them without conflict.

This moves the #233 entry into the existing section next to #263/#284 and removes the second heading.

## Not a content change

The same three entries are present, under one heading instead of two. Diff is +5/-8, all of it moving one bullet and deleting a duplicate header.

Verified after the change: each of `genblaze-google`, `genblaze-core`, `Internal` and `genblaze-gmicloud` appears exactly once, and all eight issue references (#270, #46, #261, #262, #248, #263, #284, #233) are still present.

## Why it matters

Release notes are generated from this section, so a duplicated heading would show up as two `genblaze-google` blocks in the next wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)